### PR TITLE
Isolate editor tests and fix test helper

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/Inspector/AvatarDynamicsSelectorEditorE2ETests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Inspector/AvatarDynamicsSelectorEditorE2ETests.cs
@@ -27,7 +27,7 @@ namespace KRT.VRCQuestTools.Inspector
     /// AvatarDynamicsSelectorWindow initial state when the selector is opened
     /// (issue #185).
     /// </summary>
-    public class AvatarDynamicsSelectorEditorE2ETests
+    public class AvatarDynamicsSelectorEditorE2ETests : KRT.VRCQuestTools.TestUtilities.IsolatedEditorSceneTest
     {
         private Driver driver;
         private GameObject avatarRoot;
@@ -47,6 +47,7 @@ namespace KRT.VRCQuestTools.Inspector
             driver = new Driver();
 
             avatarRoot = new GameObject("TestAvatar");
+            avatarRoot.transform.SetParent(TestRoot.transform);
             descriptor = avatarRoot.AddComponent<VRCAvatarDescriptor>();
             converterSettings = avatarRoot.AddComponent<AvatarConverterSettings>();
 

--- a/Assets/VRCQuestTools-Tests/Editor/Inspector/AvatarDynamicsSelectorTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Inspector/AvatarDynamicsSelectorTests.cs
@@ -23,7 +23,7 @@ namespace KRT.VRCQuestTools.Inspector
     /// Verifies that the Apply logic configures PlatformComponentRemover correctly
     /// instead of writing to legacy physBonesToKeep fields (issue #185).
     /// </summary>
-    public class AvatarDynamicsSelectorTests
+    public class AvatarDynamicsSelectorTests : KRT.VRCQuestTools.TestUtilities.IsolatedEditorSceneTest
     {
         private GameObject avatarRoot;
         private AvatarConverterSettings converterSettings;
@@ -39,6 +39,7 @@ namespace KRT.VRCQuestTools.Inspector
         public void SetUp()
         {
             avatarRoot = new GameObject("TestAvatar");
+            avatarRoot.transform.SetParent(TestRoot.transform);
             avatarRoot.AddComponent<VRCAvatarDescriptor>();
             converterSettings = avatarRoot.AddComponent<AvatarConverterSettings>();
 

--- a/Assets/VRCQuestTools-Tests/Editor/TestUtilities.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/TestUtilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f78acb83b0ca684cad43446f8d18274
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/TestUtilities/IsolatedEditorSceneTest.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/TestUtilities/IsolatedEditorSceneTest.cs
@@ -1,0 +1,78 @@
+#if UNITY_EDITOR
+using System;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace KRT.VRCQuestTools.TestUtilities
+{
+    /// <summary>
+    /// Provides a temporary isolated editor scene for tests so they don't modify
+    /// the user's currently open scene. Base class SetUp creates an additive
+    /// empty scene and makes it active when possible; otherwise it creates a
+    /// temporary root GameObject in the active scene. TearDown cleans up the
+    /// root and restores the previous active scene.
+    /// </summary>
+    public class IsolatedEditorSceneTest
+    {
+        private Scene previousScene;
+        private Scene testScene;
+        protected GameObject TestRoot { get; private set; }
+        private bool createdTempScene;
+
+        [SetUp]
+        public void IsolatedSceneSetUp()
+        {
+            previousScene = EditorSceneManager.GetActiveScene();
+
+            // Try to create an additive editor scene; if the active scene is
+            // unsaved or the editor forbids it, fall back to creating a root
+            // GameObject in the existing active scene.
+            createdTempScene = false;
+            try
+            {
+                testScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
+                EditorSceneManager.SetActiveScene(testScene);
+                createdTempScene = true;
+            }
+            catch (InvalidOperationException)
+            {
+                // Editor prevented creating an additive scene (untitled/unsaved).
+                // Fall back to using the current active scene and a temporary root GameObject.
+                createdTempScene = false;
+            }
+
+            // Create a root GameObject inside the active scene; derived tests
+            // should parent their test hierarchy under this root so TearDown can
+            // reliably clean it up.
+            TestRoot = new GameObject("VQT_TestRoot_" + Guid.NewGuid().ToString("N"));
+            if (createdTempScene && testScene.IsValid())
+            {
+                SceneManager.MoveGameObjectToScene(TestRoot, testScene);
+            }
+        }
+
+        [TearDown]
+        public void IsolatedSceneTearDown()
+        {
+            if (TestRoot != null)
+            {
+                UnityEngine.Object.DestroyImmediate(TestRoot);
+                TestRoot = null;
+            }
+
+            if (createdTempScene && testScene.IsValid())
+            {
+                // Close and unload the temporary scene (do not save)
+                EditorSceneManager.CloseScene(testScene, true);
+            }
+
+            if (previousScene.IsValid())
+            {
+                EditorSceneManager.SetActiveScene(previousScene);
+            }
+        }
+    }
+}
+#endif

--- a/Assets/VRCQuestTools-Tests/Editor/TestUtilities/IsolatedEditorSceneTest.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/TestUtilities/IsolatedEditorSceneTest.cs
@@ -1,3 +1,8 @@
+// <copyright file="IsolatedEditorSceneTest.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 #if UNITY_EDITOR
 using System;
 using NUnit.Framework;
@@ -64,7 +69,7 @@ namespace KRT.VRCQuestTools.TestUtilities
 
             if (createdTempScene && testScene.IsValid())
             {
-                // Close and unload the temporary scene (do not save)
+                // Close and unload the temporary scene (remove it from the hierarchy)
                 EditorSceneManager.CloseScene(testScene, true);
             }
 

--- a/Assets/VRCQuestTools-Tests/Editor/TestUtilities/IsolatedEditorSceneTest.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/TestUtilities/IsolatedEditorSceneTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: caa1e857095ea9e43bd8337dca4e1f0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/Views/PhysBonesRemoveWindowTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Views/PhysBonesRemoveWindowTests.cs
@@ -20,7 +20,7 @@ namespace KRT.VRCQuestTools.Views
     /// Tests for AvatarDynamicsSettingsUtility.Apply(VRC_AvatarDescriptor, ...)
     /// used by PhysBonesRemoveWindow's "Set Platform Component Remover" button.
     /// </summary>
-    public class PhysBonesRemoveWindowTests
+    public class PhysBonesRemoveWindowTests : KRT.VRCQuestTools.TestUtilities.IsolatedEditorSceneTest
     {
         private GameObject avatarRoot;
         private VRCAvatarDescriptor descriptor;
@@ -36,6 +36,7 @@ namespace KRT.VRCQuestTools.Views
         public void SetUp()
         {
             avatarRoot = new GameObject("TestAvatar");
+            avatarRoot.transform.SetParent(TestRoot.transform);
             descriptor = avatarRoot.AddComponent<VRCAvatarDescriptor>();
 
             boneObject = new GameObject("BoneObject");


### PR DESCRIPTION
Provide IsolatedEditorSceneTest that creates an additive editor scene when possible, falling back to a TestRoot GameObject in the active scene. Qualify UnityEngine.Object.DestroyImmediate to avoid ambiguous Object reference. Update tests to parent test objects under TestRoot so TearDown can clean up properly.