### PR TITLE
Fix NDMF preview not reflecting reactivated objects

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
@@ -84,7 +84,7 @@ namespace KRT.VRCQuestTools.Ndmf
                 context.Observe(rootConversion, c => AvatarConverterPassUtility.ResolveAvatarConverterNdmfPhase(c.gameObject));
             }
 
-            return rootConversions.Select(root => root.GetComponentsInChildren<Renderer>().Where(r => r is SkinnedMeshRenderer || r is MeshRenderer))
+            return rootConversions.Select(root => context.GetComponentsInChildren<Renderer>(root.gameObject, true).Where(r => r is SkinnedMeshRenderer || r is MeshRenderer))
                 .Where(r => r.Any())
                 .Select(r => RenderGroup.For(r))
                 .ToImmutableList();

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/VertexColorRemoverFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/VertexColorRemoverFilter.cs
@@ -38,7 +38,7 @@ namespace KRT.VRCQuestTools.Ndmf
                 .ToArray();
 
             return rootConversions
-                .SelectMany(root => root.GetComponentsInChildren<Renderer>())
+                .SelectMany(root => context.GetComponentsInChildren<Renderer>(root.gameObject, true))
                 .Distinct()
                 .Where(renderer => renderer is SkinnedMeshRenderer || renderer is MeshRenderer)
                 .Select(renderer => RenderGroup.For(renderer))


### PR DESCRIPTION
Material conversion and vertex color removal previews collected target renderers via the plain Unity `GetComponentsInChildren<Renderer>()` (includeInactive: false), so renderers on initially-inactive objects were never added to the NDMF TargetSet render groups. Because active state was not observed either, toggling such an object on afterwards did not re-run GetTargetGroups, and NDMF's ResolveActiveStages (which observes ActiveInHierarchy) could not re-include a renderer that was absent from the groups. The preview therefore kept showing the unconverted material.

Use the ComputeContext-based `GetComponentsInChildren<Renderer>(gameObject, true)` in MaterialConversionFilter and VertexColorRemoverFilter so inactive renderers are included (matching build-time collection, which uses includeInactive: true) and hierarchy structure changes are observed. NDMF then reactivates and converts the renderer when the object is turned on.