### PR TITLE
Register replaced objects to ObjectRegistry in NDMF preview filters

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Common/NdmfObjectRegistry.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Common/NdmfObjectRegistry.cs
@@ -22,6 +22,22 @@ namespace KRT.VRCQuestTools.Ndmf
         }
 
         /// <summary>
+        /// Register a replaced object into the ambient ObjectRegistry. Intended for NDMF preview filters,
+        /// whose <c>Instantiate</c>/<c>Refresh</c> calls run inside an active <c>ObjectRegistryScope</c>.
+        /// Safe to call when no active registry exists or when the object is already registered.
+        /// </summary>
+        /// <param name="original">Original object.</param>
+        /// <param name="replaced">Replaced object.</param>
+        internal static void TryRegisterReplacedObjectToActiveRegistry(Object original, Object replaced)
+        {
+            if (original == null || replaced == null || original == replaced)
+            {
+                return;
+            }
+            ObjectRegistry.TryRegisterReplacedObject(ObjectRegistry.GetReference(original), replaced);
+        }
+
+        /// <summary>
         /// Register replaced object.
         /// </summary>
         /// <param name="original">Original object.</param>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Common/NdmfObjectRegistry.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Common/NdmfObjectRegistry.cs
@@ -34,7 +34,20 @@ namespace KRT.VRCQuestTools.Ndmf
             {
                 return;
             }
-            ObjectRegistry.TryRegisterReplacedObject(ObjectRegistry.GetReference(original), replaced);
+            var objRef = ObjectRegistry.GetReference(original);
+#if VQT_NDMF_HAS_TRY_REGISTER_REPLACED_OBJECT
+            // NDMF >= 1.6.8: dedicated no-throw API.
+            ObjectRegistry.TryRegisterReplacedObject(objRef, replaced);
+#else
+            // NDMF < 1.6.8: RegisterReplacedObject throws ArgumentException when already registered.
+            try
+            {
+                ObjectRegistry.RegisterReplacedObject(objRef, replaced);
+            }
+            catch (System.ArgumentException)
+            {
+            }
+#endif
         }
 
         /// <summary>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
@@ -7,6 +7,7 @@ using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.Models.Unity;
 using KRT.VRCQuestTools.Models.VRChat;
 using KRT.VRCQuestTools.Utils;
+using nadena.dev.ndmf;
 using nadena.dev.ndmf.preview;
 using UnityEditor;
 using UnityEngine;
@@ -146,8 +147,34 @@ namespace KRT.VRCQuestTools.Ndmf
             {
                 var converter = new AvatarConverter(new MaterialWrapperBuilder());
                 var settingsMap = converter.CreateMaterialConvertSettingsMap(avatarRoot, avatarMaterials.ToArray());
+
+                // Track reference changes: when an upstream filter (e.g. another plugin) already replaced a material and
+                // registered it in the ObjectRegistry, the convert settings are keyed by the original material. Resolve
+                // the replaced material back to its original to apply the same settings (mirrors the build-time
+                // AvatarConverterPassUtility.TrackObjectRegistryForMaterialConversion/Swaps). Components are not mutated.
+                foreach (var m in avatarMaterials)
+                {
+                    if (m == null || settingsMap.ContainsKey(m))
+                    {
+                        continue;
+                    }
+                    var original = ObjectRegistry.GetReference(m)?.Object as Material;
+                    if (original != null && original != m && settingsMap.TryGetValue(original, out var s))
+                    {
+                        settingsMap[m] = s;
+                    }
+                }
+
                 // forEditorPreview: true re-uploads freshly generated normal maps so they render in the editor preview.
                 var materialLease = SharedPreviewMaterialCache.Acquire(settingsMap, m => converter.ConvertMaterialsForMobile(m, false, string.Empty, null, forEditorPreview: true, avatarRoot: avatarRoot));
+
+                // Register replaced materials so the ObjectRegistry can trace converted assets back to originals,
+                // matching build-pass behavior. Runs inside Instantiate where an ObjectRegistryScope is active.
+                foreach (var kv in materialLease.MaterialMap)
+                {
+                    NdmfObjectRegistry.TryRegisterReplacedObjectToActiveRegistry(kv.Key, kv.Value);
+                }
+
                 return Task.FromResult<IRenderFilterNode>(new MaterialConversionFilterNode(materialLease.MaterialMap, removeExtraMaterialSlots, materialLease));
             }
             catch (System.Exception e)

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
@@ -7,7 +7,6 @@ using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.Models.Unity;
 using KRT.VRCQuestTools.Models.VRChat;
 using KRT.VRCQuestTools.Utils;
-using nadena.dev.ndmf;
 using nadena.dev.ndmf.preview;
 using UnityEditor;
 using UnityEngine;
@@ -158,7 +157,7 @@ namespace KRT.VRCQuestTools.Ndmf
                     {
                         continue;
                     }
-                    var original = ObjectRegistry.GetReference(m)?.Object as Material;
+                    var original = NdmfObjectRegistry.GetReference(m)?.Object as Material;
                     if (original != null && original != m && settingsMap.TryGetValue(original, out var s))
                     {
                         settingsMap[m] = s;
@@ -168,11 +167,26 @@ namespace KRT.VRCQuestTools.Ndmf
                 // forEditorPreview: true re-uploads freshly generated normal maps so they render in the editor preview.
                 var materialLease = SharedPreviewMaterialCache.Acquire(settingsMap, m => converter.ConvertMaterialsForMobile(m, false, string.Empty, null, forEditorPreview: true, avatarRoot: avatarRoot));
 
-                // Register replaced materials so the ObjectRegistry can trace converted assets back to originals,
+                // Register replaced materials so the ObjectRegistry can trace converted materials back to originals,
                 // matching build-pass behavior. Runs inside Instantiate where an ObjectRegistryScope is active.
-                foreach (var kv in materialLease.MaterialMap)
+                // SharedPreviewMaterialCache can map multiple source materials to the same converted instance, so we
+                // group by converted material and register a single deterministic representative to keep tracing stable.
+                foreach (var materialGroup in materialLease.MaterialMap.GroupBy(kv => kv.Value))
                 {
-                    NdmfObjectRegistry.TryRegisterReplacedObjectToActiveRegistry(kv.Key, kv.Value);
+                    var converted = materialGroup.Key;
+
+                    // Skip asset-backed converted materials such as MaterialReplaceSettings replacements.
+                    // Build registers only in-memory converted materials. See AvatarConverterPassUtility.
+                    if (converted == null || !string.IsNullOrEmpty(AssetDatabase.GetAssetPath(converted)))
+                    {
+                        continue;
+                    }
+
+                    var original = materialGroup.Select(kv => kv.Key)
+                        .Where(m => m != null)
+                        .OrderBy(m => m.GetInstanceID())
+                        .FirstOrDefault();
+                    NdmfObjectRegistry.TryRegisterReplacedObjectToActiveRegistry(original, converted);
                 }
 
                 return Task.FromResult<IRenderFilterNode>(new MaterialConversionFilterNode(materialLease.MaterialMap, removeExtraMaterialSlots, materialLease));

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MeshFlipperFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MeshFlipperFilter.cs
@@ -97,6 +97,10 @@ namespace KRT.VRCQuestTools.Ndmf
                 try
                 {
                     result = MeshFlipper.CreateFlippedMesh(meshFlipper, mesh);
+
+                    // Register the replaced mesh so the ObjectRegistry can trace it back to the original,
+                    // matching build-pass behavior. Runs inside Instantiate where an ObjectRegistryScope is active.
+                    NdmfObjectRegistry.TryRegisterReplacedObjectToActiveRegistry(mesh, result);
                 }
                 catch (MeshFlipperMaskMissingException)
                 {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/VertexColorRemoverFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/VertexColorRemoverFilter.cs
@@ -68,6 +68,10 @@ namespace KRT.VRCQuestTools.Ndmf
             {
                 newMesh = Mesh.Instantiate(newMesh);
                 newMesh.colors32 = null;
+
+                // Register the replaced mesh so the ObjectRegistry can trace it back to the original,
+                // matching build-pass behavior. Runs inside Instantiate where an ObjectRegistryScope is active.
+                NdmfObjectRegistry.TryRegisterReplacedObjectToActiveRegistry(mesh, newMesh);
             }
             return Task.FromResult<IRenderFilterNode>(new VertexColorRemoverFilterNode(newMesh));
         }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestTools-Editor-Ndmf.asmdef
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestTools-Editor-Ndmf.asmdef
@@ -34,6 +34,11 @@
             "define": "VQT_HAS_NDMF"
         },
         {
+            "name": "nadena.dev.ndmf",
+            "expression": "[1.6.8,2.0.0-a)",
+            "define": "VQT_NDMF_HAS_TRY_REGISTER_REPLACED_OBJECT"
+        },
+        {
             "name": "jp.lilxyzw.ndmfmeshsimplifier",
             "expression": "0.2.0",
             "define": "VQT_LIL_NDMF_MESH_SIMPLIFIER"


### PR DESCRIPTION
NDMF build passes register replaced materials/meshes via ObjectRegistry.RegisterReplacedObject, but the preview filters did not, causing preview behavior and error tracing to diverge from build.

Register replacements inside Instantiate (where an ObjectRegistryScope is active and the merged registry propagates down the preview chain) for MaterialConversionFilter, MeshFlipperFilter and VertexColorRemoverFilter. Also resolve upstream-replaced materials back to their originals in MaterialConversionFilter to apply the correct convert settings, mirroring the build-time TrackObjectRegistryForMaterialConversion/Swaps logic.