### PR TITLE
fix: always set MinBrightness when converting materials to Toon Standard

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/ToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/ToonStandardGenerator.cs
@@ -129,13 +129,14 @@ namespace KRT.VRCQuestTools.Models
                         newMaterial.ShadowRamp = t;
                         newMaterial.ShadowBoost = 0.0f;
                         newMaterial.ShadowTint = 0.0f;
-                        newMaterial.MinBrightness = GetMinBrightness();
                     }).WaitForCompletion();
                 }
                 else
                 {
                     newMaterial.ShadowRamp = ToonStandardMaterialWrapper.RampTexture.Flat;
                 }
+
+                newMaterial.MinBrightness = GetMinBrightness();
 
                 if (GetUseEmissionMap())
                 {


### PR DESCRIPTION
Fix #81 です