### PR TITLE
Lazy loading of Logo

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestToolsNdmfPlugin.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestToolsNdmfPlugin.cs
@@ -1,8 +1,8 @@
+using System;
 using KRT.VRCQuestTools.Ndmf;
 using nadena.dev.ndmf;
 using UnityEditor;
 using UnityEngine;
-using System;
 
 [assembly: ExportsPlugin(typeof(VRCQuestToolsNdmfPlugin))]
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestToolsNdmfPlugin.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestToolsNdmfPlugin.cs
@@ -2,6 +2,7 @@ using KRT.VRCQuestTools.Ndmf;
 using nadena.dev.ndmf;
 using UnityEditor;
 using UnityEngine;
+using System;
 
 [assembly: ExportsPlugin(typeof(VRCQuestToolsNdmfPlugin))]
 
@@ -21,9 +22,9 @@ namespace KRT.VRCQuestTools.Ndmf
         public override string QualifiedName => "com.github.kurotu.vrc-quest-tools";
 
 #if VQT_HAS_NDMF_ERROR_REPORT
-        private static readonly Texture2D logoTexture = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath("e6a14816c3530ec498d3a7f1aad45a5a"));
+        private static readonly Lazy<Texture2D> logoTexture = new Lazy<Texture2D>(() => AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath("e6a14816c3530ec498d3a7f1aad45a5a")));
         /// <inheritdoc/>
-        public override Texture2D LogoTexture => logoTexture;
+        public override Texture2D LogoTexture => logoTexture.Value;
 #endif
 
         /// <inheritdoc/>


### PR DESCRIPTION
NDMF v1.5.0-rc にて NDMF-Preview の有効無効を変更できるウィンドウを開いた状態でドメインリロードが走ると、 ScriptableObject のコンストラクターのタイミングで AssetDatabase.LoadAssetAtPath が走ってしまい、例外が発生してしまうので、実際にアクセスされるまでロードしないことで問題を回避するパッチです！