### PR TITLE
Fix normal map not rendering in NDMF material conversion preview

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/LilToonToonStandardGeneratorTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/LilToonToonStandardGeneratorTests.cs
@@ -121,7 +121,7 @@ namespace KRT.VRCQuestTools.Models
             };
 
             var lilMat = new LilToonMaterial(sourceMaterial.Object);
-            var generator = new LilToonToonStandardGenerator(lilMat, settings, null);
+            var generator = new LilToonToonStandardGenerator(lilMat, settings, null, false);
 
             Material resultMat = null;
             generator.GenerateMaterial(lilMat, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) =>
@@ -179,7 +179,7 @@ namespace KRT.VRCQuestTools.Models
             };
 
             var lilMat = new LilToonMaterial(sourceMaterial.Object);
-            var generator = new LilToonToonStandardGenerator(lilMat, settings, null);
+            var generator = new LilToonToonStandardGenerator(lilMat, settings, null, false);
 
             Material resultMat = null;
             generator.GenerateMaterial(lilMat, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) =>
@@ -245,7 +245,7 @@ namespace KRT.VRCQuestTools.Models
             settings.SetAllFeatures(false);
 
             var lilMat = new LilToonMaterial(sourceMaterial.Object);
-            var generator = new LilToonToonStandardGenerator(lilMat, settings, null);
+            var generator = new LilToonToonStandardGenerator(lilMat, settings, null, false);
 
             Material resultMat = null;
             generator.GenerateMaterial(lilMat, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) =>
@@ -419,7 +419,7 @@ namespace KRT.VRCQuestTools.Models
             };
 
             var lilMat = new LilToonMaterial(sourceMaterial.Object);
-            var generator = new LilToonToonStandardGenerator(lilMat, settings, null);
+            var generator = new LilToonToonStandardGenerator(lilMat, settings, null, false);
 
             Material resultMat = null;
             generator.GenerateMaterial(lilMat, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) =>
@@ -573,9 +573,9 @@ namespace KRT.VRCQuestTools.Models
             settings.SetAllFeatures(false);
 
             var lilMat11 = new LilToonMaterial(mat11.Object);
-            var gen11 = new LilToonToonStandardGenerator(lilMat11, settings, null);
+            var gen11 = new LilToonToonStandardGenerator(lilMat11, settings, null, false);
             var lilMat22 = new LilToonMaterial(mat22.Object);
-            var gen22 = new LilToonToonStandardGenerator(lilMat22, settings, null);
+            var gen22 = new LilToonToonStandardGenerator(lilMat22, settings, null, false);
 
             Material resultMat11 = null;
             gen11.GenerateMaterial(lilMat11, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) => { resultMat11 = mat; }).WaitForCompletion();
@@ -663,7 +663,7 @@ namespace KRT.VRCQuestTools.Models
             };
 
             var lilMat = new LilToonMaterial(sourceMaterial.Object);
-            var generator = new LilToonToonStandardGenerator(lilMat, settings, null);
+            var generator = new LilToonToonStandardGenerator(lilMat, settings, null, false);
 
             Material resultMat = null;
             generator.GenerateMaterial(lilMat, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) =>
@@ -726,7 +726,7 @@ namespace KRT.VRCQuestTools.Models
             settings.useOcclusion = true;
 
             var lilMat = new LilToonMaterial(sourceMaterial.Object);
-            var generator = new LilToonToonStandardGenerator(lilMat, settings, null);
+            var generator = new LilToonToonStandardGenerator(lilMat, settings, null, false);
 
             Material resultMat = null;
             generator.GenerateMaterial(lilMat, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) =>

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterCacheTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterCacheTests.cs
@@ -96,7 +96,7 @@ namespace KRT.VRCQuestTools.Ndmf
             var original2 = new Material(shader);
             var replacement = new Material(shader);
             var converter = new AvatarConverter(new MaterialWrapperBuilder());
-            System.Func<Dictionary<Material, IMaterialConvertSettings>, Dictionary<Material, Material>> convertFunc = m => converter.ConvertMaterialsForMobile(m, false, string.Empty, null);
+            System.Func<Dictionary<Material, IMaterialConvertSettings>, Dictionary<Material, Material>> convertFunc = m => converter.ConvertMaterialsForMobile(m, false, string.Empty, null, false);
             
             object lease1 = null;
             object lease2 = null;

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs
@@ -57,10 +57,19 @@ namespace KRT.VRCQuestTools.Utils
             // Always reset the global flag so an exception mid-test cannot leave it enabled and mask
             // failures in subsequent tests.
             LogAssert.ignoreFailingMessages = false;
+            if (string.IsNullOrEmpty(tempPath))
+            {
+                return;
+            }
+
             if (AssetDatabase.IsValidFolder(tempPath))
             {
                 AssetDatabase.DeleteAsset(tempPath);
             }
+            else if (Directory.Exists(tempPath))
+            {
+                Directory.Delete(tempPath, true);
+            }
         }
 
         /// <summary>

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs
@@ -49,11 +49,14 @@ namespace KRT.VRCQuestTools.Utils
         }
 
         /// <summary>
-        /// Removes the temporary directory and its assets.
+        /// Removes the temporary directory and its assets, and resets the global log-assert flag.
         /// </summary>
         [TearDown]
         public void TearDown()
         {
+            // Always reset the global flag so an exception mid-test cannot leave it enabled and mask
+            // failures in subsequent tests.
+            LogAssert.ignoreFailingMessages = false;
             if (AssetDatabase.IsValidFolder(tempPath))
             {
                 AssetDatabase.DeleteAsset(tempPath);
@@ -322,89 +325,106 @@ namespace KRT.VRCQuestTools.Utils
         /// <returns>Rendered Texture2D containing captured pixels.</returns>
         private static Texture2D RenderWithNormalMap(Texture2D normalMap)
         {
-            // Sphere with Standard material using the normal map.
-            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-            sphere.transform.position = Vector3.zero;
-
-            var mat = new Material(Shader.Find("Standard"));
-            mat.EnableKeyword("_NORMALMAP");
-            mat.SetTexture("_BumpMap", normalMap);
-            mat.SetFloat("_BumpScale", 1f);
-            sphere.GetComponent<MeshRenderer>().sharedMaterial = mat;
-
-            // Directional light to make normal map shading visible.
-            var lightGo = new GameObject("TestLight");
-            var light = lightGo.AddComponent<Light>();
-            light.type = LightType.Directional;
-            light.transform.rotation = Quaternion.Euler(45f, 45f, 0f);
-            light.intensity = 1f;
-
-            // Camera facing the sphere from the front.
-            var camGo = new GameObject("TestCamera");
-            var cam = camGo.AddComponent<Camera>();
-            cam.transform.position = new Vector3(0f, 0f, -3f);
-            cam.transform.LookAt(sphere.transform);
-            cam.clearFlags = CameraClearFlags.SolidColor;
-            cam.backgroundColor = Color.black;
-
-            // Render to a 256x256 RenderTexture and read back pixels.
-            var rt = new RenderTexture(256, 256, 16, RenderTextureFormat.ARGB32);
-            cam.targetTexture = rt;
-            cam.Render();
-
+            GameObject sphere = null;
+            Material mat = null;
+            GameObject lightGo = null;
+            GameObject camGo = null;
+            RenderTexture rt = null;
             var prevRT = RenderTexture.active;
-            RenderTexture.active = rt;
-            var result = new Texture2D(256, 256, TextureFormat.RGBA32, false);
-            result.ReadPixels(new Rect(0f, 0f, 256f, 256f), 0, 0);
-            result.Apply();
-            RenderTexture.active = prevRT;
+            try
+            {
+                // Sphere with Standard material using the normal map.
+                sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                sphere.transform.position = Vector3.zero;
 
-            cam.targetTexture = null;
-            Object.DestroyImmediate(rt);
-            Object.DestroyImmediate(mat);
-            Object.DestroyImmediate(sphere);
-            Object.DestroyImmediate(lightGo);
-            Object.DestroyImmediate(camGo);
+                mat = new Material(Shader.Find("Standard"));
+                mat.EnableKeyword("_NORMALMAP");
+                mat.SetTexture("_BumpMap", normalMap);
+                mat.SetFloat("_BumpScale", 1f);
+                sphere.GetComponent<MeshRenderer>().sharedMaterial = mat;
 
-            return result;
+                // Directional light to make normal map shading visible.
+                lightGo = new GameObject("TestLight");
+                var light = lightGo.AddComponent<Light>();
+                light.type = LightType.Directional;
+                light.transform.rotation = Quaternion.Euler(45f, 45f, 0f);
+                light.intensity = 1f;
+
+                // Camera facing the sphere from the front.
+                camGo = new GameObject("TestCamera");
+                var cam = camGo.AddComponent<Camera>();
+                cam.transform.position = new Vector3(0f, 0f, -3f);
+                cam.transform.LookAt(sphere.transform);
+                cam.clearFlags = CameraClearFlags.SolidColor;
+                cam.backgroundColor = Color.black;
+
+                // Render to a 256x256 RenderTexture and read back pixels.
+                rt = new RenderTexture(256, 256, 16, RenderTextureFormat.ARGB32);
+                cam.targetTexture = rt;
+                cam.Render();
+
+                RenderTexture.active = rt;
+                var result = new Texture2D(256, 256, TextureFormat.RGBA32, false);
+                result.ReadPixels(new Rect(0f, 0f, 256f, 256f), 0, 0);
+                result.Apply();
+                cam.targetTexture = null;
+                return result;
+            }
+            finally
+            {
+                RenderTexture.active = prevRT;
+                if (rt != null) { Object.DestroyImmediate(rt); }
+                if (mat != null) { Object.DestroyImmediate(mat); }
+                if (sphere != null) { Object.DestroyImmediate(sphere); }
+                if (lightGo != null) { Object.DestroyImmediate(lightGo); }
+                if (camGo != null) { Object.DestroyImmediate(camGo); }
+            }
         }
 
         private static Texture2D RenderAsColorTexture(Texture2D texture)
         {
-            var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
-            quad.transform.position = Vector3.zero;
-
-            var mat = new Material(Shader.Find("Unlit/Texture"));
-            mat.SetTexture("_MainTex", texture);
-            quad.GetComponent<MeshRenderer>().sharedMaterial = mat;
-
-            var camGo = new GameObject("RawTextureCamera");
-            var cam = camGo.AddComponent<Camera>();
-            cam.orthographic = true;
-            cam.orthographicSize = 0.5f;
-            cam.transform.position = new Vector3(0f, 0f, -3f);
-            cam.transform.LookAt(quad.transform);
-            cam.clearFlags = CameraClearFlags.SolidColor;
-            cam.backgroundColor = Color.black;
-
-            var rt = new RenderTexture(256, 256, 16, RenderTextureFormat.ARGB32);
-            cam.targetTexture = rt;
-            cam.Render();
-
+            GameObject quad = null;
+            Material mat = null;
+            GameObject camGo = null;
+            RenderTexture rt = null;
             var prevRT = RenderTexture.active;
-            RenderTexture.active = rt;
-            var result = new Texture2D(256, 256, TextureFormat.RGBA32, false);
-            result.ReadPixels(new Rect(0f, 0f, 256f, 256f), 0, 0);
-            result.Apply();
-            RenderTexture.active = prevRT;
+            try
+            {
+                quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                quad.transform.position = Vector3.zero;
 
-            cam.targetTexture = null;
-            Object.DestroyImmediate(rt);
-            Object.DestroyImmediate(mat);
-            Object.DestroyImmediate(quad);
-            Object.DestroyImmediate(camGo);
+                mat = new Material(Shader.Find("Unlit/Texture"));
+                mat.SetTexture("_MainTex", texture);
+                quad.GetComponent<MeshRenderer>().sharedMaterial = mat;
 
-            return result;
+                camGo = new GameObject("RawTextureCamera");
+                var cam = camGo.AddComponent<Camera>();
+                cam.orthographic = true;
+                cam.orthographicSize = 0.5f;
+                cam.transform.position = new Vector3(0f, 0f, -3f);
+                cam.transform.LookAt(quad.transform);
+                cam.clearFlags = CameraClearFlags.SolidColor;
+                cam.backgroundColor = Color.black;
+
+                rt = new RenderTexture(256, 256, 16, RenderTextureFormat.ARGB32);
+                cam.targetTexture = rt;
+                cam.Render();
+
+                RenderTexture.active = rt;
+                var result = new Texture2D(256, 256, TextureFormat.RGBA32, false);
+                result.ReadPixels(new Rect(0f, 0f, 256f, 256f), 0, 0);
+                result.Apply();
+                cam.targetTexture = null;
+                return result;
+            }
+            finally
+            {
+                RenderTexture.active = prevRT;
+                if (rt != null) { Object.DestroyImmediate(rt); }
+                if (mat != null) { Object.DestroyImmediate(mat); }
+                if (quad != null) { Object.DestroyImmediate(quad); }
+                if (camGo != null) { Object.DestroyImmediate(camGo); }
+            }
         }
 
         private static float DecodedNormalErrorFromDownscaled(Texture2D downscaledRaw, Texture2D targetRaw, bool decodeRgb)

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs
@@ -1,0 +1,443 @@
+// <copyright file="NormalMapPreviewRenderingTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace KRT.VRCQuestTools.Utils
+{
+    /// <summary>
+    /// Tests for the in-memory normal map preview rendering issue and its countermeasure.
+    ///
+    /// Root cause: a normal map produced by TextureGenerator (CompressNormalMap) is not uploaded to the GPU
+    /// for display, so a freshly generated in-memory normal map renders incorrectly in the NDMF preview. The
+    /// same data renders correctly once re-uploaded (the editor displays the compressed normal map - DXT5nm on
+    /// desktop, ASTC on Android/iOS - correctly after a Texture2D.Apply). Cache-restored textures are already
+    /// uploaded via Apply. The actual mobile build is unaffected.
+    ///
+    /// Countermeasure: <see cref="TextureUtility.ReuploadForEditorDisplay"/> re-uploads a freshly generated
+    /// normal map (keeping its format) so that the editor preview renders the same result as the asset-imported
+    /// (baked) texture.
+    ///
+    /// NDMF preview path:  CompressNormalMap -> in-memory Texture2D -> ReuploadForEditorDisplay -> material.
+    /// NDMF bake path:     CompressNormalMap -> AssetDatabase.CreateAsset -> .asset -> loaded back -> material.
+    /// </summary>
+    public class NormalMapPreviewRenderingTests
+    {
+#if UNITY_EDITOR_WIN
+        private const float Threshold = 0.1f;
+#else
+        private const float Threshold = 0.2f;
+#endif
+
+        private string tempPath;
+
+        /// <summary>
+        /// Sets up a temporary directory for baked texture assets.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            tempPath = $"Assets/VRCQuestTools-Tests/Temp/{System.Guid.NewGuid():N}";
+            Directory.CreateDirectory(tempPath);
+            AssetDatabase.Refresh();
+        }
+
+        /// <summary>
+        /// Removes the temporary directory and its assets.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (AssetDatabase.IsValidFolder(tempPath))
+            {
+                AssetDatabase.DeleteAsset(tempPath);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a freshly generated normal map (no cache) re-uploaded for editor display renders
+        /// correctly for the current active build target. This reproduces the NDMF preview first-time generation
+        /// path: the CompressNormalMap output is not uploaded to the GPU for display until re-uploaded. A failure
+        /// indicates the fresh normal map is not reflected in the preview.
+        /// </summary>
+        [Test]
+        public void FreshNormalMap_PreparedForEditorDisplay_RendersLikeSource()
+        {
+            var sourceNormalMap = AssetDatabase.LoadAssetAtPath<Texture2D>(
+                "Assets/VRCQuestTools-Tests/Fixtures/Textures/NormalMapSample01.png");
+            Assert.IsNotNull(sourceNormalMap, "Failed to load NormalMapSample01.png.");
+
+            LogAssert.ignoreFailingMessages = true;
+            var downscaled = TextureUtility.DownscaleNormalMap(
+                sourceNormalMap, true, sourceNormalMap.width, sourceNormalMap.height);
+
+            // Generate for the active build target (ASTC for mobile, DXT5nm for desktop) like the preview does.
+            var buildTarget = EditorUserBuildSettings.activeBuildTarget;
+            var fresh = TextureUtility.CompressNormalMap(downscaled, buildTarget, TextureFormat.ASTC_8x8);
+
+            // Prepare for editor display the same way MaterialGeneratorUtility does for a freshly generated texture.
+            var prepared = TextureUtility.ReuploadForEditorDisplay(fresh);
+
+            var sourceRendered = RenderWithNormalMap(sourceNormalMap);
+            var preparedRendered = RenderWithNormalMap(prepared);
+            LogAssert.ignoreFailingMessages = false;
+
+            var diff = TestUtils.MaxDifference(sourceRendered, preparedRendered);
+            Assert.Less(diff, Threshold, $"Freshly generated normal map re-uploaded for editor display doesn't match source rendering (diff={diff:F4}, target={buildTarget}).");
+        }
+
+        /// <summary>
+        /// Verifies that the re-uploaded in-memory normal map (NDMF preview path with countermeasure)
+        /// and the .asset-serialized normal map (NDMF bake path) render equivalently to the source
+        /// normal map when applied to a Standard material.
+        /// </summary>
+        [Test]
+        public void PreviewNormalMap_And_BakedNormalMap_RenderSimilarly()
+        {
+            // Load source normal map as an asset (may be DXT5nm on Windows).
+            var sourceNormalMap = AssetDatabase.LoadAssetAtPath<Texture2D>(
+                "Assets/VRCQuestTools-Tests/Fixtures/Textures/NormalMapSample01.png");
+            Assert.IsNotNull(sourceNormalMap, "Failed to load NormalMapSample01.png.");
+
+            // Apply DownscaleNormalMap as ToonStandard does for mobile (outputRGB=true when isMobile=true).
+            // This decodes the source (e.g. DXT5nm) into a linear RGB Texture2D suitable for CompressNormalMap.
+            LogAssert.ignoreFailingMessages = true;
+            var downscaled = TextureUtility.DownscaleNormalMap(
+                sourceNormalMap, true, sourceNormalMap.width, sourceNormalMap.height);
+
+            // NDMF preview path: a freshly generated CompressNormalMap output is re-uploaded for editor display.
+            var previewCompressed = TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8);
+            var previewNormal = TextureUtility.ReuploadForEditorDisplay(previewCompressed);
+
+            // NDMF bake path: same CompressNormalMap output is serialized to .asset and reloaded.
+            var inMemoryNormal = TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8);
+            LogAssert.ignoreFailingMessages = false;
+
+            var assetPath = $"{tempPath}/normal_baked.asset";
+            AssetDatabase.CreateAsset(inMemoryNormal, assetPath);
+            AssetDatabase.SaveAssets();
+            var bakedNormal = AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
+            Assert.IsNotNull(bakedNormal, "Failed to load baked normal map .asset.");
+
+            // Render all three: source (reference), preview, and baked.
+            LogAssert.ignoreFailingMessages = true;
+            var sourceRendered = RenderWithNormalMap(sourceNormalMap);
+            var previewRendered = RenderWithNormalMap(previewNormal);
+            var bakedRendered = RenderWithNormalMap(bakedNormal);
+            LogAssert.ignoreFailingMessages = false;
+
+            // Compare each result against the source rendering (ground truth).
+            var diffSourceVsPreview = TestUtils.MaxDifference(sourceRendered, previewRendered);
+            var diffSourceVsBaked = TestUtils.MaxDifference(sourceRendered, bakedRendered);
+            var diffPreviewVsBaked = TestUtils.MaxDifference(previewRendered, bakedRendered);
+
+            var msgPreview = $"Re-uploaded preview normal map doesn't match source rendering (diff={diffSourceVsPreview:F4}). Baked diff from source: {diffSourceVsBaked:F4}.";
+            Assert.Less(diffSourceVsPreview, Threshold, msgPreview);
+            var msgBaked = $"Baked normal map doesn't match source rendering (diff={diffSourceVsBaked:F4}). Preview diff from source: {diffSourceVsPreview:F4}.";
+            Assert.Less(diffSourceVsBaked, Threshold, msgBaked);
+            var msgPreviewVsBaked = $"Re-uploaded preview and baked normal maps should render the same (diff={diffPreviewVsBaked:F4}).";
+            Assert.Less(diffPreviewVsBaked, Threshold, msgPreviewVsBaked);
+        }
+
+        /// <summary>
+        /// Verifies that a cached/restored normal map renders equivalently to the source rendering.
+        /// This reproduces the NDMF preview cache reuse path: CompressNormalMap -> TextureCache serialize ->
+        /// TextureCache.ToTexture2D. The cache-restored texture is already uploaded via Apply, so it is used
+        /// directly, while the freshly generated preview is re-uploaded.
+        /// </summary>
+        [Test]
+        public void CachedPreviewNormalMap_RenderSimilarlyToSource()
+        {
+            var sourceNormalMap = AssetDatabase.LoadAssetAtPath<Texture2D>(
+                "Assets/VRCQuestTools-Tests/Fixtures/Textures/NormalMapSample01.png");
+            Assert.IsNotNull(sourceNormalMap, "Failed to load NormalMapSample01.png.");
+
+            LogAssert.ignoreFailingMessages = true;
+            var downscaled = TextureUtility.DownscaleNormalMap(
+                sourceNormalMap, true, sourceNormalMap.width, sourceNormalMap.height);
+            var previewCompressed = TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8);
+            var cache = new CacheUtility.TextureCache(previewCompressed, true, true, UnityEditor.BuildTarget.Android);
+
+            // Freshly generated preview is re-uploaded; cache-restored texture is already uploaded (used directly).
+            var previewNormal = TextureUtility.ReuploadForEditorDisplay(previewCompressed);
+            var cachedNormal = cache.ToTexture2D();
+            LogAssert.ignoreFailingMessages = false;
+
+            LogAssert.ignoreFailingMessages = true;
+            var sourceRendered = RenderWithNormalMap(sourceNormalMap);
+            var previewRendered = RenderWithNormalMap(previewNormal);
+            var cachedRendered = RenderWithNormalMap(cachedNormal);
+            LogAssert.ignoreFailingMessages = false;
+
+            var diffSourceVsPreview = TestUtils.MaxDifference(sourceRendered, previewRendered);
+            var diffSourceVsCached = TestUtils.MaxDifference(sourceRendered, cachedRendered);
+            var diffPreviewVsCached = TestUtils.MaxDifference(previewRendered, cachedRendered);
+
+            var msgCached = $"Cached normal map doesn't match source rendering (diff={diffSourceVsCached:F4}). Preview diff from source: {diffSourceVsPreview:F4}, preview-vs-cached diff: {diffPreviewVsCached:F4}.";
+            Assert.Less(diffSourceVsCached, Threshold, msgCached);
+            var msgPreviewVsCached = $"Cached normal map should match preview rendering (diff={diffPreviewVsCached:F4}). Preview diff from source: {diffSourceVsPreview:F4}, cached diff from source: {diffSourceVsCached:F4}.";
+            Assert.Less(diffPreviewVsCached, Threshold, msgPreviewVsCached);
+        }
+
+        /// <summary>
+        /// Verifies order-dependent behavior where generated preview texture is used first and
+        /// cache-restored texture is used second. The freshly generated one is re-uploaded; the cache-restored
+        /// one is used directly.
+        /// </summary>
+        [Test]
+        public void CacheReuseOrder_GeneratedThenReused_RenderSimilarlyToSource()
+        {
+            var sourceNormalMap = AssetDatabase.LoadAssetAtPath<Texture2D>(
+                "Assets/VRCQuestTools-Tests/Fixtures/Textures/NormalMapSample01.png");
+            Assert.IsNotNull(sourceNormalMap, "Failed to load NormalMapSample01.png.");
+
+            LogAssert.ignoreFailingMessages = true;
+            var downscaled = TextureUtility.DownscaleNormalMap(
+                sourceNormalMap, true, sourceNormalMap.width, sourceNormalMap.height);
+            var generatedFirst = TextureUtility.ReuploadForEditorDisplay(TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8));
+            var cacheSource = TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8);
+            var cache = new CacheUtility.TextureCache(cacheSource, true, true, UnityEditor.BuildTarget.Android);
+            var reusedSecond = cache.ToTexture2D();
+
+            var sourceRendered = RenderWithNormalMap(sourceNormalMap);
+            var generatedRendered = RenderWithNormalMap(generatedFirst);
+            var reusedRendered = RenderWithNormalMap(reusedSecond);
+            LogAssert.ignoreFailingMessages = false;
+
+            var diffSourceVsGenerated = TestUtils.MaxDifference(sourceRendered, generatedRendered);
+            var diffSourceVsReused = TestUtils.MaxDifference(sourceRendered, reusedRendered);
+            var diffGeneratedVsReused = TestUtils.MaxDifference(generatedRendered, reusedRendered);
+
+            Assert.Less(diffSourceVsGenerated, Threshold, $"Generated-first normal map doesn't match source rendering (diff={diffSourceVsGenerated:F4}).");
+            Assert.Less(diffSourceVsReused, Threshold, $"Reused-second normal map doesn't match source rendering (diff={diffSourceVsReused:F4}).");
+            Assert.Less(diffGeneratedVsReused, Threshold, $"Generated-first and reused-second renderings should match (diff={diffGeneratedVsReused:F4}).");
+        }
+
+        /// <summary>
+        /// Verifies order-dependent behavior where cache-restored texture is used first and
+        /// generated preview texture is used second. The cache-restored one is used directly; the freshly
+        /// generated one is re-uploaded.
+        /// </summary>
+        [Test]
+        public void CacheReuseOrder_ReusedThenGenerated_RenderSimilarlyToSource()
+        {
+            var sourceNormalMap = AssetDatabase.LoadAssetAtPath<Texture2D>(
+                "Assets/VRCQuestTools-Tests/Fixtures/Textures/NormalMapSample01.png");
+            Assert.IsNotNull(sourceNormalMap, "Failed to load NormalMapSample01.png.");
+
+            LogAssert.ignoreFailingMessages = true;
+            var downscaled = TextureUtility.DownscaleNormalMap(
+                sourceNormalMap, true, sourceNormalMap.width, sourceNormalMap.height);
+            var cacheSource = TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8);
+            var cache = new CacheUtility.TextureCache(cacheSource, true, true, UnityEditor.BuildTarget.Android);
+            var reusedFirst = cache.ToTexture2D();
+            var generatedSecond = TextureUtility.ReuploadForEditorDisplay(TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8));
+
+            var sourceRendered = RenderWithNormalMap(sourceNormalMap);
+            var reusedRendered = RenderWithNormalMap(reusedFirst);
+            var generatedRendered = RenderWithNormalMap(generatedSecond);
+            LogAssert.ignoreFailingMessages = false;
+
+            var diffSourceVsReused = TestUtils.MaxDifference(sourceRendered, reusedRendered);
+            var diffSourceVsGenerated = TestUtils.MaxDifference(sourceRendered, generatedRendered);
+            var diffReusedVsGenerated = TestUtils.MaxDifference(reusedRendered, generatedRendered);
+
+            Assert.Less(diffSourceVsReused, Threshold, $"Reused-first normal map doesn't match source rendering (diff={diffSourceVsReused:F4}).");
+            Assert.Less(diffSourceVsGenerated, Threshold, $"Generated-second normal map doesn't match source rendering (diff={diffSourceVsGenerated:F4}).");
+            Assert.Less(diffReusedVsGenerated, Threshold, $"Reused-first and generated-second renderings should match (diff={diffReusedVsGenerated:F4}).");
+        }
+
+        /// <summary>
+        /// Compares channel decode assumptions (RGB vs AG) and verifies that the preview/cache textures follow
+        /// the same decode model (RGB) as the baked texture.
+        /// </summary>
+        [Test]
+        public void ChannelDecodeModel_PreviewAndCacheMatchBaked()
+        {
+            var sourceNormalMap = AssetDatabase.LoadAssetAtPath<Texture2D>(
+                "Assets/VRCQuestTools-Tests/Fixtures/Textures/NormalMapSample01.png");
+            Assert.IsNotNull(sourceNormalMap, "Failed to load NormalMapSample01.png.");
+
+            LogAssert.ignoreFailingMessages = true;
+            var downscaled = TextureUtility.DownscaleNormalMap(
+                sourceNormalMap, true, sourceNormalMap.width, sourceNormalMap.height);
+            var previewCompressed = TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8);
+            var inMemoryNormal = TextureUtility.CompressNormalMap(
+                downscaled, UnityEditor.BuildTarget.Android, TextureFormat.ASTC_8x8);
+            var cache = new CacheUtility.TextureCache(previewCompressed, true, true, UnityEditor.BuildTarget.Android);
+            var previewNormal = TextureUtility.ReuploadForEditorDisplay(previewCompressed);
+            var cachedNormal = cache.ToTexture2D();
+            LogAssert.ignoreFailingMessages = false;
+
+            var assetPath = $"{tempPath}/normal_model_check.asset";
+            AssetDatabase.CreateAsset(inMemoryNormal, assetPath);
+            AssetDatabase.SaveAssets();
+            var bakedNormal = AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
+            Assert.IsNotNull(bakedNormal, "Failed to load baked normal map .asset.");
+
+            LogAssert.ignoreFailingMessages = true;
+            var downscaledRaw = RenderAsColorTexture(downscaled);
+            var previewRaw = RenderAsColorTexture(previewNormal);
+            var cachedRaw = RenderAsColorTexture(cachedNormal);
+            var bakedRaw = RenderAsColorTexture(bakedNormal);
+            LogAssert.ignoreFailingMessages = false;
+
+            var previewRgbError = DecodedNormalErrorFromDownscaled(downscaledRaw, previewRaw, decodeRgb: true);
+            var previewAgError = DecodedNormalErrorFromDownscaled(downscaledRaw, previewRaw, decodeRgb: false);
+            var cachedRgbError = DecodedNormalErrorFromDownscaled(downscaledRaw, cachedRaw, decodeRgb: true);
+            var cachedAgError = DecodedNormalErrorFromDownscaled(downscaledRaw, cachedRaw, decodeRgb: false);
+            var bakedRgbError = DecodedNormalErrorFromDownscaled(downscaledRaw, bakedRaw, decodeRgb: true);
+            var bakedAgError = DecodedNormalErrorFromDownscaled(downscaledRaw, bakedRaw, decodeRgb: false);
+
+            var bakedUsesRgb = bakedRgbError <= bakedAgError;
+            var previewUsesRgb = previewRgbError <= previewAgError;
+            var cachedUsesRgb = cachedRgbError <= cachedAgError;
+            Debug.Log($"[NormalMapPreviewRenderingTests] decode errors: preview RGB/AG={previewRgbError:F4}/{previewAgError:F4}, cached RGB/AG={cachedRgbError:F4}/{cachedAgError:F4}, baked RGB/AG={bakedRgbError:F4}/{bakedAgError:F4}");
+
+            Assert.IsTrue(bakedUsesRgb, $"Baked normal map should follow RGB decode model but RGB/AG error={bakedRgbError:F4}/{bakedAgError:F4}.");
+            var msgPreview = $"Preview decode model mismatch. Preview RGB/AG error={previewRgbError:F4}/{previewAgError:F4}, Baked RGB/AG error={bakedRgbError:F4}/{bakedAgError:F4}.";
+            Assert.AreEqual(bakedUsesRgb, previewUsesRgb, msgPreview);
+            var msgCached = $"Cached decode model mismatch. Cached RGB/AG error={cachedRgbError:F4}/{cachedAgError:F4}, Baked RGB/AG error={bakedRgbError:F4}/{bakedAgError:F4}.";
+            Assert.AreEqual(bakedUsesRgb, cachedUsesRgb, msgCached);
+        }
+
+        /// <summary>
+        /// Renders a sphere with the given normal map texture using a camera and returns the captured pixels.
+        /// </summary>
+        /// <param name="normalMap">Normal map texture to apply to the Standard material's BumpMap slot.</param>
+        /// <returns>Rendered Texture2D containing captured pixels.</returns>
+        private static Texture2D RenderWithNormalMap(Texture2D normalMap)
+        {
+            // Sphere with Standard material using the normal map.
+            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            sphere.transform.position = Vector3.zero;
+
+            var mat = new Material(Shader.Find("Standard"));
+            mat.EnableKeyword("_NORMALMAP");
+            mat.SetTexture("_BumpMap", normalMap);
+            mat.SetFloat("_BumpScale", 1f);
+            sphere.GetComponent<MeshRenderer>().sharedMaterial = mat;
+
+            // Directional light to make normal map shading visible.
+            var lightGo = new GameObject("TestLight");
+            var light = lightGo.AddComponent<Light>();
+            light.type = LightType.Directional;
+            light.transform.rotation = Quaternion.Euler(45f, 45f, 0f);
+            light.intensity = 1f;
+
+            // Camera facing the sphere from the front.
+            var camGo = new GameObject("TestCamera");
+            var cam = camGo.AddComponent<Camera>();
+            cam.transform.position = new Vector3(0f, 0f, -3f);
+            cam.transform.LookAt(sphere.transform);
+            cam.clearFlags = CameraClearFlags.SolidColor;
+            cam.backgroundColor = Color.black;
+
+            // Render to a 256x256 RenderTexture and read back pixels.
+            var rt = new RenderTexture(256, 256, 16, RenderTextureFormat.ARGB32);
+            cam.targetTexture = rt;
+            cam.Render();
+
+            var prevRT = RenderTexture.active;
+            RenderTexture.active = rt;
+            var result = new Texture2D(256, 256, TextureFormat.RGBA32, false);
+            result.ReadPixels(new Rect(0f, 0f, 256f, 256f), 0, 0);
+            result.Apply();
+            RenderTexture.active = prevRT;
+
+            cam.targetTexture = null;
+            Object.DestroyImmediate(rt);
+            Object.DestroyImmediate(mat);
+            Object.DestroyImmediate(sphere);
+            Object.DestroyImmediate(lightGo);
+            Object.DestroyImmediate(camGo);
+
+            return result;
+        }
+
+        private static Texture2D RenderAsColorTexture(Texture2D texture)
+        {
+            var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            quad.transform.position = Vector3.zero;
+
+            var mat = new Material(Shader.Find("Unlit/Texture"));
+            mat.SetTexture("_MainTex", texture);
+            quad.GetComponent<MeshRenderer>().sharedMaterial = mat;
+
+            var camGo = new GameObject("RawTextureCamera");
+            var cam = camGo.AddComponent<Camera>();
+            cam.orthographic = true;
+            cam.orthographicSize = 0.5f;
+            cam.transform.position = new Vector3(0f, 0f, -3f);
+            cam.transform.LookAt(quad.transform);
+            cam.clearFlags = CameraClearFlags.SolidColor;
+            cam.backgroundColor = Color.black;
+
+            var rt = new RenderTexture(256, 256, 16, RenderTextureFormat.ARGB32);
+            cam.targetTexture = rt;
+            cam.Render();
+
+            var prevRT = RenderTexture.active;
+            RenderTexture.active = rt;
+            var result = new Texture2D(256, 256, TextureFormat.RGBA32, false);
+            result.ReadPixels(new Rect(0f, 0f, 256f, 256f), 0, 0);
+            result.Apply();
+            RenderTexture.active = prevRT;
+
+            cam.targetTexture = null;
+            Object.DestroyImmediate(rt);
+            Object.DestroyImmediate(mat);
+            Object.DestroyImmediate(quad);
+            Object.DestroyImmediate(camGo);
+
+            return result;
+        }
+
+        private static float DecodedNormalErrorFromDownscaled(Texture2D downscaledRaw, Texture2D targetRaw, bool decodeRgb)
+        {
+            var xs = new int[] { 64, 128, 192 };
+            var ys = new int[] { 64, 128, 192 };
+            float errorSum = 0f;
+            int count = 0;
+            foreach (var x in xs)
+            {
+                foreach (var y in ys)
+                {
+                    var reference = DecodeRgbNormal(downscaledRaw.GetPixel(x, y));
+                    var target = decodeRgb ? DecodeRgbNormal(targetRaw.GetPixel(x, y)) : DecodeAgNormal(targetRaw.GetPixel(x, y));
+                    errorSum += Vector3.Distance(reference, target);
+                    count++;
+                }
+            }
+            return errorSum / count;
+        }
+
+        private static Vector3 DecodeRgbNormal(Color color)
+        {
+            var normal = new Vector3((color.r * 2f) - 1f, (color.g * 2f) - 1f, (color.b * 2f) - 1f);
+            return normal.sqrMagnitude > 0f ? normal.normalized : Vector3.forward;
+        }
+
+        private static Vector3 DecodeAgNormal(Color color)
+        {
+            var x = (color.a * 2f) - 1f;
+            var y = (color.g * 2f) - 1f;
+            var z = Mathf.Sqrt(Mathf.Clamp01(1f - (x * x) - (y * y)));
+            return new Vector3(x, y, z);
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/NormalMapPreviewRenderingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29ecbc9f8e4e14942a5412b7d2e20fe2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Temp/.gitignore
+++ b/Assets/VRCQuestTools-Tests/Temp/.gitignore
@@ -1,0 +1,3 @@
+# Ignore test-generated temporary assets/folders.
+*
+!.gitignore

--- a/Assets/VRCQuestTools-Tests/Temp/0f7b43d5cb5346afb774c89b15e4b4e7.meta
+++ b/Assets/VRCQuestTools-Tests/Temp/0f7b43d5cb5346afb774c89b15e4b4e7.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1618479e5b6ccb746b5ee18cce3880c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Temp/0f7b43d5cb5346afb774c89b15e4b4e7.meta
+++ b/Assets/VRCQuestTools-Tests/Temp/0f7b43d5cb5346afb774c89b15e4b4e7.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 1618479e5b6ccb746b5ee18cce3880c7
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/GenericToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/GenericToonStandardGenerator.cs
@@ -19,8 +19,9 @@ namespace KRT.VRCQuestTools.Models
         /// <param name="material">Material to convert.</param>
         /// <param name="settings">Convert settings.</param>
         /// <param name="sharedBlackTexture">Shared black texture to disable emission.</param>
-        public GenericToonStandardGenerator(MaterialBase material, ToonStandardConvertSettings settings, Texture2D sharedBlackTexture)
-            : base(settings, sharedBlackTexture)
+        /// <param name="forEditorPreview">Whether the conversion is for the NDMF editor preview.</param>
+        public GenericToonStandardGenerator(MaterialBase material, ToonStandardConvertSettings settings, Texture2D sharedBlackTexture, bool forEditorPreview)
+            : base(settings, sharedBlackTexture, forEditorPreview)
         {
             this.material = material;
         }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/LilToonToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/LilToonToonStandardGenerator.cs
@@ -21,8 +21,9 @@ namespace KRT.VRCQuestTools.Models
         /// <param name="material">LilToon material.</param>
         /// <param name="settings">Convert settings.</param>
         /// <param name="sharedBlackTexture">Shared black texture to disable emission.</param>
-        public LilToonToonStandardGenerator(LilToonMaterial material, ToonStandardConvertSettings settings, Texture2D sharedBlackTexture)
-            : base(settings, sharedBlackTexture)
+        /// <param name="forEditorPreview">Whether the conversion is for the NDMF editor preview.</param>
+        public LilToonToonStandardGenerator(LilToonMaterial material, ToonStandardConvertSettings settings, Texture2D sharedBlackTexture, bool forEditorPreview)
+            : base(settings, sharedBlackTexture, forEditorPreview)
         {
             this.lilMaterial = material;
         }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/MaterialGeneratorUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/MaterialGeneratorUtility.cs
@@ -35,7 +35,7 @@ namespace KRT.VRCQuestTools.Models
         /// <returns>Async callback request.</returns>
         internal static AsyncCallbackRequest GenerateTexture(Material material, IMaterialConvertSettings settings, string textureType, bool saveAsPng, string texturesPath, Func<Action<Texture2D>, AsyncCallbackRequest> requestGenerateImageFunc, Action<Texture2D> completion, (int MaxTextureSize, TextureFormat Format)? platformOverride)
         {
-            return GenerateTexture(material, settings, textureType, saveAsPng, texturesPath, TextureConfig.SRGB, requestGenerateImageFunc, completion, platformOverride);
+            return GenerateTexture(material, settings, textureType, saveAsPng, texturesPath, TextureConfig.SRGB, requestGenerateImageFunc, completion, platformOverride, false);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace KRT.VRCQuestTools.Models
         /// <returns>Async callback request.</returns>
         internal static AsyncCallbackRequest GenerateParameterTexture(Material material, IMaterialConvertSettings settings, string textureType, bool saveAsPng, string texturesPath, Func<Action<Texture2D>, AsyncCallbackRequest> requestGenerateImageFunc, Action<Texture2D> completion, (int MaxTextureSize, TextureFormat Format)? platformOverride)
         {
-            return GenerateTexture(material, settings, textureType, saveAsPng, texturesPath, TextureConfig.Parameter, requestGenerateImageFunc, completion, platformOverride);
+            return GenerateTexture(material, settings, textureType, saveAsPng, texturesPath, TextureConfig.Parameter, requestGenerateImageFunc, completion, platformOverride, false);
         }
 
         /// <summary>
@@ -66,13 +66,14 @@ namespace KRT.VRCQuestTools.Models
         /// <param name="requestGenerateImageFunc">Function to generate Texture2D.</param>
         /// <param name="completion">Completion callback.</param>
         /// <param name="platformOverride">Optional platform override settings (MaxTextureSize and Format) from source textures.</param>
+        /// <param name="forEditorPreview">Whether the conversion is for the NDMF editor preview; re-uploads the generated normal map so it displays.</param>
         /// <returns>Async callback request.</returns>
-        internal static AsyncCallbackRequest GenerateNormalMap(Material material, IMaterialConvertSettings settings, string textureType, bool saveAsPng, string texturesPath, Func<Action<Texture2D>, AsyncCallbackRequest> requestGenerateImageFunc, Action<Texture2D> completion, (int MaxTextureSize, TextureFormat Format)? platformOverride)
+        internal static AsyncCallbackRequest GenerateNormalMap(Material material, IMaterialConvertSettings settings, string textureType, bool saveAsPng, string texturesPath, Func<Action<Texture2D>, AsyncCallbackRequest> requestGenerateImageFunc, Action<Texture2D> completion, (int MaxTextureSize, TextureFormat Format)? platformOverride, bool forEditorPreview)
         {
-            return GenerateTexture(material, settings, textureType, saveAsPng, texturesPath, TextureConfig.NormalMap, requestGenerateImageFunc, completion, platformOverride);
+            return GenerateTexture(material, settings, textureType, saveAsPng, texturesPath, TextureConfig.NormalMap, requestGenerateImageFunc, completion, platformOverride, forEditorPreview);
         }
 
-        private static AsyncCallbackRequest GenerateTexture(Material material, IMaterialConvertSettings settings, string textureType, bool saveAsPng, string texturesPath, TextureConfig config, Func<Action<Texture2D>, AsyncCallbackRequest> requestGenerateImageFunc, Action<Texture2D> completion, (int MaxTextureSize, TextureFormat Format)? platformOverride)
+        private static AsyncCallbackRequest GenerateTexture(Material material, IMaterialConvertSettings settings, string textureType, bool saveAsPng, string texturesPath, TextureConfig config, Func<Action<Texture2D>, AsyncCallbackRequest> requestGenerateImageFunc, Action<Texture2D> completion, (int MaxTextureSize, TextureFormat Format)? platformOverride, bool forEditorPreview)
         {
             var assetHash = Hash128.Compute(CacheUtility.GetContentCacheKey(material) + settings.GetCacheKey());
             var cacheFile = $"texture_{VRCQuestTools.Version}_{settings.GetType()}_{textureType}_{EditorUserBuildSettings.activeBuildTarget}_{assetHash}" + (saveAsPng ? ".png" : ".json");
@@ -97,6 +98,15 @@ namespace KRT.VRCQuestTools.Models
                 {
                     texToWrite.name = texName;
                     texToWrite = SaveTexture(settings.MobileTextureFormat, saveAsPng, texturesPath, config, texToWrite, cacheFile, outFile, platformOverride);
+
+                    // A freshly generated normal map is not uploaded to the GPU by TextureGenerator; re-upload it
+                    // for the NDMF preview (preview only) so it renders. See TextureUtility.ReuploadForEditorDisplay.
+                    if (config.isNormalMap && forEditorPreview)
+                    {
+                        var reuploaded = TextureUtility.ReuploadForEditorDisplay(texToWrite);
+                        TextureUtility.DestroyTexture(texToWrite);
+                        texToWrite = reuploaded;
+                    }
                 }
                 completion?.Invoke(texToWrite);
             });

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/ToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/ToonStandardGenerator.cs
@@ -24,14 +24,22 @@ namespace KRT.VRCQuestTools.Models
         protected readonly Texture2D sharedBlackTexture;
 
         /// <summary>
+        /// Whether the conversion is for the NDMF editor preview. When true, the generated normal map is
+        /// re-uploaded so it displays correctly in the editor.
+        /// </summary>
+        protected readonly bool forEditorPreview;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ToonStandardGenerator"/> class.
         /// </summary>
         /// <param name="settings">Convert settings.</param>
         /// <param name="sharedBlackTexture">Shared black texture to disable emission.</param>
-        internal ToonStandardGenerator(ToonStandardConvertSettings settings, Texture2D sharedBlackTexture)
+        /// <param name="forEditorPreview">Whether the conversion is for the NDMF editor preview.</param>
+        internal ToonStandardGenerator(ToonStandardConvertSettings settings, Texture2D sharedBlackTexture, bool forEditorPreview)
         {
             this.Settings = settings;
             this.sharedBlackTexture = sharedBlackTexture;
+            this.forEditorPreview = forEditorPreview;
         }
 
         /// <summary>
@@ -183,7 +191,7 @@ namespace KRT.VRCQuestTools.Models
                         newMaterial.NormalMap = t;
                         (newMaterial.NormalMapTextureScale, newMaterial.NormalMapTextureOffset) = GetNormalMapST();
                         newMaterial.NormalMapScale = GetNormalMapScale();
-                    }, normalPlatformOverride).WaitForCompletion();
+                    }, normalPlatformOverride, forEditorPreview).WaitForCompletion();
                 }
 
                 newMaterial.Culling = GetCulling();

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRChat/AvatarConverter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRChat/AvatarConverter.cs
@@ -136,7 +136,7 @@ namespace KRT.VRCQuestTools.Models.VRChat
 
             // Convert materials and generate textures.
             var convertSettingsMap = CreateMaterialConvertSettingsMap(avatar);
-            var convertedMaterials = ConvertMaterialsForMobile(convertSettingsMap, saveAssetsAsFile, assetsDirectory, progressCallback.onTextureProgress);
+            var convertedMaterials = ConvertMaterialsForMobile(convertSettingsMap, saveAssetsAsFile, assetsDirectory, progressCallback.onTextureProgress, forEditorPreview: false);
             CacheManager.Texture.Clear(VRCQuestToolsSettings.TextureCacheSize);
 
             ApplyConvertedMaterials(questAvatarObject, convertedMaterials, saveAssetsAsFile, assetsDirectory, progressCallback);
@@ -373,11 +373,11 @@ namespace KRT.VRCQuestTools.Models.VRChat
                                 var m2 = MaterialWrapperBuilder.Build(m);
                                 if (m2 is LilToonMaterial lil)
                                 {
-                                    request = new LilToonToonStandardGenerator(lil, toonStandardConvertSettings, sharedBlackTexture).GenerateTextures(m2, buildTarget, saveAsPng, saveDirectory, Completion);
+                                    request = new LilToonToonStandardGenerator(lil, toonStandardConvertSettings, sharedBlackTexture, forEditorPreview: false).GenerateTextures(m2, buildTarget, saveAsPng, saveDirectory, Completion);
                                 }
                                 else
                                 {
-                                    request = new GenericToonStandardGenerator(m2, toonStandardConvertSettings, sharedBlackTexture).GenerateTextures(m2, buildTarget, saveAsPng, saveDirectory, Completion);
+                                    request = new GenericToonStandardGenerator(m2, toonStandardConvertSettings, sharedBlackTexture, forEditorPreview: false).GenerateTextures(m2, buildTarget, saveAsPng, saveDirectory, Completion);
                                 }
                             }
                             else
@@ -408,12 +408,14 @@ namespace KRT.VRCQuestTools.Models.VRChat
         /// <param name="saveAsFile">Whether to save materials as file.</param>
         /// <param name="assetsDirectory">Root directory for converted avatar.</param>
         /// <param name="progressCallback">Callback to show progress.</param>
+        /// <param name="forEditorPreview">Whether the conversion is for the NDMF editor preview (re-uploads generated normal maps so they display in the editor).</param>
         /// <returns>Converted materials (key: original material).</returns>
         internal Dictionary<Material, Material> ConvertMaterialsForMobile(
             Dictionary<Material, IMaterialConvertSettings> convertSettingsMap,
             bool saveAsFile,
             string assetsDirectory,
-            TextureProgressCallback progressCallback)
+            TextureProgressCallback progressCallback,
+            bool forEditorPreview)
         {
             var convertedMaterials = new Dictionary<Material, Material>();
 
@@ -431,7 +433,7 @@ namespace KRT.VRCQuestTools.Models.VRChat
 
                 try
                 {
-                    var request = ConvertSingleMaterial(material, convertSettingsMap[material], saveAsFile, assetsDirectory, (output) =>
+                    var request = ConvertSingleMaterial(material, convertSettingsMap[material], saveAsFile, assetsDirectory, forEditorPreview, (output) =>
                     {
                         convertedMaterials[material] = output;
                         progressCallback?.Invoke(materialsToConvert.Length, currentIndex, material, output);
@@ -684,13 +686,14 @@ namespace KRT.VRCQuestTools.Models.VRChat
             IMaterialConvertSettings convertSettings,
             bool saveAsFile,
             string assetsDirectory,
+            bool forEditorPreview,
             Action<Material> completion)
         {
             AssetDatabase.TryGetGUIDAndLocalFileIdentifier(material, out string guid, out long localId);
             var materialWrapper = MaterialWrapperBuilder.Build(material);
 
             // Generate converted material based on settings
-            return GenerateConvertedMaterial(materialWrapper, convertSettings, saveAsFile, assetsDirectory, convertedMaterial =>
+            return GenerateConvertedMaterial(materialWrapper, convertSettings, saveAsFile, assetsDirectory, forEditorPreview, convertedMaterial =>
             {
                 // Save as asset if required
                 if (!(convertSettings is MaterialReplaceSettings))
@@ -717,6 +720,7 @@ namespace KRT.VRCQuestTools.Models.VRChat
             IMaterialConvertSettings settings,
             bool saveAsFile,
             string assetsDirectory,
+            bool forEditorPreview,
             Action<Material> completion)
         {
             var buildTarget = EditorUserBuildSettings.activeBuildTarget;
@@ -733,9 +737,9 @@ namespace KRT.VRCQuestTools.Models.VRChat
                 case ToonStandardConvertSettings toonStandardSettings:
                     if (material is LilToonMaterial)
                     {
-                        return new LilToonToonStandardGenerator((LilToonMaterial)material, toonStandardSettings, sharedBlackTexture).GenerateMaterial(material, buildTarget, saveAsFile, texturesPath, completion);
+                        return new LilToonToonStandardGenerator((LilToonMaterial)material, toonStandardSettings, sharedBlackTexture, forEditorPreview).GenerateMaterial(material, buildTarget, saveAsFile, texturesPath, completion);
                     }
-                    return new GenericToonStandardGenerator(material, toonStandardSettings, sharedBlackTexture).GenerateMaterial(material, buildTarget, saveAsFile, texturesPath, completion);
+                    return new GenericToonStandardGenerator(material, toonStandardSettings, sharedBlackTexture, forEditorPreview).GenerateMaterial(material, buildTarget, saveAsFile, texturesPath, completion);
                 case MaterialReplaceSettings replaceSettings:
                     if (replaceSettings.material == null)
                     {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
@@ -144,7 +144,8 @@ namespace KRT.VRCQuestTools.Ndmf
 
             var converter = new AvatarConverter(new MaterialWrapperBuilder());
             var settingsMap = converter.CreateMaterialConvertSettingsMap(avatarRoot, avatarMaterials.ToArray());
-            var materialLease = SharedPreviewMaterialCache.Acquire(settingsMap, m => converter.ConvertMaterialsForMobile(m, false, string.Empty, null));
+            // forEditorPreview: true re-uploads freshly generated normal maps so they render in the editor preview.
+            var materialLease = SharedPreviewMaterialCache.Acquire(settingsMap, m => converter.ConvertMaterialsForMobile(m, false, string.Empty, null, forEditorPreview: true));
             return Task.FromResult<IRenderFilterNode>(new MaterialConversionFilterNode(materialLease.MaterialMap, removeExtraMaterialSlots, materialLease));
         }
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheUtility.cs
@@ -160,7 +160,8 @@ namespace KRT.VRCQuestTools.Utils
                     var normal = AssetDatabase.LoadAssetAtPath<Texture2D>(path);
                     if (normal != null)
                     {
-                        return TextureUtility.CopyAsReadable(normal, false);
+                        // Restore the cached color space (normal maps are linear); CopyAsReadable's bool is the Texture2D "linear" flag.
+                        return TextureUtility.CopyAsReadable(normal, linear);
                     }
                     Logger.LogWarning($"Failed to load normal map from {path}. Creating normal map from uncompressed one.");
                 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureUtility.cs
@@ -651,6 +651,28 @@ namespace KRT.VRCQuestTools.Utils
         }
 
         /// <summary>
+        /// Re-uploads an in-memory texture into a fresh same-format copy so that it can be displayed in the editor.
+        /// Textures produced by <see cref="UnityEditor.TextureGenerator"/> (e.g. <see cref="CompressNormalMap"/>)
+        /// are not uploaded to the GPU, so a freshly generated normal map renders incorrectly in the editor
+        /// preview until re-uploaded (the editor displays the compressed normal map correctly once uploaded).
+        /// </summary>
+        /// <param name="texture">Texture to re-upload.</param>
+        /// <returns>A newly created copy that the caller is responsible for destroying, or null when input is null.</returns>
+        internal static Texture2D ReuploadForEditorDisplay(Texture2D texture)
+        {
+            if (texture == null)
+            {
+                return null;
+            }
+
+            var copy = new Texture2D(texture.width, texture.height, texture.format, texture.mipmapCount > 1, !texture.isDataSRGB);
+            copy.LoadRawTextureData(texture.GetRawTextureData());
+            copy.Apply(false, true);
+            copy.name = texture.name;
+            return copy;
+        }
+
+        /// <summary>
         /// Creates a single color 4x4 texture.
         /// </summary>
         /// <param name="color">Color to use.</param>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureUtility.cs
@@ -669,6 +669,9 @@ namespace KRT.VRCQuestTools.Utils
             copy.LoadRawTextureData(texture.GetRawTextureData());
             copy.Apply(false, true);
             copy.name = texture.name;
+            copy.wrapMode = texture.wrapMode;
+            copy.filterMode = texture.filterMode;
+            copy.anisoLevel = texture.anisoLevel;
             return copy;
         }
 
@@ -769,7 +772,7 @@ namespace KRT.VRCQuestTools.Utils
                 return;
             }
 
-            if (AssetDatabase.GetAssetPath(texture) != null)
+            if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(texture)))
             {
                 return;
             }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureUtility.cs
@@ -415,11 +415,11 @@ namespace KRT.VRCQuestTools.Utils
         /// Copy a texture as readable.
         /// </summary>
         /// <param name="texture">Texture to copy.</param>
-        /// <param name="isDataSRGB">Texture is sRGB.</param>
+        /// <param name="linear">Texture is linear.</param>
         /// <returns>Readable texture.</returns>
-        internal static Texture2D CopyAsReadable(Texture2D texture, bool isDataSRGB)
+        internal static Texture2D CopyAsReadable(Texture2D texture, bool linear)
         {
-            var copy = new Texture2D(texture.width, texture.height, texture.format, texture.mipmapCount > 1, isDataSRGB);
+            var copy = new Texture2D(texture.width, texture.height, texture.format, texture.mipmapCount > 1, linear);
             var data = texture.GetRawTextureData();
             copy.LoadRawTextureData(data);
             copy.Apply(); // Do not use arguments to keep readable.


### PR DESCRIPTION
A normal map generated by TextureGenerator (CompressNormalMap) is not uploaded to the GPU, so a freshly generated in-memory normal map renders incorrectly in the NDMF material conversion preview. This is independent of the texture format (ASTC on Android/iOS, DXT5nm on desktop); re-uploading the texture via Texture2D.Apply makes the editor display it correctly, matching the asset-imported (baked) result.

- Add TextureUtility.ReuploadForEditorDisplay, which recreates and re-uploads a generated texture (keeping its format) for editor display.
- Re-upload freshly generated normal maps in MaterialGeneratorUtility, and thread a forEditorPreview parameter through the conversion pipeline (ConvertMaterialsForMobile -> ToonStandard generators -> MaterialGeneratorUtility) so the re-upload runs only for the editor preview; actual builds and manual conversion are unaffected.
- Fix CacheUtility.CreateCompressedNormalMap restoring cached normal maps with an incorrect sRGB color space instead of linear, which made cache-restored preview normal maps render wrong.
- Add NormalMapPreviewRenderingTests covering the preview, cache-restore, cache-reuse-order, and baked-comparison paths.