### PR TITLE
Gray out and label EditorOnly components in Avatar Dynamics Selector / PhysBones Remover

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/Utils/VRCSDKUtilityTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/VRCSDKUtilityTests.cs
@@ -111,5 +111,35 @@ namespace KRT.VRCQuestTools.Utils
             Assert.AreEqual(i18n.ContactsWillBeRemovedAtRunTime, VRCSDKUtility.GetAvatarDynamicsVeryPoorViolationMessage(AvatarPerformanceCategory.ContactCount, i18n));
             Assert.Throws<System.InvalidProgramException>(() => VRCSDKUtility.GetAvatarDynamicsVeryPoorViolationMessage(AvatarPerformanceCategory.Overall, i18n));
         }
+
+        /// <summary>
+        /// IsEditorOnlyInHierarchy test.
+        /// </summary>
+        [Test]
+        public void IsEditorOnlyInHierarchy()
+        {
+            var root = new GameObject("Root");
+            var editorOnlyChild = new GameObject("EditorOnlyChild");
+            editorOnlyChild.tag = "EditorOnly";
+            editorOnlyChild.transform.SetParent(root.transform);
+            var grandchild = new GameObject("Grandchild");
+            grandchild.transform.SetParent(editorOnlyChild.transform);
+            var normalChild = new GameObject("NormalChild");
+            normalChild.transform.SetParent(root.transform);
+
+            try
+            {
+                Assert.IsTrue(VRCSDKUtility.IsEditorOnlyInHierarchy(root, editorOnlyChild), "the object itself is tagged as EditorOnly");
+                Assert.IsTrue(VRCSDKUtility.IsEditorOnlyInHierarchy(root, grandchild), "a descendant of an EditorOnly object is EditorOnly");
+                Assert.IsFalse(VRCSDKUtility.IsEditorOnlyInHierarchy(root, normalChild), "an untagged object under untagged parents is not EditorOnly");
+
+                root.tag = "EditorOnly";
+                Assert.IsFalse(VRCSDKUtility.IsEditorOnlyInHierarchy(root, normalChild), "the walk stops before checking the avatar root's own tag");
+            }
+            finally
+            {
+                Object.DestroyImmediate(root);
+            }
+        }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
@@ -219,6 +219,7 @@ namespace KRT.VRCQuestTools.I18n
         internal string SelectAllButtonLabel => GetText("SelectAllButtonLabel");
         internal string DeselectAllButtonLabel => GetText("DeselectAllButtonLabel");
         internal string ApplyButtonLabel => GetText("ApplyButtonLabel");
+        internal string EditorOnlyTooltip => GetText("EditorOnlyTooltip");
 
         // Metallic Smoothness
         internal string TextureLabel => GetText("TextureLabel");

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
@@ -452,6 +452,9 @@ msgstr "Deselect All"
 msgid "ApplyButtonLabel"
 msgstr "Apply"
 
+msgid "EditorOnlyTooltip"
+msgstr "This object is tagged as EditorOnly. VRChat SDK removes it when building the avatar."
+
 msgid "TextureLabel"
 msgstr "Texture"
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
@@ -452,6 +452,9 @@ msgstr "すべて解除"
 msgid "ApplyButtonLabel"
 msgstr "適用"
 
+msgid "EditorOnlyTooltip"
+msgstr "このオブジェクトにはEditorOnlyタグが設定されています。アバターのビルド時にVRChat SDKによって削除されます。"
+
 msgid "TextureLabel"
 msgstr "テクスチャ"
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
@@ -393,6 +393,9 @@ msgstr "Снять выделение"
 msgid "ApplyButtonLabel"
 msgstr "Применить"
 
+msgid "EditorOnlyTooltip"
+msgstr ""
+
 msgid "TextureLabel"
 msgstr "Текстура"
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRChat/AvatarDynamics.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRChat/AvatarDynamics.cs
@@ -78,14 +78,14 @@ namespace KRT.VRCQuestTools.Models.VRChat
         private static int CalculatePhysBonesCollisionCheckCount(GameObject root, VRCPhysBone[] physbones, VRCPhysBoneCollider[] colliders)
         {
             // exclude editor only physbones
-            var actualPbs = physbones.Where((obj) => !IsFinallyEditorOnly(root, obj.gameObject));
+            var actualPbs = physbones.Where((obj) => !VRCSDKUtility.IsEditorOnlyInHierarchy(root, obj.gameObject));
             var collisions = actualPbs.Select((pb) =>
             {
                 var transformCount = CalculatePhysBoneTransformCount(pb) - 1; // ignore itself.
                 var rootTrans = pb.rootTransform == null ? pb.gameObject.transform : pb.rootTransform;
 
                 var multiChildRoots = rootTrans.GetComponentsInChildren<Transform>(true)
-                    .Where(t => !IsFinallyEditorOnly(root, t.gameObject))
+                    .Where(t => !VRCSDKUtility.IsEditorOnlyInHierarchy(root, t.gameObject))
                     .Where(t => IsMultiChildRoot(pb, t))
                     .ToArray();
                 transformCount -= multiChildRoots.Sum(t => t.childCount);
@@ -101,7 +101,7 @@ namespace KRT.VRCQuestTools.Models.VRChat
                     var endpoints = rootTrans.GetComponentsInChildren<Transform>(true)
                         .Where(t => t.childCount == 0)
                         .Where(t => !IsIgnoredTransform(t, ignore))
-                        .Where(t => !IsFinallyEditorOnly(root, t.gameObject));
+                        .Where(t => !VRCSDKUtility.IsEditorOnlyInHierarchy(root, t.gameObject));
                     transformCount += endpoints.Count();
                 }
 
@@ -123,25 +123,12 @@ namespace KRT.VRCQuestTools.Models.VRChat
         private static VRCPhysBone[] GetActualPhysBones(GameObject root, VRCPhysBone[] physbones)
         {
             // exclude editor only physbones
-            return physbones.Where(obj => !IsFinallyEditorOnly(root, obj.gameObject)).ToArray();
+            return physbones.Where(obj => !VRCSDKUtility.IsEditorOnlyInHierarchy(root, obj.gameObject)).ToArray();
         }
 
         private static bool IsColliderReferencedByPhysBone(VRCPhysBoneCollider collider, VRCPhysBone physBone)
         {
             return physBone.colliders.Contains(collider);
-        }
-
-        private static bool IsFinallyEditorOnly(GameObject root, GameObject obj)
-        {
-            if (obj.tag == "EditorOnly")
-            {
-                return true;
-            }
-            if (obj.transform.parent == null || obj.transform.parent.gameObject == root)
-            {
-                return false;
-            }
-            return IsFinallyEditorOnly(root, obj.transform.parent.gameObject);
         }
 
         private static bool IsIgnoredTransform(Transform transform, Transform[] ignoreTransforms)

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/VRCSDKUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/VRCSDKUtility.cs
@@ -590,6 +590,25 @@ namespace KRT.VRCQuestTools.Utils
             return null;
         }
 
+        /// <summary>
+        /// Gets whether the game object is finally "EditorOnly" in the avatar, i.e. the object itself or
+        /// any ancestor below the avatar root is tagged as "EditorOnly". Such objects are removed by VRCSDK on build.
+        /// </summary>
+        /// <param name="avatarRoot">Avatar root object.</param>
+        /// <param name="gameObject">Game object to test.</param>
+        /// <returns>true when the object is effectively EditorOnly.</returns>
+        internal static bool IsEditorOnlyInHierarchy(GameObject avatarRoot, GameObject gameObject)
+        {
+            if (gameObject.tag == "EditorOnly")
+            {
+                return true;
+            }
+            if (gameObject.transform.parent == null || gameObject.transform.parent.gameObject == avatarRoot)
+            {
+                return false;
+            }
+            return IsEditorOnlyInHierarchy(avatarRoot, gameObject.transform.parent.gameObject);
+        }
 
         /// <summary>
         /// Stripes unused network ids from the avatar.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/VRCSDKUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/VRCSDKUtility.cs
@@ -591,8 +591,8 @@ namespace KRT.VRCQuestTools.Utils
         }
 
         /// <summary>
-        /// Gets whether the game object is finally "EditorOnly" in the avatar, i.e. the object itself or
-        /// any ancestor below the avatar root is tagged as "EditorOnly". Such objects are removed by VRCSDK on build.
+        /// Gets whether the game object is effectively "EditorOnly" in the avatar hierarchy, i.e. the object itself or
+        /// any ancestor below the avatar root is tagged as "EditorOnly". Such objects are removed by VRCSDK during build.
         /// </summary>
         /// <param name="avatarRoot">Avatar root object.</param>
         /// <param name="gameObject">Game object to test.</param>

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/EditorGUIUtility.cs
@@ -122,8 +122,9 @@ namespace KRT.VRCQuestTools.Views
         /// <param name="objects">Components to list.</param>
         /// <param name="selectedObjects">Already selected components.</param>
         /// <param name="componentFieldIndent">Left offset (px) of the component field, so it aligns under the group header label.</param>
+        /// <param name="avatarRoot">Avatar root GameObject used to detect components under an EditorOnly-tagged object. When null, EditorOnly detection is skipped.</param>
         /// <returns>New selected components.</returns>
-        internal static T[] AvatarDynamicsComponentSelectorList<T>(T[] objects, T[] selectedObjects, float componentFieldIndent = 0f)
+        internal static T[] AvatarDynamicsComponentSelectorList<T>(T[] objects, T[] selectedObjects, float componentFieldIndent = 0f, GameObject avatarRoot = null)
             where T : IVRCAvatarDynamicsProvider
         {
             var afterSelected = new List<T>();
@@ -132,7 +133,8 @@ namespace KRT.VRCQuestTools.Views
 
             foreach (var obj in objects)
             {
-                var isSelected = ToggleAvatarDynamicsComponentField(selectedComponents.Contains(obj.Component), obj, componentFieldIndent);
+                var isEditorOnly = avatarRoot != null && VRCSDKUtility.IsEditorOnlyInHierarchy(avatarRoot, obj.GameObject);
+                var isSelected = ToggleAvatarDynamicsComponentField(selectedComponents.Contains(obj.Component), obj, componentFieldIndent, isEditorOnly);
 
                 // Check for hover on the last drawn control
                 var currentEvent = Event.current;
@@ -269,7 +271,7 @@ namespace KRT.VRCQuestTools.Views
                     // Align each item's component field under the group header label. The right (RootTransform)
                     // column stays fixed, so the component field width shrinks as the group is nested deeper.
                     var currentGroupSelected = groupArray.Where(o => selectedComponents.Contains(o.Component)).ToArray();
-                    var newGroupSelected = AvatarDynamicsComponentSelectorList(groupArray, currentGroupSelected, labelOffset);
+                    var newGroupSelected = AvatarDynamicsComponentSelectorList(groupArray, currentGroupSelected, labelOffset, avatarRoot);
                     var newSet = new HashSet<Component>(newGroupSelected.Select(o => o.Component));
                     foreach (var o in groupArray)
                     {
@@ -294,13 +296,16 @@ namespace KRT.VRCQuestTools.Views
         /// <param name="value">Current state.</param>
         /// <param name="provider">Provider to show.</param>
         /// <param name="componentFieldIndent">Left offset (px) of the component field so it aligns under the group header label.</param>
+        /// <param name="isEditorOnly">Whether the component is under an EditorOnly-tagged object. When true, an "EO" label is shown next to the checkbox and the component/root fields are grayed out.</param>
         /// <returns>true for selected.</returns>
-        internal static bool ToggleAvatarDynamicsComponentField(bool value, IVRCAvatarDynamicsProvider provider, float componentFieldIndent = 0f)
+        internal static bool ToggleAvatarDynamicsComponentField(bool value, IVRCAvatarDynamicsProvider provider, float componentFieldIndent = 0f, bool isEditorOnly = false)
         {
             const float checkBoxWidth = 16f;
             const float gap = 2f;
             const float minComponentWidth = 80f;
+            const string editorOnlyLabelText = "EO"; // Abbreviation of Unity's "EditorOnly" tag name; not localized.
             var lineHeight = UnityEditor.EditorGUIUtility.singleLineHeight;
+            var i18n = VRCQuestToolsSettings.I18nResource;
 
             var prevIndent = EditorGUI.indentLevel;
             EditorGUI.indentLevel = 0;
@@ -316,16 +321,41 @@ namespace KRT.VRCQuestTools.Views
             var maxComponentX = Mathf.Max(minComponentX, half - gap - minComponentWidth);
             var componentX = Mathf.Clamp(componentFieldIndent, minComponentX, maxComponentX);
             var checkRect = new Rect(rowRect.x + componentX - gap - checkBoxWidth, rowRect.y, checkBoxWidth, lineHeight);
-            var componentWidth = Mathf.Max(0f, half - gap - componentX);
-            var componentRect = new Rect(rowRect.x + componentX, rowRect.y, componentWidth, lineHeight);
             var rootWidth = Mathf.Max(0f, rowRect.width - half - gap);
             var rootRect = new Rect(rowRect.x + half + gap, rowRect.y, rootWidth, lineHeight);
 
+            // When EditorOnly, an "EO" text label is inserted right after the checkbox so it's noticed while
+            // scanning the checkbox column, and the component field's start is pushed right to make room.
+            // Non-EditorOnly rows are unaffected, so normal rows keep their shared group alignment.
+            var componentStartX = rowRect.x + componentX;
+            Rect editorOnlyLabelRect = default;
+            GUIContent editorOnlyLabelContent = null;
+            if (isEditorOnly)
+            {
+                editorOnlyLabelContent = new GUIContent(editorOnlyLabelText, i18n.EditorOnlyTooltip);
+                var editorOnlyLabelWidth = EditorStyles.miniBoldLabel.CalcSize(editorOnlyLabelContent).x;
+                editorOnlyLabelRect = new Rect(checkRect.xMax + gap, rowRect.y, editorOnlyLabelWidth, lineHeight);
+                componentStartX = Mathf.Max(componentStartX, editorOnlyLabelRect.xMax + gap);
+            }
+            var componentWidth = Mathf.Max(0f, half - gap - (componentStartX - rowRect.x));
+            var componentRect = new Rect(componentStartX, rowRect.y, componentWidth, lineHeight);
+
             var selected = EditorGUI.Toggle(checkRect, value);
+            var prevColor = GUI.color;
+            if (isEditorOnly)
+            {
+                GUI.color = prevColor * new Color(1f, 1f, 1f, 0.5f);
+            }
             using (new EditorGUI.DisabledScope(true))
             {
                 EditorGUI.ObjectField(componentRect, provider.Component, typeof(Component), true);
                 EditorGUI.ObjectField(rootRect, VRCSDKUtility.GetRootTransform(provider.Component), typeof(Transform), true);
+            }
+            GUI.color = prevColor;
+            if (isEditorOnly)
+            {
+                // Drawn at full opacity (after the tint is restored) so the label stays noticeable.
+                GUI.Label(editorOnlyLabelRect, editorOnlyLabelContent, EditorStyles.miniBoldLabel);
             }
             return selected;
         }


### PR DESCRIPTION
EditorOnly-tagged objects are stripped by VRCSDK at build time and already excluded from performance stats, but PhysBones/Colliders/Contacts under them were listed identically to normal components, which was confusing. Rows now show a bold "EO" label next to the checkbox and gray out the component/root fields, while keeping the checkbox interactive.