### PR TITLE
Improve Avatar Dynamics Selector and PhysBones Remover UI

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Services/AvatarDynamicsPreviewService.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Services/AvatarDynamicsPreviewService.cs
@@ -44,6 +44,15 @@ namespace KRT.VRCQuestTools.Services
         private static bool isTrackingHoverFrame = false;
         private static bool hoverDetectedInFrame = false;
 
+        // Window currently running its OnGUI pass (set by BeginPreviewFrame), and the window that
+        // owns the current hoveredProvider (set by SetPreviewComponent). Since OnGUI calls never
+        // interleave, a window's Begin/End pair fully brackets its own SetPreviewComponent calls.
+        // EndPreviewFrame/BeginPreviewFrame's MouseLeaveWindow branch only clear the hover when their
+        // own window owns it, so a non-hovered window's pass can't clobber the hover another window
+        // legitimately set earlier in the same Repaint cycle.
+        private static EditorWindow currentTrackingWindow;
+        private static EditorWindow hoveredOwnerWindow;
+
         // Reference count of active users (windows). The service stays alive while any user is active,
         // so closing one window does not tear down the scene preview for another still-open window.
         private static int referenceCount = 0;
@@ -57,6 +66,7 @@ namespace KRT.VRCQuestTools.Services
             if (isTrackingHoverFrame && provider != null)
             {
                 hoverDetectedInFrame = true;
+                hoveredOwnerWindow = currentTrackingWindow;
             }
             if (hoveredProvider != provider)
             {
@@ -111,13 +121,16 @@ namespace KRT.VRCQuestTools.Services
         internal static void BeginPreviewFrame(EditorWindow window)
         {
             ownerWindows.Add(window);
+            currentTrackingWindow = window;
 
             var eventType = Event.current.type;
             if (eventType == EventType.MouseLeaveWindow)
             {
                 // The scene view doesn't repaint by itself when the cursor moves off the window,
                 // so trigger a repaint to hide the fallback preview. Same for showing it on enter.
-                ClearPreview();
+                // Only clear if this window owns the hover: otherwise the cursor leaving a
+                // non-hovered window would wipe out another window's legitimate hover.
+                ClearPreviewOwnedBy(window);
                 if (isInitialized)
                 {
                     SceneView.RepaintAll();
@@ -136,31 +149,49 @@ namespace KRT.VRCQuestTools.Services
         }
 
         /// <summary>
-        /// Ends hover tracking for a window OnGUI pass. Clears the hover preview when
-        /// no row reported hover during the pass, falling back to the selected components.
+        /// Ends hover tracking for a window OnGUI pass. Clears the hover preview when no row
+        /// reported hover during the pass and this window owns it, falling back to the selected
+        /// components. A window that doesn't currently own the hover never clears it: multiple
+        /// windows using this service can be open at once, and Unity may run each window's Repaint
+        /// pass within the same cycle, so a non-hovered window's pass must not clobber the hover
+        /// another window legitimately set moments earlier.
         /// </summary>
-        internal static void EndPreviewFrame()
+        /// <param name="window">Window ending its OnGUI pass. Must match the window passed to <see cref="BeginPreviewFrame"/>.</param>
+        internal static void EndPreviewFrame(EditorWindow window)
         {
             if (isTrackingHoverFrame && !hoverDetectedInFrame)
             {
-                ClearPreview();
+                ClearPreviewOwnedBy(window);
             }
             isTrackingHoverFrame = false;
         }
 
         /// <summary>
-        /// Clears the current preview component.
+        /// Clears the current preview component, regardless of which window owns it.
         /// </summary>
         internal static void ClearPreview()
         {
             if (hoveredProvider != null)
             {
                 hoveredProvider = null;
+                hoveredOwnerWindow = null;
                 if (isInitialized)
                 {
                     SceneView.RepaintAll();
                 }
             }
+        }
+
+        // Clears the hover only if it is not owned by another window. A null owner (e.g. the hover
+        // was never set by a window, such as right after Initialize) is treated as clearable by
+        // anyone.
+        private static void ClearPreviewOwnedBy(EditorWindow window)
+        {
+            if (hoveredOwnerWindow != null && hoveredOwnerWindow != window)
+            {
+                return;
+            }
+            ClearPreview();
         }
 
         /// <summary>
@@ -193,6 +224,8 @@ namespace KRT.VRCQuestTools.Services
 
             SceneView.duringSceneGui -= OnSceneGUI;
             hoveredProvider = null;
+            hoveredOwnerWindow = null;
+            currentTrackingWindow = null;
             selectedProviders = new List<IVRCAvatarDynamicsProvider>();
             selectedComponents = new HashSet<Component>();
             ownerWindows = new HashSet<EditorWindow>();

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Services/AvatarDynamicsPreviewService.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Services/AvatarDynamicsPreviewService.cs
@@ -29,6 +29,21 @@ namespace KRT.VRCQuestTools.Services
         private static IVRCAvatarDynamicsProvider hoveredProvider;
         private static bool isInitialized = false;
 
+        // Fallback preview drawn while no list row is hovered: all selected PhysBones and Contacts.
+        private static List<IVRCAvatarDynamicsProvider> selectedProviders = new List<IVRCAvatarDynamicsProvider>();
+        private static HashSet<Component> selectedComponents = new HashSet<Component>();
+
+        // Windows using the preview, registered through BeginPreviewFrame. The fallback preview is
+        // drawn only while the mouse cursor is over one of them. Closed windows are only removed on
+        // full cleanup, but stale entries are harmless: a destroyed window is never under the mouse.
+        private static HashSet<EditorWindow> ownerWindows = new HashSet<EditorWindow>();
+
+        // Hover tracking for a single window OnGUI pass. When a pass which can detect hover
+        // (MouseMove/Repaint) ends without any SetPreviewComponent call, the hover is cleared
+        // so the preview falls back to the selected components.
+        private static bool isTrackingHoverFrame = false;
+        private static bool hoverDetectedInFrame = false;
+
         // Reference count of active users (windows). The service stays alive while any user is active,
         // so closing one window does not tear down the scene preview for another still-open window.
         private static int referenceCount = 0;
@@ -39,6 +54,10 @@ namespace KRT.VRCQuestTools.Services
         /// <param name="provider">Provider to preview, or null to clear preview.</param>
         internal static void SetPreviewComponent(IVRCAvatarDynamicsProvider provider)
         {
+            if (isTrackingHoverFrame && provider != null)
+            {
+                hoverDetectedInFrame = true;
+            }
             if (hoveredProvider != provider)
             {
                 hoveredProvider = provider;
@@ -47,6 +66,86 @@ namespace KRT.VRCQuestTools.Services
                     SceneView.RepaintAll();
                 }
             }
+        }
+
+        /// <summary>
+        /// Sets the selected components drawn as a fallback preview while no row is hovered.
+        /// Providers are recreated on every OnGUI pass, so the change is detected by comparing
+        /// the underlying components; the scene view is repainted only when the set changed.
+        /// </summary>
+        /// <param name="providers">Selected providers, or an empty sequence to clear.</param>
+        internal static void SetSelectedPreviewComponents(IEnumerable<IVRCAvatarDynamicsProvider> providers)
+        {
+            var newProviders = new List<IVRCAvatarDynamicsProvider>();
+            var newComponents = new HashSet<Component>();
+            foreach (var provider in providers)
+            {
+                if (provider?.Component == null)
+                {
+                    continue;
+                }
+                newProviders.Add(provider);
+                newComponents.Add(provider.Component);
+            }
+
+            if (selectedComponents.SetEquals(newComponents))
+            {
+                return;
+            }
+
+            selectedProviders = newProviders;
+            selectedComponents = newComponents;
+            if (isInitialized)
+            {
+                SceneView.RepaintAll();
+            }
+        }
+
+        /// <summary>
+        /// Begins hover tracking for a window OnGUI pass.
+        /// Call at the beginning of OnGUI; pair with <see cref="EndPreviewFrame"/>.
+        /// The window must set <see cref="EditorWindow.wantsMouseEnterLeaveWindow"/> so the
+        /// enter/leave events reach this method.
+        /// </summary>
+        /// <param name="window">Window running the OnGUI pass. The fallback preview is drawn only while the cursor is over a registered window.</param>
+        internal static void BeginPreviewFrame(EditorWindow window)
+        {
+            ownerWindows.Add(window);
+
+            var eventType = Event.current.type;
+            if (eventType == EventType.MouseLeaveWindow)
+            {
+                // The scene view doesn't repaint by itself when the cursor moves off the window,
+                // so trigger a repaint to hide the fallback preview. Same for showing it on enter.
+                ClearPreview();
+                if (isInitialized)
+                {
+                    SceneView.RepaintAll();
+                }
+                return;
+            }
+
+            if (eventType == EventType.MouseEnterWindow && isInitialized)
+            {
+                SceneView.RepaintAll();
+            }
+
+            // Only these event types run the hover detection in the selector lists.
+            isTrackingHoverFrame = eventType == EventType.MouseMove || eventType == EventType.Repaint;
+            hoverDetectedInFrame = false;
+        }
+
+        /// <summary>
+        /// Ends hover tracking for a window OnGUI pass. Clears the hover preview when
+        /// no row reported hover during the pass, falling back to the selected components.
+        /// </summary>
+        internal static void EndPreviewFrame()
+        {
+            if (isTrackingHoverFrame && !hoverDetectedInFrame)
+            {
+                ClearPreview();
+            }
+            isTrackingHoverFrame = false;
         }
 
         /// <summary>
@@ -94,39 +193,70 @@ namespace KRT.VRCQuestTools.Services
 
             SceneView.duringSceneGui -= OnSceneGUI;
             hoveredProvider = null;
+            selectedProviders = new List<IVRCAvatarDynamicsProvider>();
+            selectedComponents = new HashSet<Component>();
+            ownerWindows = new HashSet<EditorWindow>();
             isInitialized = false;
         }
 
         private static void OnSceneGUI(SceneView sceneView)
         {
-            if (hoveredProvider == null)
-            {
-                return;
-            }
-
             var originalColor = Handles.color;
 
             try
             {
-                switch (hoveredProvider.ComponentType)
+                if (hoveredProvider != null)
                 {
-                    case AvatarDynamicsComponentType.PhysBone:
-                        Handles.color = PrimaryPreviewColor;
-                        DrawPhysBonePreview((VRCPhysBoneProviderBase)hoveredProvider);
-                        break;
-                    case AvatarDynamicsComponentType.PhysBoneCollider:
-                        Handles.color = PrimaryPreviewColor;
-                        DrawColliderPreview((VRCPhysBoneColliderProvider)hoveredProvider, drawRelatedPhysBones: true);
-                        break;
-                    case AvatarDynamicsComponentType.Contact:
-                        Handles.color = PrimaryPreviewColor;
-                        DrawContactPreview((VRCContactBaseProvider)hoveredProvider);
-                        break;
+                    DrawProviderPreview(hoveredProvider);
+                }
+                else if (IsMouseOverOwnerWindow())
+                {
+                    // Fallback: draw all selected PhysBones and Contacts so the whole selection is
+                    // visible at a glance. Colliders are drawn only through the PhysBones referencing
+                    // them, the same way as when a PhysBone is hovered. Drawn only while the cursor
+                    // is over one of the owner windows to keep the scene view clean otherwise.
+                    foreach (var provider in selectedProviders)
+                    {
+                        if (provider.Component == null)
+                        {
+                            continue;
+                        }
+                        if (provider.ComponentType == AvatarDynamicsComponentType.PhysBoneCollider)
+                        {
+                            continue;
+                        }
+                        DrawProviderPreview(provider);
+                    }
                 }
             }
             finally
             {
                 Handles.color = originalColor;
+            }
+        }
+
+        private static bool IsMouseOverOwnerWindow()
+        {
+            var mouseOver = EditorWindow.mouseOverWindow;
+            return mouseOver != null && ownerWindows.Contains(mouseOver);
+        }
+
+        private static void DrawProviderPreview(IVRCAvatarDynamicsProvider provider)
+        {
+            switch (provider.ComponentType)
+            {
+                case AvatarDynamicsComponentType.PhysBone:
+                    Handles.color = PrimaryPreviewColor;
+                    DrawPhysBonePreview((VRCPhysBoneProviderBase)provider);
+                    break;
+                case AvatarDynamicsComponentType.PhysBoneCollider:
+                    Handles.color = PrimaryPreviewColor;
+                    DrawColliderPreview((VRCPhysBoneColliderProvider)provider, drawRelatedPhysBones: true);
+                    break;
+                case AvatarDynamicsComponentType.Contact:
+                    Handles.color = PrimaryPreviewColor;
+                    DrawContactPreview((VRCContactBaseProvider)provider);
+                    break;
             }
         }
 
@@ -157,7 +287,7 @@ namespace KRT.VRCQuestTools.Services
 
         private static void DrawColliderPreview(VRCPhysBoneColliderProvider provider, bool drawRelatedPhysBones = false)
         {
-            if (provider?.Component is not VRCPhysBoneCollider collider)
+            if (provider?.Component is not VRCPhysBoneCollider collider || collider == null)
             {
                 return;
             }
@@ -231,7 +361,7 @@ namespace KRT.VRCQuestTools.Services
 
         private static void DrawContactPreview(VRCContactBaseProvider provider)
         {
-            if (provider?.Component is not ContactBase contact)
+            if (provider?.Component is not ContactBase contact || contact == null)
             {
                 return;
             }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/ViewModels/PhysBonesRemoveViewModel.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/ViewModels/PhysBonesRemoveViewModel.cs
@@ -26,8 +26,11 @@ namespace KRT.VRCQuestTools.ViewModels
         [SerializeField]
         private GameObject avatarRoot;
 
+        // Underlying components of the selected PhysBone providers. Providers themselves are not
+        // serializable (abstract, wrapping a non-serialized component), so the components are
+        // stored instead and providers are rebuilt on access. Insertion order is preserved.
         [SerializeField]
-        private List<VRCPhysBoneProviderBase> physBonesToKeep = new List<VRCPhysBoneProviderBase>();
+        private List<Component> physBonesToKeep = new List<Component>();
 
         [SerializeField]
         private List<VRCPhysBoneCollider> physBoneCollidersToKeep = new List<VRCPhysBoneCollider>();
@@ -68,7 +71,22 @@ namespace KRT.VRCQuestTools.ViewModels
         /// <summary>
         /// Gets selected PhysBones to keep as providers for abstraction layer.
         /// </summary>
-        internal IEnumerable<VRCPhysBoneProviderBase> PhysBoneProvidersToKeep => physBonesToKeep;
+        internal IEnumerable<VRCPhysBoneProviderBase> PhysBoneProvidersToKeep
+        {
+            get
+            {
+                var avatar = Avatar;
+                if (avatar == null)
+                {
+                    return Enumerable.Empty<VRCPhysBoneProviderBase>();
+                }
+                var providers = avatar.GetPhysBoneProviders().ToDictionary(p => p.Component);
+                return physBonesToKeep
+                    .Where(c => c != null && providers.ContainsKey(c))
+                    .Select(c => providers[c])
+                    .ToList();
+            }
+        }
 
         /// <summary>
         /// Gets selected PhysBoneColliders to keep.
@@ -111,7 +129,7 @@ namespace KRT.VRCQuestTools.ViewModels
         internal void SetSelectedPhysBoneProviders(IEnumerable<VRCPhysBoneProviderBase> physBoneProviders)
         {
             physBonesToKeep.Clear();
-            physBonesToKeep.AddRange(physBoneProviders);
+            physBonesToKeep.AddRange(physBoneProviders.Select(p => p.Component));
         }
 
         /// <summary>
@@ -123,14 +141,14 @@ namespace KRT.VRCQuestTools.ViewModels
         {
             if (select)
             {
-                if (!physBonesToKeep.Contains(physBone))
+                if (!physBonesToKeep.Contains(physBone.Component))
                 {
-                    physBonesToKeep.Add(physBone);
+                    physBonesToKeep.Add(physBone.Component);
                 }
             }
             else
             {
-                physBonesToKeep.Remove(physBone);
+                physBonesToKeep.Remove(physBone.Component);
             }
         }
 
@@ -238,7 +256,7 @@ namespace KRT.VRCQuestTools.ViewModels
         {
             Undo.IncrementCurrentGroup();
             Undo.SetCurrentGroupName("Remove Avatar Dynamics Components");
-            var pbToKeep = physBonesToKeep.ToArray();
+            var pbToKeep = PhysBoneProvidersToKeep.ToArray();
             var pbcToKeep = physBoneCollidersToKeep.ToArray();
             var cToKeep = contactsToKeep.ToArray();
             VRCSDKUtility.DeleteAvatarDynamicsComponents(Avatar, pbToKeep, pbcToKeep, cToKeep);
@@ -250,13 +268,33 @@ namespace KRT.VRCQuestTools.ViewModels
         /// </summary>
         internal void DeselectRemovedComponents()
         {
-            physBonesToKeep.RemoveAll(p => p.GetPhysBones().Length == 0);
+            physBonesToKeep.RemoveAll(c => c == null);
 
             var colliders = Avatar.GetPhysBoneColliders();
             physBoneCollidersToKeep.RemoveAll(c => !colliders.Contains(c));
 
             var contacts = Avatar.GetContacts();
             contactsToKeep.RemoveAll(c => !contacts.Contains(c));
+        }
+
+        /// <summary>
+        /// Re-derives the selection after returning from Play Mode, using the same safe default
+        /// logic as selecting the avatar fresh (see <see cref="SelectAvatar"/>). The precise pre-play
+        /// selection can't be preserved: NDMF's Play Mode avatar processing destroys, and can
+        /// merge/replace, the underlying PhysBone and Collider components while testing, so any
+        /// component reference captured before Play Mode still ends up dangling once Unity remaps
+        /// object references through the round trip. Falling back to the default selection avoids
+        /// silently ending up with an empty "keep" list, which would mark every component for removal.
+        /// Call from <see cref="PlayModeStateChange.EnteredEditMode"/>.
+        /// </summary>
+        internal void ResetSelectionAfterPlayMode()
+        {
+            if (avatarRoot == null || Avatar?.AvatarDescriptor == null)
+            {
+                return;
+            }
+
+            SelectAvatar(Avatar.AvatarDescriptor);
         }
 
         /// <summary>
@@ -274,7 +312,7 @@ namespace KRT.VRCQuestTools.ViewModels
                 switch (setting.component)
                 {
                     case VRCPhysBone physBone:
-                        physBonesToKeep.RemoveAll(provider => provider.GetPhysBones().Contains(physBone));
+                        physBonesToKeep.RemoveAll(c => c == physBone);
                         break;
                     case VRCPhysBoneCollider physBoneCollider:
                         physBoneCollidersToKeep.Remove(physBoneCollider);

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsSelectorWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsSelectorWindow.cs
@@ -18,27 +18,32 @@ namespace KRT.VRCQuestTools.Views
     /// <summary>
     /// Editor window for selecting avatar dynamics components to keep.
     /// </summary>
-    internal class AvatarDynamicsSelectorWindow : EditorWindow
+    internal class AvatarDynamicsSelectorWindow : EditorWindow, ISerializationCallbackReceiver
     {
-        /// <summary>
-        /// AvatarConverterSettings to edit.
-        /// </summary>
-        internal KRT.VRCQuestTools.Components.AvatarConverterSettings converterSettings;
+        [SerializeField]
+        private GameObject avatarRootGameObject;
 
         /// <summary>
         /// PhysBone providers to keep.
+        /// Providers are not serializable, so the underlying components are serialized in
+        /// <see cref="serializedPhysBonesToKeep"/> and providers are rebuilt on enable.
         /// </summary>
         internal VRCPhysBoneProviderBase[] physBoneProvidersToKeep = { };
 
         /// <summary>
         /// PhysBoneColliders to keep.
         /// </summary>
+        [SerializeField]
         internal VRCPhysBoneCollider[] physBoneCollidersToKeep = { };
 
         /// <summary>
         /// ContactSenders & ContactReceivers to keep.
         /// </summary>
+        [SerializeField]
         internal VRC.Dynamics.ContactBase[] contactsToKeep = { };
+
+        [SerializeField]
+        private List<Component> serializedPhysBonesToKeep = new List<Component>();
 
         [SerializeField]
         private Vector2 scrollPosition = Vector2.zero;
@@ -48,6 +53,8 @@ namespace KRT.VRCQuestTools.Views
         private bool foldoutPhysBonesColliders = true;
         [SerializeField]
         private bool foldoutContacts = true;
+        [SerializeField]
+        private bool foldoutEstimatedPerformance = true;
 
         private GUIStyle foldoutContentStyle;
         private I18nBase i18n;
@@ -57,6 +64,36 @@ namespace KRT.VRCQuestTools.Views
         private Dictionary<string, bool> physBoneGroupFoldouts = new Dictionary<string, bool>();
         private Dictionary<string, bool> colliderGroupFoldouts = new Dictionary<string, bool>();
         private Dictionary<string, bool> contactGroupFoldouts = new Dictionary<string, bool>();
+
+        /// <summary>
+        /// AvatarConverterSettings to edit. Backed by a GameObject reference rather than the component
+        /// directly: this component is editor-only and gets destroyed by NDMF's Play Mode avatar
+        /// processing, so a direct component reference would be unrecoverable after a Play Mode round
+        /// trip. The backing GameObject is not destroyed, so it is re-resolved live on every access.
+        /// </summary>
+        internal KRT.VRCQuestTools.Components.AvatarConverterSettings converterSettings
+        {
+            get => avatarRootGameObject != null ? avatarRootGameObject.GetComponent<KRT.VRCQuestTools.Components.AvatarConverterSettings>() : null;
+            set => avatarRootGameObject = value != null ? value.gameObject : null;
+        }
+
+        /// <summary>
+        /// Stores the underlying components of the PhysBone providers, which are not serializable themselves.
+        /// </summary>
+        public void OnBeforeSerialize()
+        {
+            serializedPhysBonesToKeep = physBoneProvidersToKeep
+                .Where(p => p != null && p.Component != null)
+                .Select(p => p.Component)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Providers are rebuilt in OnEnable because the Unity API is not available during deserialization.
+        /// </summary>
+        public void OnAfterDeserialize()
+        {
+        }
 
         /// <summary>
         /// Applies avatar dynamics settings to PlatformComponentRemover components.
@@ -97,22 +134,80 @@ namespace KRT.VRCQuestTools.Views
         {
             titleContent = new GUIContent("Avatar Dynamics Selector");
             wantsMouseMove = true;
+            wantsMouseEnterLeaveWindow = true;
             foldoutContentStyle = new GUIStyle()
             {
                 padding = new RectOffset(16, 0, 0, 0),
             };
             statsLevelSet = VRCSDKUtility.LoadAvatarPerformanceStatsLevelSet(true);
             AvatarDynamicsPreviewService.Initialize();
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+            RestorePhysBoneProviders();
         }
 
         private void OnDisable()
         {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
             AvatarDynamicsPreviewService.Cleanup();
+        }
+
+        private void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.EnteredEditMode)
+            {
+                ResetSelectionAfterPlayMode();
+            }
+        }
+
+        // Rebuilds PhysBone providers from the serialized components after a domain reload.
+        private void RestorePhysBoneProviders()
+        {
+            if (physBoneProvidersToKeep.Length > 0 || serializedPhysBonesToKeep.Count == 0)
+            {
+                return;
+            }
+            if (converterSettings == null || converterSettings.AvatarDescriptor == null)
+            {
+                return;
+            }
+            var components = new HashSet<Component>(serializedPhysBonesToKeep.Where(c => c != null));
+            physBoneProvidersToKeep = new VRChatAvatar(converterSettings.AvatarDescriptor)
+                .GetPhysBoneProviders()
+                .Where(p => components.Contains(p.Component))
+                .ToArray();
+        }
+
+        // Re-derives the selection after returning from Play Mode, using the same safe default logic
+        // as opening the window fresh (see AvatarConverterSettingsEditor.InitializeSelectorWindow).
+        // The precise pre-play selection can't be preserved: NDMF's Play Mode avatar processing
+        // destroys, and can merge/replace, the underlying PhysBone and Collider components while
+        // testing, so any component reference captured before Play Mode still ends up dangling once
+        // Unity remaps object references through the round trip. Falling back to the default
+        // selection avoids silently ending up with an empty "keep" list, which would mark every
+        // component for Android removal if Apply were pressed.
+        private void ResetSelectionAfterPlayMode()
+        {
+            if (converterSettings == null || converterSettings.AvatarDescriptor == null)
+            {
+                return;
+            }
+            KRT.VRCQuestTools.Inspector.AvatarConverterSettingsEditor.InitializeSelectorWindow(this, converterSettings, converterSettings.AvatarDescriptor);
         }
 
         private void OnGUI()
         {
             i18n = VRCQuestToolsSettings.I18nResource;
+
+            if (EditorApplication.isPlaying)
+            {
+                // The referenced AvatarConverterSettings is editor-only and gets destroyed by NDMF's
+                // Play Mode avatar processing, so it looks "missing" while playing even though the
+                // selection is preserved (see OnPlayModeStateChanged) and will reappear on returning
+                // to Edit Mode.
+                EditorGUILayout.HelpBox(i18n.ExitPlayModeToEdit, MessageType.Warning);
+                return;
+            }
+
             if (converterSettings == null)
             {
                 EditorGUILayout.LabelField("Referenced AvatarConverter is missing.");
@@ -123,8 +218,15 @@ namespace KRT.VRCQuestTools.Views
                 return;
             }
 
+            AvatarDynamicsPreviewService.BeginPreviewFrame(this);
+
             var avatar = new VRChatAvatar(converterSettings.AvatarDescriptor);
             var avatarRoot = converterSettings.AvatarDescriptor.gameObject;
+
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.ObjectField(i18n.AvatarLabel, converterSettings.AvatarDescriptor, typeof(VRC.SDKBase.VRC_AvatarDescriptor), true);
+            }
 
             EditorGUILayout.LabelField(i18n.SelectComponentsToKeep, EditorStyles.wordWrappedLabel);
             using (var scrollView = new EditorGUILayout.ScrollViewScope(scrollPosition))
@@ -241,19 +343,30 @@ namespace KRT.VRCQuestTools.Views
 
             EditorGUILayout.Space();
 
-            EditorGUILayout.LabelField(i18n.EstimatedPerformanceStats, EditorStyles.boldLabel);
-            var pbcToKeep = physBoneCollidersToKeep.Where(x => x != null).ToArray();
-            var cToKeep = contactsToKeep.Where(x => x != null).ToArray();
-            var stats = avatar.EstimatePerformanceStats(physBoneProvidersToKeep, pbcToKeep, cToKeep, true);
-            var categories = VRCSDKUtility.AvatarDynamicsPerformanceCategories;
-            foreach (var category in categories)
+            // Update the fallback scene preview with the current selection (drawn while no row is hovered).
+            AvatarDynamicsPreviewService.SetSelectedPreviewComponents(
+                physBoneProvidersToKeep.Cast<IVRCAvatarDynamicsProvider>()
+                    .Concat(contactsToKeep.Where(c => c != null).Select(c => (IVRCAvatarDynamicsProvider)new VRCContactBaseProvider(c))));
+
+            using (var foldout = new EditorGUIUtility.FoldoutHeaderGroupScope(foldoutEstimatedPerformance, new GUIContent(i18n.EstimatedPerformanceStats)))
             {
-                EditorGUIUtility.PerformanceRatingPanel(stats, statsLevelSet, category, i18n);
+                foldoutEstimatedPerformance = foldout.Foldout;
+                if (foldoutEstimatedPerformance)
+                {
+                    var pbcToKeep = physBoneCollidersToKeep.Where(x => x != null).ToArray();
+                    var cToKeep = contactsToKeep.Where(x => x != null).ToArray();
+                    var stats = avatar.EstimatePerformanceStats(physBoneProvidersToKeep, pbcToKeep, cToKeep, true);
+                    var categories = VRCSDKUtility.AvatarDynamicsPerformanceCategories;
+                    foreach (var category in categories)
+                    {
+                        EditorGUIUtility.PerformanceRatingPanel(stats, statsLevelSet, category, i18n);
+                    }
+                }
             }
 
-            EditorGUILayout.Space();
+            EditorGUILayout.Space(8);
 
-            if (GUILayout.Button(i18n.ApplyButtonLabel))
+            if (EditorGUIUtility.LargeButton(i18n.ApplyButtonLabel))
             {
                 ApplyDynamicsSettings(converterSettings, physBoneProvidersToKeep, physBoneCollidersToKeep, contactsToKeep);
 
@@ -266,7 +379,9 @@ namespace KRT.VRCQuestTools.Views
                 Close();
             }
 
-            EditorGUILayout.Space();
+            EditorGUILayout.Space(8);
+
+            AvatarDynamicsPreviewService.EndPreviewFrame();
         }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsSelectorWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsSelectorWindow.cs
@@ -381,7 +381,7 @@ namespace KRT.VRCQuestTools.Views
 
             EditorGUILayout.Space(8);
 
-            AvatarDynamicsPreviewService.EndPreviewFrame();
+            AvatarDynamicsPreviewService.EndPreviewFrame(this);
         }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using KRT.VRCQuestTools.I18n;
 using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.Models.VRChat;
@@ -20,6 +21,12 @@ namespace KRT.VRCQuestTools.Views
     /// </summary>
     internal static class EditorGUIUtility
     {
+        // GUIClip.visibleRect is internal but is the only way to know the visible portion of the
+        // current clip area (e.g. a scroll view) during a layout-based OnGUI pass.
+        private static readonly PropertyInfo GuiClipVisibleRectProperty = typeof(GUI).Assembly
+            .GetType("UnityEngine.GUIClip")
+            ?.GetProperty("visibleRect", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
         private static Dictionary<DisplayLanguage, string> displayLanguageNames = System.Enum.GetValues(typeof(DisplayLanguage))
             .Cast<DisplayLanguage>()
             .ToDictionary(x => x, x =>
@@ -132,7 +139,11 @@ namespace KRT.VRCQuestTools.Views
                 if ((currentEvent.type == EventType.Repaint || currentEvent.type == EventType.MouseMove))
                 {
                     var lastRect = GUILayoutUtility.GetLastRect();
-                    if (lastRect.Contains(currentEvent.mousePosition))
+
+                    // Extend the rect over the layout spacing below the row so the hover doesn't
+                    // drop out (falling back to the all-selected preview) between adjacent rows.
+                    lastRect.height += UnityEditor.EditorGUIUtility.standardVerticalSpacing;
+                    if (lastRect.Contains(currentEvent.mousePosition) && IsMouseInVisibleClipRect(currentEvent.mousePosition))
                     {
                         hoveredProvider = obj;
                     }
@@ -450,6 +461,17 @@ namespace KRT.VRCQuestTools.Views
         }
 
         /// <summary>
+        /// Show a large button for primary window actions. Taller than the default button
+        /// so it is easier to click without hitting neighboring controls.
+        /// </summary>
+        /// <param name="label">Button label.</param>
+        /// <returns>true when clicked.</returns>
+        internal static bool LargeButton(string label)
+        {
+            return GUILayout.Button(label, GUILayout.Height(28));
+        }
+
+        /// <summary>
         /// Show horizontal divider.
         /// </summary>
         /// <param name="lineHeight">Line height.</param>
@@ -493,6 +515,21 @@ namespace KRT.VRCQuestTools.Views
             }
 
             return display;
+        }
+
+        // Rows scrolled out of a scroll view still have layout rects, and the mouse position is
+        // translated into the scroll content space, so a rect check alone can hit a hidden row
+        // while the cursor is physically outside the viewport. Require the mouse to also be inside
+        // the visible clip area. When the internal API cannot be resolved, everything is treated
+        // as visible (the previous behavior).
+        private static bool IsMouseInVisibleClipRect(Vector2 mousePosition)
+        {
+            if (GuiClipVisibleRectProperty == null)
+            {
+                return true;
+            }
+            var visibleRect = (Rect)GuiClipVisibleRectProperty.GetValue(null);
+            return visibleRect.Contains(mousePosition);
         }
 
         // Unique foldout key per group. Uses the relative path so prefabs sharing a name keep independent foldout states.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/PhysBonesRemoveWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/PhysBonesRemoveWindow.cs
@@ -242,9 +242,14 @@ namespace KRT.VRCQuestTools.Views
 
             EditorGUILayout.Space();
 
+            // PhysBoneProvidersToKeep rebuilds providers from the serialized components on every
+            // access, so it's fetched once here and reused below instead of being enumerated
+            // separately for the preview and the performance stats.
+            var physBoneProvidersToKeep = model.PhysBoneProvidersToKeep.ToArray();
+
             // Update the fallback scene preview with the current selection (drawn while no row is hovered).
             AvatarDynamicsPreviewService.SetSelectedPreviewComponents(
-                model.PhysBoneProvidersToKeep.Cast<IVRCAvatarDynamicsProvider>()
+                physBoneProvidersToKeep.Cast<IVRCAvatarDynamicsProvider>()
                     .Concat(model.ContactsToKeep.Where(c => c != null).Select(c => (IVRCAvatarDynamicsProvider)new VRCContactBaseProvider(c))));
 
             using (var foldout = new EditorGUIUtility.FoldoutHeaderGroupScope(foldoutEstimatedPerformance, new GUIContent(i18n.EstimatedPerformanceStats)))
@@ -253,7 +258,7 @@ namespace KRT.VRCQuestTools.Views
                 if (foldoutEstimatedPerformance)
                 {
                     var stats = model.Avatar.EstimatePerformanceStats(
-                        model.PhysBoneProvidersToKeep.ToArray(),
+                        physBoneProvidersToKeep,
                         model.PhysBoneCollidersToKeep.ToArray(),
                         model.ContactsToKeep.ToArray(),
                         true);
@@ -280,7 +285,7 @@ namespace KRT.VRCQuestTools.Views
 
             EditorGUILayout.Space(8);
 
-            AvatarDynamicsPreviewService.EndPreviewFrame();
+            AvatarDynamicsPreviewService.EndPreviewFrame(this);
         }
 
         private void OnSelectAvatar(VRC_AvatarDescriptor avatar)

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/PhysBonesRemoveWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/PhysBonesRemoveWindow.cs
@@ -30,10 +30,16 @@ namespace KRT.VRCQuestTools.Views
 
         [SerializeField]
         private PhysBonesRemoveViewModel model = new PhysBonesRemoveViewModel();
+        [SerializeField]
         private Vector2 scrollPosition;
+        [SerializeField]
         private bool showPhysBones = true;
+        [SerializeField]
         private bool showPhysBoneColliders = true;
+        [SerializeField]
         private bool showContacts = true;
+        [SerializeField]
+        private bool foldoutEstimatedPerformance = true;
 
         // Per-group foldout states keyed by relative path label. Default: open (true).
         private Dictionary<string, bool> physBoneGroupFoldouts = new Dictionary<string, bool>();
@@ -69,6 +75,7 @@ namespace KRT.VRCQuestTools.Views
         {
             titleContent.text = "PhysBones Remover";
             wantsMouseMove = true;
+            wantsMouseEnterLeaveWindow = true;
             foldedContentPanel = new GUIStyle()
             {
                 padding =
@@ -78,16 +85,35 @@ namespace KRT.VRCQuestTools.Views
             };
             statsLevelSet = VRCSDKUtility.LoadAvatarPerformanceStatsLevelSet(true);
             AvatarDynamicsPreviewService.Initialize();
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
         }
 
         private void OnDisable()
         {
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
             AvatarDynamicsPreviewService.Cleanup();
+        }
+
+        private void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.EnteredEditMode)
+            {
+                model.ResetSelectionAfterPlayMode();
+            }
         }
 
         private void OnGUI()
         {
             var i18n = VRCQuestToolsSettings.I18nResource;
+
+            if (EditorApplication.isPlaying)
+            {
+                // The referenced PhysBones/Colliders/Contacts are destroyed by NDMF's Play Mode avatar
+                // processing, so they look "missing" while playing even though the selection is
+                // preserved (see OnPlayModeStateChanged) and will reappear on returning to Edit Mode.
+                EditorGUILayout.HelpBox(i18n.ExitPlayModeToEdit, MessageType.Warning);
+                return;
+            }
 
             var selectedAvatar = (VRC_AvatarDescriptor)EditorGUILayout.ObjectField(i18n.AvatarLabel, model.Avatar?.AvatarDescriptor, typeof(VRC_AvatarDescriptor), true);
             if (model.Avatar?.AvatarDescriptor != selectedAvatar)
@@ -99,6 +125,8 @@ namespace KRT.VRCQuestTools.Views
                 return;
             }
             model.DeselectRemovedComponents();
+
+            AvatarDynamicsPreviewService.BeginPreviewFrame(this);
 
             var avatarRoot = model.Avatar.AvatarDescriptor.gameObject;
 
@@ -214,28 +242,45 @@ namespace KRT.VRCQuestTools.Views
 
             EditorGUILayout.Space();
 
-            var stats = model.Avatar.EstimatePerformanceStats(
-                model.PhysBoneProvidersToKeep.ToArray(),
-                model.PhysBoneCollidersToKeep.ToArray(),
-                model.ContactsToKeep.ToArray(),
-                true);
-            EditorGUILayout.LabelField(i18n.EstimatedPerformanceStats, EditorStyles.boldLabel);
-            foreach (var category in VRCSDKUtility.AvatarDynamicsPerformanceCategories)
+            // Update the fallback scene preview with the current selection (drawn while no row is hovered).
+            AvatarDynamicsPreviewService.SetSelectedPreviewComponents(
+                model.PhysBoneProvidersToKeep.Cast<IVRCAvatarDynamicsProvider>()
+                    .Concat(model.ContactsToKeep.Where(c => c != null).Select(c => (IVRCAvatarDynamicsProvider)new VRCContactBaseProvider(c))));
+
+            using (var foldout = new EditorGUIUtility.FoldoutHeaderGroupScope(foldoutEstimatedPerformance, new GUIContent(i18n.EstimatedPerformanceStats)))
             {
-                EditorGUIUtility.PerformanceRatingPanel(stats, statsLevelSet, category, i18n);
+                foldoutEstimatedPerformance = foldout.Foldout;
+                if (foldoutEstimatedPerformance)
+                {
+                    var stats = model.Avatar.EstimatePerformanceStats(
+                        model.PhysBoneProvidersToKeep.ToArray(),
+                        model.PhysBoneCollidersToKeep.ToArray(),
+                        model.ContactsToKeep.ToArray(),
+                        true);
+                    foreach (var category in VRCSDKUtility.AvatarDynamicsPerformanceCategories)
+                    {
+                        EditorGUIUtility.PerformanceRatingPanel(stats, statsLevelSet, category, i18n);
+                    }
+                }
             }
 
-            if (GUILayout.Button(i18n.DeleteUnselectedComponents))
+            EditorGUILayout.Space(8);
+
+            if (EditorGUIUtility.LargeButton(i18n.DeleteUnselectedComponents))
             {
                 OnClickDelete();
             }
 
-            if (GUILayout.Button(i18n.SetPlatformComponentRemoverButtonLabel))
+            EditorGUILayout.Space(4);
+
+            if (EditorGUIUtility.LargeButton(i18n.SetPlatformComponentRemoverButtonLabel))
             {
                 OnClickSetPlatformComponentRemover();
             }
 
-            EditorGUILayout.Space();
+            EditorGUILayout.Space(8);
+
+            AvatarDynamicsPreviewService.EndPreviewFrame();
         }
 
         private void OnSelectAvatar(VRC_AvatarDescriptor avatar)


### PR DESCRIPTION
Show all selected PhysBones/Contacts in the scene view as a fallback preview when no row is hovered, restore the target avatar and selection across domain reloads and Play/Edit switches, make the estimated performance rank section collapsible, enlarge the bottom action buttons, and show a disabled avatar field in the Selector window to match the Remover window.