### PR TITLE
Add serializedVersion field to components and material convert settings

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/AvatarConverterSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/AvatarConverterSettings.cs
@@ -122,6 +122,12 @@ namespace KRT.VRCQuestTools.Components
         public bool forceMaterialPreview = false;
 
         /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
+        /// <summary>
         /// Gets avatar descriptor of the avatar root object.
         /// </summary>
         public VRC_AvatarDescriptor AvatarDescriptor => gameObject.GetComponent<VRC_AvatarDescriptor>();

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/AvatarConverterSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/AvatarConverterSettings.cs
@@ -125,7 +125,9 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
         /// <summary>
         /// Gets avatar descriptor of the avatar root object.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/ConvertedAvatar.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/ConvertedAvatar.cs
@@ -11,5 +11,10 @@ namespace KRT.VRCQuestTools.Components
     [HelpURL("https://kurotu.github.io/VRCQuestTools/docs/references/components/converted-avatar?lang=auto")]
     public class ConvertedAvatar : VRCQuestToolsEditorOnly
     {
+        /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/ConvertedAvatar.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/ConvertedAvatar.cs
@@ -15,6 +15,8 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/FallbackAvatar.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/FallbackAvatar.cs
@@ -15,5 +15,10 @@ namespace KRT.VRCQuestTools.Components
     [DisallowMultipleComponent]
     public class FallbackAvatar : VRCQuestToolsEditorOnly, IAvatarRootComponent
     {
+        /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/FallbackAvatar.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/FallbackAvatar.cs
@@ -19,6 +19,8 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialConversionSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialConversionSettings.cs
@@ -48,6 +48,12 @@ namespace KRT.VRCQuestTools.Components
         [System.NonSerialized]
         public bool forceMaterialPreview = false;
 
+        /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
         /// <inheritdoc/>
         public IMaterialConvertSettings DefaultMaterialConvertSettings => defaultMaterialConvertSettings;
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialConversionSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialConversionSettings.cs
@@ -52,7 +52,9 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
         /// <inheritdoc/>
         public IMaterialConvertSettings DefaultMaterialConvertSettings => defaultMaterialConvertSettings;

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialSwap.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialSwap.cs
@@ -21,7 +21,9 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
         /// <summary>
         /// Apply material swaps based on the mapping.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialSwap.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialSwap.cs
@@ -18,6 +18,12 @@ namespace KRT.VRCQuestTools.Components
         public List<MaterialMapping> materialMappings = new List<MaterialMapping>();
 
         /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
+        /// <summary>
         /// Apply material swaps based on the mapping.
         /// </summary>
         public void ApplyMaterialSwaps()

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MenuIconResizer.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MenuIconResizer.cs
@@ -35,7 +35,9 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
         /// <summary>
         /// Texture size limit for quest.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MenuIconResizer.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MenuIconResizer.cs
@@ -32,6 +32,12 @@ namespace KRT.VRCQuestTools.Components
         public MobileTextureFormat mobileTextureFormat = MobileTextureFormat.ASTC_8x8;
 
         /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
+        /// <summary>
         /// Texture size limit for quest.
         /// 256px is the maximum size for VRChat expressions menu icons.
         /// </summary>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MeshFlipper.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MeshFlipper.cs
@@ -95,6 +95,12 @@ namespace KRT.VRCQuestTools.Components
         /// </summary>
         public MeshFlipperProcessingPhase processingPhase = MeshFlipperProcessingPhase.AfterPolygonReduction;
 
+        /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
 #if UNITY_EDITOR
         /// <summary>
         /// Create a new mesh basd on the component settings.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MeshFlipper.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MeshFlipper.cs
@@ -99,7 +99,9 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
 #if UNITY_EDITOR
         /// <summary>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/NetworkIDAssigner.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/NetworkIDAssigner.cs
@@ -16,6 +16,8 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/NetworkIDAssigner.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/NetworkIDAssigner.cs
@@ -12,6 +12,10 @@ namespace KRT.VRCQuestTools.Components
     [DisallowMultipleComponent]
     public class NetworkIDAssigner : VRCQuestToolsEditorOnly
     {
-        // no members.
+        /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformComponentRemover.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformComponentRemover.cs
@@ -19,6 +19,12 @@ namespace KRT.VRCQuestTools.Components
         public PlatformComponentRemoverItem[] componentSettings = new PlatformComponentRemoverItem[0];
 
         /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
+        /// <summary>
         /// Remove non-existing components then add unregistered components.
         /// </summary>
         public void UpdateComponentSettings()

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformComponentRemover.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformComponentRemover.cs
@@ -22,7 +22,9 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
         /// <summary>
         /// Remove non-existing components then add unregistered components.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformGameObjectRemover.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformGameObjectRemover.cs
@@ -23,6 +23,8 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformGameObjectRemover.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformGameObjectRemover.cs
@@ -18,5 +18,11 @@ namespace KRT.VRCQuestTools.Components
         /// Remove the GameObject this component is attached when the target platform is Android.
         /// </summary>
         public bool removeOnAndroid = false;
+
+        /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformTargetSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformTargetSettings.cs
@@ -20,6 +20,8 @@ namespace KRT.VRCQuestTools.Components
         /// Serialized schema version for forward compatibility.
         /// </summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformTargetSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/PlatformTargetSettings.cs
@@ -15,5 +15,11 @@ namespace KRT.VRCQuestTools.Components
         /// Build target to control VQT Platform components.
         /// </summary>
         public BuildTarget buildTarget = BuildTarget.Auto;
+
+        /// <summary>
+        /// Serialized schema version for forward compatibility.
+        /// </summary>
+        [SerializeField]
+        private int serializedVersion = 1;
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MatCapLitConvertSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MatCapLitConvertSettings.cs
@@ -44,6 +44,10 @@ namespace KRT.VRCQuestTools.Models
         /// </summary>
         public Texture matCapTexture;
 
+        /// <summary>Serialized schema version for forward compatibility.</summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
         private static Lazy<FieldInfo[]> unitySerializableFields = new Lazy<FieldInfo[]>(() => GetUnitySerializableFields(typeof(MatCapLitConvertSettings)));
 
         /// <inheritdoc/>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MatCapLitConvertSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MatCapLitConvertSettings.cs
@@ -46,9 +46,14 @@ namespace KRT.VRCQuestTools.Models
 
         /// <summary>Serialized schema version for forward compatibility.</summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
-        private static Lazy<FieldInfo[]> unitySerializableFields = new Lazy<FieldInfo[]>(() => GetUnitySerializableFields(typeof(MatCapLitConvertSettings)));
+        private static Lazy<FieldInfo[]> unitySerializableFields = new Lazy<FieldInfo[]>(() =>
+            GetUnitySerializableFields(typeof(MatCapLitConvertSettings))
+                .Where(f => f.Name != nameof(serializedVersion))
+                .ToArray());
 
         /// <inheritdoc/>
         public bool GenerateQuestTextures => generateQuestTextures;

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MaterialReplaceSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MaterialReplaceSettings.cs
@@ -13,6 +13,10 @@ namespace KRT.VRCQuestTools.Models
         [SerializeField]
         public Material material;
 
+        /// <summary>Serialized schema version for forward compatibility.</summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
         /// <inheritdoc/>
         public MobileTextureFormat MobileTextureFormat => throw new System.InvalidProgramException("MaterialReplaceSettings doesn't generate textures.");
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MaterialReplaceSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/MaterialReplaceSettings.cs
@@ -15,7 +15,9 @@ namespace KRT.VRCQuestTools.Models
 
         /// <summary>Serialized schema version for forward compatibility.</summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
         /// <inheritdoc/>
         public MobileTextureFormat MobileTextureFormat => throw new System.InvalidProgramException("MaterialReplaceSettings doesn't generate textures.");

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/ToonLitConvertSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/ToonLitConvertSettings.cs
@@ -41,7 +41,9 @@ namespace KRT.VRCQuestTools.Models
 
         /// <summary>Serialized schema version for forward compatibility.</summary>
         [SerializeField]
+#pragma warning disable CS0414
         private int serializedVersion = 1;
+#pragma warning restore CS0414
 
         /// <inheritdoc/>
         public bool GenerateQuestTextures => generateQuestTextures;

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/ToonLitConvertSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/ToonLitConvertSettings.cs
@@ -39,6 +39,10 @@ namespace KRT.VRCQuestTools.Models
         /// </summary>
         public bool generateShadowFromNormalMap = true;
 
+        /// <summary>Serialized schema version for forward compatibility.</summary>
+        [SerializeField]
+        private int serializedVersion = 1;
+
         /// <inheritdoc/>
         public bool GenerateQuestTextures => generateQuestTextures;
 


### PR DESCRIPTION
For future forward-compatibility, add [SerializeField] private int serializedVersion = 1 to:
- 11 MonoBehaviour components in Runtime/Components/
- 3 IMaterialConvertSettings implementations in Runtime/Models/MaterialConvertSettings/

This field provides a schema version placeholder for later migration logic. Follows existing naming convention established in ToonStandardConvertSettings.