### PR TITLE
Exclude sdk-latest aao-minimum test pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,11 @@ jobs:
           - name: aao-latest
             packages:
               - { name: com.anatawa12.avatar-optimizer, version: 'latest' }
+        exclude:
+          - sdk:
+              name: latest
+            dependencies:
+              name: aao-minimum
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4


### PR DESCRIPTION
Regularly AAO might not support latest SDK depends on CI timing.