### PR TITLE
Group avatar dynamics selector list by prefab root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Avatar Dynamics Selector now stores keep/remove settings in `Platform Component Remover` instead of the legacy arrays in `Avatar Converter Settings`. Applying the selector migrates settings and clears the legacy arrays to avoid stale references.
 - Added a button in PhysBones Remover to apply current keep/remove selections to `Platform Component Remover`.
+- Grouped the component list in Avatar Dynamics Selector and PhysBones Remover by prefab.
 - Optimized Avatar Dynamics performance estimation timing in `Avatar Converter Settings` inspector.
 - Manual conversion from `Avatar Converter Settings` now keeps the original avatar active and places the converted avatar offset along world +Z from the original avatar.
 - Changed the initial value of default material conversion settings to Toon Standard.

--- a/CHANGELOG_JP.md
+++ b/CHANGELOG_JP.md
@@ -26,6 +26,7 @@
 ### 変更
 - Avatar Dynamics Selector の保持/削除設定を `Avatar Converter Settings` のレガシー配列ではなく `Platform Component Remover` に保存するように変更。適用時に設定を移行し、古い参照が残らないようレガシー配列をクリアします。
 - PhysBones Remover に、現在の保持/削除選択を `Platform Component Remover` に反映するボタンを追加。
+- Avatar Dynamics Selector と PhysBones Remover のコンポーネント一覧をプレハブごとにグループ化。
 - `Avatar Converter Settings` インスペクターの Avatar Dynamics パフォーマンス推定タイミングを最適化。
 - `Avatar Converter Settings` の変換ボタンによる手動変換で、元アバターを非アクティブ化せず、変換後アバターを元アバターの位置からワールド座標の +Z 方向に配置するよう変更。
 - デフォルトのマテリアル変換設定の初期値を Toon Standard に変更。

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Services/AvatarDynamicsPreviewService.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Services/AvatarDynamicsPreviewService.cs
@@ -29,6 +29,10 @@ namespace KRT.VRCQuestTools.Services
         private static IVRCAvatarDynamicsProvider hoveredProvider;
         private static bool isInitialized = false;
 
+        // Reference count of active users (windows). The service stays alive while any user is active,
+        // so closing one window does not tear down the scene preview for another still-open window.
+        private static int referenceCount = 0;
+
         /// <summary>
         /// Sets the VRCPhysBoneProviderBase component to preview in the scene view.
         /// </summary>
@@ -62,9 +66,11 @@ namespace KRT.VRCQuestTools.Services
 
         /// <summary>
         /// Initializes the preview service by subscribing to scene view events.
+        /// Reference counted: each caller must pair this with <see cref="Cleanup"/>.
         /// </summary>
         internal static void Initialize()
         {
+            referenceCount++;
             if (!isInitialized)
             {
                 SceneView.duringSceneGui -= OnSceneGUI;
@@ -75,9 +81,17 @@ namespace KRT.VRCQuestTools.Services
 
         /// <summary>
         /// Cleanup the preview service by unsubscribing from scene view events.
+        /// The service is only torn down once every caller has cleaned up (reference count reaches zero),
+        /// so closing one window keeps the preview working for other still-open windows.
         /// </summary>
         internal static void Cleanup()
         {
+            referenceCount = Mathf.Max(0, referenceCount - 1);
+            if (referenceCount > 0)
+            {
+                return;
+            }
+
             SceneView.duringSceneGui -= OnSceneGUI;
             hoveredProvider = null;
             isInitialized = false;

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsSelectorWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsSelectorWindow.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using KRT.VRCQuestTools.I18n;
 using KRT.VRCQuestTools.Models;
@@ -52,6 +53,11 @@ namespace KRT.VRCQuestTools.Views
         private I18nBase i18n;
         private AvatarPerformanceStatsLevelSet statsLevelSet;
 
+        // Per-group foldout states keyed by relative path label. Default: open (true).
+        private Dictionary<string, bool> physBoneGroupFoldouts = new Dictionary<string, bool>();
+        private Dictionary<string, bool> colliderGroupFoldouts = new Dictionary<string, bool>();
+        private Dictionary<string, bool> contactGroupFoldouts = new Dictionary<string, bool>();
+
         /// <summary>
         /// Applies avatar dynamics settings to PlatformComponentRemover components.
         /// Components not in the keep lists will be configured for Android removal.
@@ -90,6 +96,7 @@ namespace KRT.VRCQuestTools.Views
         private void OnEnable()
         {
             titleContent = new GUIContent("Avatar Dynamics Selector");
+            wantsMouseMove = true;
             foldoutContentStyle = new GUIStyle()
             {
                 padding = new RectOffset(16, 0, 0, 0),
@@ -117,6 +124,7 @@ namespace KRT.VRCQuestTools.Views
             }
 
             var avatar = new VRChatAvatar(converterSettings.AvatarDescriptor);
+            var avatarRoot = converterSettings.AvatarDescriptor.gameObject;
 
             EditorGUILayout.LabelField(i18n.SelectComponentsToKeep, EditorStyles.wordWrappedLabel);
             using (var scrollView = new EditorGUILayout.ScrollViewScope(scrollPosition))
@@ -148,7 +156,7 @@ namespace KRT.VRCQuestTools.Views
                                         physBoneProvidersToKeep = new VRCPhysBoneProviderBase[] { };
                                     }
                                 }
-                                physBoneProvidersToKeep = EditorGUIUtility.AvatarDynamicsComponentSelectorList(pbs, physBoneProvidersToKeep);
+                                physBoneProvidersToKeep = EditorGUIUtility.GroupedAvatarDynamicsComponentSelectorList(pbs, physBoneProvidersToKeep, avatarRoot, physBoneGroupFoldouts);
                             }
                         }
                     }
@@ -182,10 +190,10 @@ namespace KRT.VRCQuestTools.Views
                                         physBoneCollidersToKeep = new VRCPhysBoneCollider[] { };
                                     }
                                 }
-                                var providers = colliders.Select(c => new VRCPhysBoneColliderProvider(c)).ToArray();
-                                var selected = physBoneCollidersToKeep.Select(c => new VRCPhysBoneColliderProvider(c)).ToArray();
-                                selected = EditorGUIUtility.AvatarDynamicsComponentSelectorList(providers, selected);
-                                physBoneCollidersToKeep = selected.Select(p => p.Component).Cast<VRCPhysBoneCollider>().ToArray();
+                                var colliderProviders = colliders.Select(c => new VRCPhysBoneColliderProvider(c)).ToArray();
+                                var selectedColliders = physBoneCollidersToKeep.Select(c => new VRCPhysBoneColliderProvider(c)).ToArray();
+                                selectedColliders = EditorGUIUtility.GroupedAvatarDynamicsComponentSelectorList(colliderProviders, selectedColliders, avatarRoot, colliderGroupFoldouts);
+                                physBoneCollidersToKeep = selectedColliders.Select(p => p.Component).Cast<VRCPhysBoneCollider>().ToArray();
                             }
                         }
                     }
@@ -220,10 +228,10 @@ namespace KRT.VRCQuestTools.Views
                                         contactsToKeep = new VRC.Dynamics.ContactBase[] { };
                                     }
                                 }
-                                var providers = contacts.Select(c => new VRCContactBaseProvider(c)).ToArray();
-                                var selected = contactsToKeep.Select(c => new VRCContactBaseProvider(c)).ToArray();
-                                selected = EditorGUIUtility.AvatarDynamicsComponentSelectorList(providers, selected);
-                                contactsToKeep = selected.Select(p => p.Component).Cast<ContactBase>().ToArray();
+                                var contactProviders = contacts.Select(c => new VRCContactBaseProvider(c)).ToArray();
+                                var selectedContacts = contactsToKeep.Select(c => new VRCContactBaseProvider(c)).ToArray();
+                                selectedContacts = EditorGUIUtility.GroupedAvatarDynamicsComponentSelectorList(contactProviders, selectedContacts, avatarRoot, contactGroupFoldouts);
+                                contactsToKeep = selectedContacts.Select(p => p.Component).Cast<ContactBase>().ToArray();
                             }
                         }
                     }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
@@ -114,8 +114,9 @@ namespace KRT.VRCQuestTools.Views
         /// <typeparam name="T">Component type.</typeparam>
         /// <param name="objects">Components to list.</param>
         /// <param name="selectedObjects">Already selected components.</param>
+        /// <param name="componentFieldIndent">Left offset (px) of the component field, so it aligns under the group header label.</param>
         /// <returns>New selected components.</returns>
-        internal static T[] AvatarDynamicsComponentSelectorList<T>(T[] objects, T[] selectedObjects)
+        internal static T[] AvatarDynamicsComponentSelectorList<T>(T[] objects, T[] selectedObjects, float componentFieldIndent = 0f)
             where T : IVRCAvatarDynamicsProvider
         {
             var afterSelected = new List<T>();
@@ -123,7 +124,7 @@ namespace KRT.VRCQuestTools.Views
 
             foreach (var obj in objects)
             {
-                var isSelected = ToggleAvatarDynamicsComponentField(selectedObjects.Select(o => o.Component).Contains(obj.Component), obj);
+                var isSelected = ToggleAvatarDynamicsComponentField(selectedObjects.Select(o => o.Component).Contains(obj.Component), obj, componentFieldIndent);
 
                 // Check for hover on the last drawn control
                 var currentEvent = Event.current;
@@ -151,24 +152,164 @@ namespace KRT.VRCQuestTools.Views
         }
 
         /// <summary>
+        /// Show a check list to select components, grouped by the nearest prefab instance root.
+        /// Each group has its own foldout, indentation by prefab nesting depth, and select/deselect buttons.
+        /// </summary>
+        /// <typeparam name="T">Component provider type.</typeparam>
+        /// <param name="objects">Components to list.</param>
+        /// <param name="selectedObjects">Already selected components.</param>
+        /// <param name="avatarRoot">Avatar root GameObject for relative path labels.</param>
+        /// <param name="groupFoldouts">Foldout states keyed by group label. Modified in place.</param>
+        /// <returns>New selected components, in the original order of <paramref name="objects"/>.</returns>
+        internal static T[] GroupedAvatarDynamicsComponentSelectorList<T>(T[] objects, T[] selectedObjects, GameObject avatarRoot, Dictionary<string, bool> groupFoldouts)
+            where T : IVRCAvatarDynamicsProvider
+        {
+            var i18n = VRCQuestToolsSettings.I18nResource;
+            var selectedComponents = new HashSet<Component>(selectedObjects.Select(o => o.Component));
+            var groups = objects
+                .GroupBy(o => PrefabUtility.GetNearestPrefabInstanceRoot(o.GameObject))
+                .OrderBy(g => (g.Key == null || g.Key == avatarRoot) ? 0 : 1);
+            var baseIndent = EditorGUI.indentLevel;
+            foreach (var group in groups)
+            {
+                var groupArray = group.ToArray();
+                var isPrefab = group.Key != null && group.Key != avatarRoot;
+                var iconTarget = isPrefab ? group.Key : avatarRoot;
+                var label = iconTarget.name;
+                var key = GetGroupFoldoutKey(avatarRoot, group.Key);
+                var depth = GetGroupNestingDepth(avatarRoot.transform, group.Key != null ? group.Key.transform : null);
+                if (!groupFoldouts.TryGetValue(key, out var groupOpen))
+                {
+                    groupOpen = true;
+                }
+
+                // Draw the header manually so the whole row toggles the foldout (like the Hierarchy) and
+                // highlights on hover. EditorGUILayout.Foldout cannot render the icon reliably when indented,
+                // so the arrow glyph, icon and label are drawn on explicit rects within the row.
+                var lineHeight = UnityEditor.EditorGUIUtility.singleLineHeight;
+                const float arrowWidth = 13f;
+                const float arrowIconGap = 4f;
+                const float iconLabelGap = 2f;
+                var icon = GetHierarchyIcon(iconTarget);
+                var selectContent = new GUIContent(i18n.SelectAllButtonLabel);
+                var deselectContent = new GUIContent(i18n.DeselectAllButtonLabel);
+                var selectWidth = EditorStyles.miniButton.CalcSize(selectContent).x;
+                var deselectWidth = EditorStyles.miniButton.CalcSize(deselectContent).x;
+
+                EditorGUI.indentLevel = 0;
+                var rowRect = EditorGUILayout.GetControlRect(false, lineHeight);
+                var indent = (baseIndent + depth) * 15f;
+
+                // Left offset of the header label; item component fields align to this so they sit under the label.
+                var labelOffset = indent + arrowWidth + arrowIconGap + lineHeight + iconLabelGap;
+                var deselectRect = new Rect(rowRect.xMax - deselectWidth, rowRect.y, deselectWidth, lineHeight);
+                var selectRect = new Rect(deselectRect.x - selectWidth, rowRect.y, selectWidth, lineHeight);
+                var toggleRect = new Rect(rowRect.x, rowRect.y, selectRect.x - rowRect.x, lineHeight);
+                var hovered = toggleRect.Contains(Event.current.mousePosition);
+
+                if (Event.current.type == EventType.Repaint)
+                {
+                    if (hovered)
+                    {
+                        var hoverColor = UnityEditor.EditorGUIUtility.isProSkin ? new Color(1f, 1f, 1f, 0.08f) : new Color(0f, 0f, 0f, 0.06f);
+                        EditorGUI.DrawRect(toggleRect, hoverColor);
+                    }
+                    var arrowRect = new Rect(rowRect.x + indent, rowRect.y, arrowWidth, lineHeight);
+                    EditorStyles.foldout.Draw(arrowRect, false, false, groupOpen, false);
+                    var iconRect = new Rect(arrowRect.xMax + arrowIconGap, rowRect.y, lineHeight, lineHeight);
+                    if (icon != null)
+                    {
+                        GUI.DrawTexture(iconRect, icon, ScaleMode.ScaleToFit);
+                    }
+                    var labelRect = new Rect(iconRect.xMax + iconLabelGap, rowRect.y, toggleRect.xMax - iconRect.xMax - iconLabelGap, lineHeight);
+                    GUI.Label(labelRect, label, EditorStyles.boldLabel);
+                }
+
+                if (Event.current.type == EventType.MouseDown && Event.current.button == 0 && toggleRect.Contains(Event.current.mousePosition))
+                {
+                    groupFoldouts[key] = !groupOpen;
+                    Event.current.Use();
+                }
+                else
+                {
+                    groupFoldouts[key] = groupOpen;
+                }
+
+                if (GUI.Button(selectRect, selectContent, EditorStyles.miniButton))
+                {
+                    foreach (var o in groupArray)
+                    {
+                        selectedComponents.Add(o.Component);
+                    }
+                }
+                if (GUI.Button(deselectRect, deselectContent, EditorStyles.miniButton))
+                {
+                    foreach (var o in groupArray)
+                    {
+                        selectedComponents.Remove(o.Component);
+                    }
+                }
+
+                // Use the value captured at the start of this frame for item visibility so the
+                // EditorGUILayout control count stays consistent between Layout and other events.
+                if (groupOpen)
+                {
+                    // Align each item's component field under the group header label. The right (RootTransform)
+                    // column stays fixed, so the component field width shrinks as the group is nested deeper.
+                    var currentGroupSelected = groupArray.Where(o => selectedComponents.Contains(o.Component)).ToArray();
+                    var newGroupSelected = AvatarDynamicsComponentSelectorList(groupArray, currentGroupSelected, labelOffset);
+                    var newSet = new HashSet<Component>(newGroupSelected.Select(o => o.Component));
+                    foreach (var o in groupArray)
+                    {
+                        if (newSet.Contains(o.Component))
+                        {
+                            selectedComponents.Add(o.Component);
+                        }
+                        else
+                        {
+                            selectedComponents.Remove(o.Component);
+                        }
+                    }
+                }
+                EditorGUI.indentLevel = baseIndent;
+            }
+            return objects.Where(o => selectedComponents.Contains(o.Component)).ToArray();
+        }
+
+        /// <summary>
         /// Show a toggle field for Avatar Dynamics component.
         /// </summary>
         /// <param name="value">Current state.</param>
         /// <param name="provider">Provider to show.</param>
+        /// <param name="componentFieldIndent">Left offset (px) of the component field so it aligns under the group header label.</param>
         /// <returns>true for selected.</returns>
-        internal static bool ToggleAvatarDynamicsComponentField(bool value, IVRCAvatarDynamicsProvider provider)
+        internal static bool ToggleAvatarDynamicsComponentField(bool value, IVRCAvatarDynamicsProvider provider, float componentFieldIndent = 0f)
         {
-            const int CheckBoxWidth = 16;
-            using (var horizontal = new EditorGUILayout.HorizontalScope())
+            const float checkBoxWidth = 16f;
+            const float gap = 2f;
+            const float minComponentWidth = 80f;
+            var lineHeight = UnityEditor.EditorGUIUtility.singleLineHeight;
+
+            var prevIndent = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+            var rowRect = EditorGUILayout.GetControlRect(false, lineHeight);
+            EditorGUI.indentLevel = prevIndent;
+
+            // The right (RootTransform) column is fixed at the midpoint; the component field's left edge is
+            // aligned under the group header label, so its width shrinks as the group is nested deeper.
+            var half = rowRect.width * 0.5f;
+            var componentX = Mathf.Clamp(componentFieldIndent, checkBoxWidth + gap, half - gap - minComponentWidth);
+            var checkRect = new Rect(rowRect.x + componentX - gap - checkBoxWidth, rowRect.y, checkBoxWidth, lineHeight);
+            var componentRect = new Rect(rowRect.x + componentX, rowRect.y, rowRect.x + half - gap - (rowRect.x + componentX), lineHeight);
+            var rootRect = new Rect(rowRect.x + half + gap, rowRect.y, rowRect.xMax - (rowRect.x + half + gap), lineHeight);
+
+            var selected = EditorGUI.Toggle(checkRect, value);
+            using (new EditorGUI.DisabledScope(true))
             {
-                var selected = EditorGUILayout.Toggle(value, GUILayout.Width(CheckBoxWidth));
-                GUILayout.Space(2);
-                using var disabledScope = new EditorGUI.DisabledScope(true);
-                EditorGUILayout.ObjectField(provider.Component, typeof(Component), true);
-                GUILayout.Space(2);
-                EditorGUILayout.ObjectField(VRCSDKUtility.GetRootTransform(provider.Component), typeof(Transform), true);
-                return selected;
+                EditorGUI.ObjectField(componentRect, provider.Component, typeof(Component), true);
+                EditorGUI.ObjectField(rootRect, VRCSDKUtility.GetRootTransform(provider.Component), typeof(Transform), true);
             }
+            return selected;
         }
 
         /// <summary>
@@ -345,6 +486,61 @@ namespace KRT.VRCQuestTools.Views
             }
 
             return display;
+        }
+
+        // Unique foldout key per group. Uses the relative path so prefabs sharing a name keep independent foldout states.
+        private static string GetGroupFoldoutKey(GameObject avatarRoot, GameObject prefabRoot)
+        {
+            if (prefabRoot == null || prefabRoot == avatarRoot)
+            {
+                return avatarRoot.name;
+            }
+            return GetRelativeTransformPath(avatarRoot.transform, prefabRoot.transform);
+        }
+
+        // Returns the icon Unity uses for the GameObject in the Hierarchy (plain GameObject, prefab, or variant).
+        private static Texture GetHierarchyIcon(GameObject go)
+        {
+            var icon = AssetPreview.GetMiniThumbnail(go);
+            if (icon == null)
+            {
+                icon = AssetPreview.GetMiniTypeThumbnail(typeof(GameObject));
+            }
+            return icon;
+        }
+
+        private static string GetRelativeTransformPath(Transform root, Transform target)
+        {
+            var parts = new List<string>();
+            var t = target;
+            while (t != null && t != root)
+            {
+                parts.Insert(0, t.name);
+                t = t.parent;
+            }
+            return string.Join(" / ", parts);
+        }
+
+        // Returns how many intermediate prefab instance roots exist between avatarRoot and prefabRoot.
+        // null or avatarRoot → 0; direct child prefab → 1; nested inside another prefab → 2; etc.
+        private static int GetGroupNestingDepth(Transform avatarRoot, Transform prefabRoot)
+        {
+            if (prefabRoot == null || prefabRoot == avatarRoot)
+            {
+                return 0;
+            }
+            int depth = 0;
+            var t = prefabRoot.parent;
+            while (t != null && t != avatarRoot)
+            {
+                var root = PrefabUtility.GetNearestPrefabInstanceRoot(t.gameObject);
+                if (root != null && root == t.gameObject)
+                {
+                    depth++;
+                }
+                t = t.parent;
+            }
+            return depth + 1;
         }
 
         private static GUIContent MessageTypeIconContent(MessageType type)

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
@@ -121,10 +121,11 @@ namespace KRT.VRCQuestTools.Views
         {
             var afterSelected = new List<T>();
             IVRCAvatarDynamicsProvider hoveredProvider = null;
+            var selectedComponents = new HashSet<Component>(selectedObjects.Select(o => o.Component));
 
             foreach (var obj in objects)
             {
-                var isSelected = ToggleAvatarDynamicsComponentField(selectedObjects.Select(o => o.Component).Contains(obj.Component), obj, componentFieldIndent);
+                var isSelected = ToggleAvatarDynamicsComponentField(selectedComponents.Contains(obj.Component), obj, componentFieldIndent);
 
                 // Check for hover on the last drawn control
                 var currentEvent = Event.current;
@@ -297,11 +298,17 @@ namespace KRT.VRCQuestTools.Views
 
             // The right (RootTransform) column is fixed at the midpoint; the component field's left edge is
             // aligned under the group header label, so its width shrinks as the group is nested deeper.
+            // Clamp bounds are kept ordered (min <= max) and the resulting rect widths are non-negative so
+            // narrow window sizes cannot produce invalid rects.
             var half = rowRect.width * 0.5f;
-            var componentX = Mathf.Clamp(componentFieldIndent, checkBoxWidth + gap, half - gap - minComponentWidth);
+            var minComponentX = checkBoxWidth + gap;
+            var maxComponentX = Mathf.Max(minComponentX, half - gap - minComponentWidth);
+            var componentX = Mathf.Clamp(componentFieldIndent, minComponentX, maxComponentX);
             var checkRect = new Rect(rowRect.x + componentX - gap - checkBoxWidth, rowRect.y, checkBoxWidth, lineHeight);
-            var componentRect = new Rect(rowRect.x + componentX, rowRect.y, rowRect.x + half - gap - (rowRect.x + componentX), lineHeight);
-            var rootRect = new Rect(rowRect.x + half + gap, rowRect.y, rowRect.xMax - (rowRect.x + half + gap), lineHeight);
+            var componentWidth = Mathf.Max(0f, half - gap - componentX);
+            var componentRect = new Rect(rowRect.x + componentX, rowRect.y, componentWidth, lineHeight);
+            var rootWidth = Mathf.Max(0f, rowRect.width - half - gap);
+            var rootRect = new Rect(rowRect.x + half + gap, rowRect.y, rootWidth, lineHeight);
 
             var selected = EditorGUI.Toggle(checkRect, value);
             using (new EditorGUI.DisabledScope(true))

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/PhysBonesRemoveWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/PhysBonesRemoveWindow.cs
@@ -35,6 +35,11 @@ namespace KRT.VRCQuestTools.Views
         private bool showPhysBoneColliders = true;
         private bool showContacts = true;
 
+        // Per-group foldout states keyed by relative path label. Default: open (true).
+        private Dictionary<string, bool> physBoneGroupFoldouts = new Dictionary<string, bool>();
+        private Dictionary<string, bool> colliderGroupFoldouts = new Dictionary<string, bool>();
+        private Dictionary<string, bool> contactGroupFoldouts = new Dictionary<string, bool>();
+
         private AvatarPerformanceStatsLevelSet statsLevelSet;
 
         /// <summary>
@@ -63,6 +68,7 @@ namespace KRT.VRCQuestTools.Views
         private void OnEnable()
         {
             titleContent.text = "PhysBones Remover";
+            wantsMouseMove = true;
             foldedContentPanel = new GUIStyle()
             {
                 padding =
@@ -94,6 +100,8 @@ namespace KRT.VRCQuestTools.Views
             }
             model.DeselectRemovedComponents();
 
+            var avatarRoot = model.Avatar.AvatarDescriptor.gameObject;
+
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField(i18n.SelectComponentsToKeep, EditorStyles.wordWrappedLabel);
@@ -121,8 +129,7 @@ namespace KRT.VRCQuestTools.Views
                                 }
                             }
                             var selected = model.PhysBoneProvidersToKeep.ToArray();
-                            var physBoneComponents = physBones;
-                            selected = Views.EditorGUIUtility.AvatarDynamicsComponentSelectorList(physBoneComponents, selected);
+                            selected = Views.EditorGUIUtility.GroupedAvatarDynamicsComponentSelectorList(physBones, selected, avatarRoot, physBoneGroupFoldouts);
                             model.SetSelectedPhysBoneProviders(selected);
                         }
                         else
@@ -153,7 +160,7 @@ namespace KRT.VRCQuestTools.Views
                                 }
                             }
                             var selected = model.PhysBoneCollidersToKeep.Select(c => new VRCPhysBoneColliderProvider(c)).ToArray();
-                            selected = Views.EditorGUIUtility.AvatarDynamicsComponentSelectorList(colliders.Select(c => new VRCPhysBoneColliderProvider(c)).ToArray(), selected);
+                            selected = Views.EditorGUIUtility.GroupedAvatarDynamicsComponentSelectorList(colliders.Select(c => new VRCPhysBoneColliderProvider(c)).ToArray(), selected, avatarRoot, colliderGroupFoldouts);
                             model.SetSelectedPhysBoneColliders(selected.Select(provider => provider.Component).Cast<VRCPhysBoneCollider>());
                         }
                         else
@@ -185,7 +192,7 @@ namespace KRT.VRCQuestTools.Views
                                 }
                             }
                             var selected = model.ContactsToKeep.Select(c => new VRCContactBaseProvider(c)).ToArray();
-                            selected = Views.EditorGUIUtility.AvatarDynamicsComponentSelectorList(contacts.Select(c => new VRCContactBaseProvider(c)).ToArray(), selected);
+                            selected = Views.EditorGUIUtility.GroupedAvatarDynamicsComponentSelectorList(contacts.Select(c => new VRCContactBaseProvider(c)).ToArray(), selected, avatarRoot, contactGroupFoldouts);
                             model.SetSelectedContacts(selected.Select(provider => provider.Component).Cast<VRC.Dynamics.ContactBase>());
                         }
                         else


### PR DESCRIPTION
Group PhysBones/Colliders/Contacts by their nearest prefab instance root in both Avatar Dynamics Selector and PhysBones Remover so that selecting newly added prefabs does not disturb existing selections. Each group has a hierarchy icon, per-group select/deselect buttons, full-row-click foldout with hover highlight, a fixed RootTransform column, and component fields aligned under the group label. Reference-count the shared preview service so closing one window keeps the scene preview alive for the other.