### PR TITLE
Derive occlusion strength from lilToon shadow colors in ToonStandard conversion

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/LilToonToonStandardGeneratorTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/LilToonToonStandardGeneratorTests.cs
@@ -746,5 +746,249 @@ namespace KRT.VRCQuestTools.Models
                 Assert.Greater(texture2D.height, 0, "Generated occlusion texture height should be greater than zero.");
             }
         }
+
+        /// <summary>
+        /// Test that ConvertToToonStandard derives OcclusionStrength from the shadow color floor luminance.
+        /// </summary>
+        [Test]
+        public void ConvertToToonStandard_SetsOcclusionStrengthFromShadowColor()
+        {
+            if (!IsLilToonTestEnvironmentAvailable())
+            {
+                return;
+            }
+
+            var shadowColor = new Color(0.5f, 0.5f, 0.5f, 1.0f);
+            using var sourceMaterial = DisposableObject.New(CreateLilToonMaterialWithAOMap());
+            sourceMaterial.Object.SetColor("_ShadowColor", shadowColor);
+            sourceMaterial.Object.SetColor("_Shadow2ndColor", new Color(0, 0, 0, 0));
+            sourceMaterial.Object.SetColor("_Shadow3rdColor", new Color(0, 0, 0, 0));
+            sourceMaterial.Object.SetFloat("_ShadowStrength", 1.0f);
+
+            var strength = GetGeneratedOcclusionStrength(sourceMaterial.Object, false);
+
+            var floor = Color.Lerp(Color.white, Color.white * shadowColor.linear, shadowColor.a);
+            var expected = 1.0f - Utils.ColorUtility.GetRec709Grayscale(floor);
+            Assert.AreEqual(expected, strength, 0.001f, "OcclusionStrength should match 1 - luminance of the linear shadow floor color.");
+            Assert.Less(strength, 1.0f, "OcclusionStrength should be less than the shader default 1.0.");
+        }
+
+        /// <summary>
+        /// Test that an enabled 2nd shadow color darkens the floor and increases OcclusionStrength.
+        /// </summary>
+        [Test]
+        public void ConvertToToonStandard_OcclusionStrengthIncreasesWithShadow2nd()
+        {
+            if (!IsLilToonTestEnvironmentAvailable())
+            {
+                return;
+            }
+
+            var shadowColor = new Color(0.7f, 0.65f, 0.72f, 1.0f);
+
+            using var baseMaterial = DisposableObject.New(CreateLilToonMaterialWithAOMap());
+            baseMaterial.Object.SetColor("_ShadowColor", shadowColor);
+            baseMaterial.Object.SetColor("_Shadow2ndColor", new Color(0, 0, 0, 0));
+            baseMaterial.Object.SetColor("_Shadow3rdColor", new Color(0, 0, 0, 0));
+            baseMaterial.Object.SetFloat("_ShadowStrength", 1.0f);
+            var strength1 = GetGeneratedOcclusionStrength(baseMaterial.Object, false);
+
+            using var secondShadowMaterial = DisposableObject.New(CreateLilToonMaterialWithAOMap());
+            secondShadowMaterial.Object.SetColor("_ShadowColor", shadowColor);
+            secondShadowMaterial.Object.SetColor("_Shadow2ndColor", new Color(0.2f, 0.2f, 0.2f, 1.0f));
+            secondShadowMaterial.Object.SetColor("_Shadow3rdColor", new Color(0, 0, 0, 0));
+            secondShadowMaterial.Object.SetFloat("_ShadowStrength", 1.0f);
+            var strength2 = GetGeneratedOcclusionStrength(secondShadowMaterial.Object, false);
+
+            Assert.Greater(strength2, strength1, "OcclusionStrength should increase when the 2nd shadow color darkens the floor.");
+        }
+
+        /// <summary>
+        /// Test that OcclusionStrength becomes zero when shadow strength is zero.
+        /// </summary>
+        [Test]
+        public void ConvertToToonStandard_OcclusionStrengthZeroWhenShadowStrengthZero()
+        {
+            if (!IsLilToonTestEnvironmentAvailable())
+            {
+                return;
+            }
+
+            using var sourceMaterial = DisposableObject.New(CreateLilToonMaterialWithAOMap());
+            sourceMaterial.Object.SetColor("_ShadowColor", new Color(0.5f, 0.5f, 0.5f, 1.0f));
+            sourceMaterial.Object.SetColor("_Shadow2ndColor", new Color(0, 0, 0, 0));
+            sourceMaterial.Object.SetColor("_Shadow3rdColor", new Color(0, 0, 0, 0));
+            sourceMaterial.Object.SetFloat("_ShadowStrength", 0.0f);
+
+            var strength = GetGeneratedOcclusionStrength(sourceMaterial.Object, false);
+
+            Assert.AreEqual(0.0f, strength, 0.001f, "OcclusionStrength should be zero when shadow strength is zero.");
+        }
+
+        /// <summary>
+        /// Test that the Quest texture generation path also sets OcclusionStrength.
+        /// </summary>
+        [Test]
+        public void GenerateMaterial_QuestTextures_SetsOcclusionStrength()
+        {
+            if (!IsLilToonTestEnvironmentAvailable())
+            {
+                return;
+            }
+
+            var shadowColor = new Color(0.5f, 0.5f, 0.5f, 1.0f);
+            using var aoMap = DisposableObject.New(new Texture2D(32, 32));
+            using var sourceMaterial = DisposableObject.New(CreateLilToonMaterialWithAOMap(aoMap.Object));
+            sourceMaterial.Object.SetColor("_ShadowColor", shadowColor);
+            sourceMaterial.Object.SetColor("_Shadow2ndColor", new Color(0, 0, 0, 0));
+            sourceMaterial.Object.SetColor("_Shadow3rdColor", new Color(0, 0, 0, 0));
+            sourceMaterial.Object.SetFloat("_ShadowStrength", 1.0f);
+
+            var strength = GetGeneratedOcclusionStrength(sourceMaterial.Object, true);
+
+            var floor = Color.Lerp(Color.white, Color.white * shadowColor.linear, shadowColor.a);
+            var expected = 1.0f - Utils.ColorUtility.GetRec709Grayscale(floor);
+            Assert.AreEqual(expected, strength, 0.001f, "OcclusionStrength should be set on the Quest texture generation path.");
+        }
+
+        /// <summary>
+        /// Test that the _ShadowAOShift remap is baked into the generated occlusion mask.
+        /// </summary>
+        [Test]
+        public void GenerateMaterial_QuestTextures_BakesShadowAOShiftIntoOcclusionMask()
+        {
+            if (!IsLilToonTestEnvironmentAvailable())
+            {
+                return;
+            }
+
+            using var aoMap = DisposableObject.New(new Texture2D(4, 4));
+            var pixels = new Color[4 * 4];
+            for (var i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = new Color(0.25f, 0.25f, 0.25f, 1.0f);
+            }
+            aoMap.Object.SetPixels(pixels);
+            aoMap.Object.Apply();
+
+            using var sourceMaterial = DisposableObject.New(CreateLilToonMaterialWithAOMap(aoMap.Object));
+
+            // Scale 0 and offset 1 remap every AO value to white regardless of color space conversion.
+            sourceMaterial.Object.SetVector("_ShadowAOShift", new Vector4(0.0f, 1.0f, 1.0f, 0.0f));
+            sourceMaterial.Object.SetColor("_Shadow2ndColor", new Color(0, 0, 0, 0));
+            sourceMaterial.Object.SetColor("_Shadow3rdColor", new Color(0, 0, 0, 0));
+
+            var resultMat = GenerateMaterial(sourceMaterial.Object, true);
+            using var resultMaterial = DisposableObject.New(resultMat);
+            var resultWrapper = new ToonStandardMaterialWrapper(resultMat);
+
+            Assert.IsTrue(resultWrapper.UseOcclusion, "UseOcclusion should be enabled.");
+            var occlusionMap = resultWrapper.OcclusionMap as Texture2D;
+            Assert.IsNotNull(occlusionMap, "Occlusion map should be generated as Texture2D.");
+
+            var sample = SampleCenterPixel(occlusionMap);
+            Assert.GreaterOrEqual(sample.g, 0.99f, "AO values remapped by _ShadowAOShift should be baked as white.");
+        }
+
+        private static bool IsLilToonTestEnvironmentAvailable()
+        {
+            if (!AssetUtility.IsLilToonImported())
+            {
+                Assert.Ignore("lilToon is not installed.");
+                return false;
+            }
+
+            var lilToonVersion = AssetUtility.LilToonVersion;
+            var requiredVersion = new SemVer(1, 10, 0);
+            var breakingVersion = new SemVer(3, 0, 0);
+            if (lilToonVersion < requiredVersion || lilToonVersion >= breakingVersion)
+            {
+                Assert.Ignore($"lilToon version {lilToonVersion} is not supported.");
+                return false;
+            }
+
+            if (Shader.Find("VRChat/Mobile/Toon Standard") == null)
+            {
+                Assert.Ignore("VRChat/Mobile/Toon Standard shader not available.");
+                return false;
+            }
+
+            if (Shader.Find("lilToon") == null)
+            {
+                Assert.Ignore("lilToon shader not available.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static Material CreateLilToonMaterialWithAOMap(Texture2D aoMap = null)
+        {
+            var material = new Material(Shader.Find("lilToon"));
+            material.SetFloat("_UseShadow", 1);
+            material.SetTexture("_ShadowBorderMask", aoMap != null ? aoMap : Texture2D.whiteTexture);
+            return material;
+        }
+
+        private static Material GenerateMaterial(Material sourceMaterial, bool generateQuestTextures)
+        {
+            var settings = new ToonStandardConvertSettings
+            {
+                generateQuestTextures = generateQuestTextures,
+                maxTextureSize = TextureSizeLimit.NoLimit,
+                maskMaxTextureSize = TextureSizeLimit.NoLimit,
+            };
+            settings.SetAllFeatures(false);
+            settings.useOcclusion = true;
+
+            var lilMat = new LilToonMaterial(sourceMaterial);
+            var generator = new LilToonToonStandardGenerator(lilMat, settings, null, false);
+
+            Material resultMat = null;
+            generator.GenerateMaterial(lilMat, UnityEditor.BuildTarget.Android, false, string.Empty, (mat) =>
+            {
+                resultMat = mat;
+            }).WaitForCompletion();
+
+            Assert.IsNotNull(resultMat, "Generated material should not be null.");
+            return resultMat;
+        }
+
+        private static Color SampleCenterPixel(Texture2D texture)
+        {
+            // The baked texture may be non-readable, so read pixels back through a temporary RenderTexture.
+            var rt = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
+            var previous = RenderTexture.active;
+            try
+            {
+                Graphics.Blit(texture, rt);
+                RenderTexture.active = rt;
+                var readable = new Texture2D(texture.width, texture.height, TextureFormat.RGBA32, false, true);
+                try
+                {
+                    readable.ReadPixels(new Rect(0, 0, texture.width, texture.height), 0, 0);
+                    readable.Apply(false, false);
+                    return readable.GetPixel(texture.width / 2, texture.height / 2);
+                }
+                finally
+                {
+                    Object.DestroyImmediate(readable);
+                }
+            }
+            finally
+            {
+                RenderTexture.active = previous;
+                RenderTexture.ReleaseTemporary(rt);
+            }
+        }
+
+        private static float GetGeneratedOcclusionStrength(Material sourceMaterial, bool generateQuestTextures)
+        {
+            var resultMat = GenerateMaterial(sourceMaterial, generateQuestTextures);
+            using var resultMaterial = DisposableObject.New(resultMat);
+            var resultWrapper = new ToonStandardMaterialWrapper(resultMat);
+            Assert.IsTrue(resultWrapper.UseOcclusion, "UseOcclusion should be enabled.");
+            return resultWrapper.OcclusionStrength;
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed RenderTexture and Material memory leaks in texture generation pipeline during avatar conversion.
 - Fixed an issue where texture generation failed when a material used an un-rendered RenderTexture as a texture.
 - Limited stack trace lines shown in avatar conversion failure dialog to keep the dialog operable.
+- Fixed lilToon to Toon Standard conversion producing overly dark results by deriving occlusion strength from the lilToon shadow colors instead of always applying full-strength occlusion.
 
 ### Removed
 - Removed support for Unity 2019.

--- a/CHANGELOG_JP.md
+++ b/CHANGELOG_JP.md
@@ -21,7 +21,7 @@
 - `VQT Fallback Avatar` コンポーネントを追加。モバイルプラットフォームのパフォーマンス要件（Good以上）を満たした場合、アップロード後に自動的にアバターをフォールバックアバターとして設定します。
 - Mobile向けアップロード時、Avatar Dynamics のカテゴリが Very Poor の場合に警告ログを表示するよう追加。
 - (実験的機能) Poiyomi から Toon Standard へのマテリアル変換を追加。
-- パーティクルシェーダー、パーティクルシステム、Trail Renderer、Line Renderer 専用のマテリアル変換を追加。
+- パーティクルシェーダー、パーティクルシステム、Trail Renderer、Line Renderer 専用のマテリアル変換を追加。
 
 ### 変更
 - Avatar Dynamics Selector の保持/削除設定を `Avatar Converter Settings` のレガシー配列ではなく `Platform Component Remover` に保存するように変更。適用時に設定を移行し、古い参照が残らないようレガシー配列をクリアします。
@@ -50,6 +50,7 @@
 - アバター変換時のテクスチャ生成処理における RenderTexture と Material のメモリリークを修正。
 - 一度も描画されていない RenderTexture をテクスチャとして使用しているマテリアルのテクスチャ生成が失敗する問題を修正。
 - アバター変換失敗ダイアログに表示するスタックトレースの行数を制限し、ダイアログが操作不能になる問題を修正。
+- lilToon から Toon Standard への変換結果が暗くなりすぎる問題を修正。Occlusion の強度を常にフル適用するのではなく、lilToon の陰影色から算出するように変更。
 
 ### 削除
 - Unity 2019 のサポートを終了。

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/GenericToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/GenericToonStandardGenerator.cs
@@ -245,6 +245,12 @@ namespace KRT.VRCQuestTools.Models
         }
 
         /// <inheritdoc/>
+        protected override float GetOcclusionStrength()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
         protected override float GetReflectance()
         {
             throw new NotImplementedException();

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/LilToonToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/LilToonToonStandardGenerator.cs
@@ -78,9 +78,12 @@ namespace KRT.VRCQuestTools.Models
             if (lilMaterial.UseShadow && lilMaterial.AOMap != null && Settings.useOcclusion)
             {
                 newMaterial.UseOcclusion = true;
+
+                // The original texture is assigned directly, so _ShadowAOShift remapping is not applied here.
                 newMaterial.OcclusionMap = lilMaterial.AOMap;
                 newMaterial.OcclusionMapTextureScale = lilMaterial.AOMapTextureScale;
                 newMaterial.OcclusionMapTextureOffset = lilMaterial.AOMapTextureOffset;
+                newMaterial.OcclusionStrength = GetOcclusionStrength();
             }
 
             if (lilMaterial.UseReflection && Settings.useSpecular)
@@ -582,17 +585,25 @@ namespace KRT.VRCQuestTools.Models
 
             var swizzleMat = new Material(Shader.Find("Hidden/VRCQuestTools/Swizzle"));
             swizzleMat.SetTexture("_Texture0", aoMap);
+
+            // Bake the _ShadowAOShift remap (saturate(v * scale + offset)) of the selected channel into the mask.
             if (lilMaterial.UseShadow3rd)
             {
                 swizzleMat.SetFloat("_Texture0Input", 2);
+                swizzleMat.SetFloat("_Texture0Scale", lilMaterial.ShadowAOShift2.x);
+                swizzleMat.SetFloat("_Texture0Offset", lilMaterial.ShadowAOShift2.y);
             }
             else if (lilMaterial.UseShadow2nd)
             {
                 swizzleMat.SetFloat("_Texture0Input", 1);
+                swizzleMat.SetFloat("_Texture0Scale", lilMaterial.ShadowAOShift.z);
+                swizzleMat.SetFloat("_Texture0Offset", lilMaterial.ShadowAOShift.w);
             }
             else
             {
                 swizzleMat.SetFloat("_Texture0Input", 0);
+                swizzleMat.SetFloat("_Texture0Scale", lilMaterial.ShadowAOShift.x);
+                swizzleMat.SetFloat("_Texture0Offset", lilMaterial.ShadowAOShift.y);
             }
             swizzleMat.SetFloat("_Texture0Output", 1); // G
 
@@ -1019,6 +1030,31 @@ namespace KRT.VRCQuestTools.Models
         protected override (Vector2 Scale, Vector2 Offset) GetOcculusionMapST()
         {
             return (lilMaterial.AOMapTextureScale, lilMaterial.AOMapTextureOffset);
+        }
+
+        /// <inheritdoc/>
+        protected override float GetOcclusionStrength()
+        {
+            // lilToon's AO map only shifts shadow borders, so the darkest achievable color is bounded by
+            // the shadow color chain. Derive the strength so that Toon Standard's lerp(1, sample, strength)
+            // never darkens below the luminance of the fully shadowed color.
+            // Shadow colors are composed in linear space by the shader, so convert sRGB inspector values first.
+            var floor = Color.white;
+            var c1 = lilMaterial.ShadowColor;
+            floor = Color.Lerp(floor, floor * c1.linear, c1.a);
+            if (lilMaterial.UseShadow2nd)
+            {
+                var c2 = lilMaterial.Shadow2ndColor;
+                floor = Color.Lerp(floor, floor * c2.linear, c2.a);
+            }
+            if (lilMaterial.UseShadow3rd)
+            {
+                var c3 = lilMaterial.Shadow3rdColor;
+                floor = Color.Lerp(floor, floor * c3.linear, c3.a);
+            }
+            floor = Color.Lerp(Color.white, floor, lilMaterial.ShadowStrength);
+            var floorBrightness = Utils.ColorUtility.GetRec709Grayscale(floor);
+            return Mathf.Clamp01(1.0f - floorBrightness);
         }
 
         /// <inheritdoc/>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/PoiyomiToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/PoiyomiToonStandardGenerator.cs
@@ -839,6 +839,13 @@ namespace KRT.VRCQuestTools.Models
         }
 
         /// <inheritdoc/>
+        protected override float GetOcclusionStrength()
+        {
+            var (_, strength) = GetPrimaryAOChannelAndStrength();
+            return strength;
+        }
+
+        /// <inheritdoc/>
         protected override float GetReflectance()
         {
             switch (GetSpecularSource())

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/ToonStandardGenerator.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/ToonStandardGenerator.cs
@@ -246,6 +246,7 @@ namespace KRT.VRCQuestTools.Models
                 if (GetUseOcclusionMap() && Settings.useOcclusion)
                 {
                     newMaterial.UseOcclusion = true;
+                    newMaterial.OcclusionStrength = GetOcclusionStrength();
                     masks.Add(MaskType.OcculusionMap);
                 }
 
@@ -468,6 +469,12 @@ namespace KRT.VRCQuestTools.Models
         /// </summary>
         /// <returns>Scale and offset.</returns>
         protected abstract (Vector2 Scale, Vector2 Offset) GetOcculusionMapST();
+
+        /// <summary>
+        /// Gets the occlusion strength of the material.
+        /// </summary>
+        /// <returns>Occlusion strength.</returns>
+        protected abstract float GetOcclusionStrength();
 
         /// <summary>
         /// Gets the material should use occulusion map.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/Unity/LilToonMaterial.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/Unity/LilToonMaterial.cs
@@ -107,6 +107,26 @@ namespace KRT.VRCQuestTools.Models.Unity
         internal bool UseShadow3rd => UseShadow && Material.GetColor("_Shadow3rdColor").a > 0.0f;
 
         /// <summary>
+        /// Gets the 1st shadow color.
+        /// </summary>
+        internal Color ShadowColor => Material.GetColor("_ShadowColor");
+
+        /// <summary>
+        /// Gets the 2nd shadow color.
+        /// </summary>
+        internal Color Shadow2ndColor => Material.GetColor("_Shadow2ndColor");
+
+        /// <summary>
+        /// Gets the 3rd shadow color.
+        /// </summary>
+        internal Color Shadow3rdColor => Material.GetColor("_Shadow3rdColor");
+
+        /// <summary>
+        /// Gets the shadow strength.
+        /// </summary>
+        internal float ShadowStrength => Material.GetFloat("_ShadowStrength");
+
+        /// <summary>
         /// Gets a value indicating whether to use main 2nd texture.
         /// </summary>
         internal bool UseMain2ndTex => Material.GetFloat("_UseMain2ndTex") > 0.5f;
@@ -140,6 +160,16 @@ namespace KRT.VRCQuestTools.Models.Unity
         /// Gets the ao map texture offset.
         /// </summary>
         internal Vector2 AOMapTextureOffset => Material.GetTextureOffset("_ShadowBorderMask");
+
+        /// <summary>
+        /// Gets the AO map remap parameters for 1st and 2nd shadows (x: 1st scale, y: 1st offset, z: 2nd scale, w: 2nd offset).
+        /// </summary>
+        internal Vector4 ShadowAOShift => Material.GetVector("_ShadowAOShift");
+
+        /// <summary>
+        /// Gets the AO map remap parameters for 3rd shadow (x: 3rd scale, y: 3rd offset).
+        /// </summary>
+        internal Vector4 ShadowAOShift2 => Material.GetVector("_ShadowAOShift2");
 
         /// <summary>
         /// Gets cull mode.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Shader/vqt_swizzle.shader
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Shader/vqt_swizzle.shader
@@ -5,6 +5,8 @@ Shader "Hidden/VRCQuestTools/Swizzle"
         _Texture0 ("Texture 0", 2D) = "white" {}
         [Enum(R, 0, G, 1, B, 2, A, 3, Grayscale, 4)] _Texture0Input ("Texture 0 Input", Int) = 0
         [Enum(R, 0, G, 1, B, 2, A, 3)] _Texture0Output ("Texture 0 Output", Int) = -1
+        _Texture0Scale ("Texture 0 Scale", Float) = 1
+        _Texture0Offset ("Texture 0 Offset", Float) = 0
 
         _Texture1 ("Texture 1", 2D) = "white" {}
         [Enum(R, 0, G, 1, B, 2, A, 3, Grayscale, 4)] _Texture1Input ("Texture 1 Input", Int) = 1
@@ -47,6 +49,8 @@ Shader "Hidden/VRCQuestTools/Swizzle"
             float4 _Texture0_ST;
             float _Texture0Input;
             float _Texture0Output;
+            float _Texture0Scale;
+            float _Texture0Offset;
 
             sampler2D _Texture1;
             float4 _Texture1_ST;
@@ -93,6 +97,7 @@ Shader "Hidden/VRCQuestTools/Swizzle"
 
                 fixed4 input0 = tex2D(_Texture0, i.uv);
                 float value0 = swizzleInput(input0, _Texture0Input);
+                value0 = saturate(value0 * _Texture0Scale + _Texture0Offset);
                 if (_Texture0Output == 0) {
                     output.r = value0;
                 } else if (_Texture0Output == 1) {


### PR DESCRIPTION
lilToon's AO map (_ShadowBorderMask) only shifts shadow borders, but the conversion copied it into Toon Standard's occlusion map with the shader default _OcclusionStrength of 1.0, multiplying both direct and indirect light down to black and making converted avatars too dark.

Compute the fully shadowed floor color from the shadow color chain (1st/2nd/3rd colors and _ShadowStrength) in linear space and set _OcclusionStrength to 1 - Rec.709 luminance of that floor, so the AO map never darkens below what lilToon's shadows could produce. Also bake the _ShadowAOShift remap into the generated occlusion mask, and wire the occlusion strength through the Quest texture generation path, which previously left it unset for all generators including Poiyomi.