### PR TITLE
Add NDMF pipeline-level EditMode tests for NDMF passes

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AssignNetworkIDsPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AssignNetworkIDsPassTests.cs
@@ -1,0 +1,102 @@
+// <copyright file="AssignNetworkIDsPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System.Text.RegularExpressions;
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Guard-clause tests for <see cref="AssignNetworkIDsPass"/> driven through NDMF's
+    /// <see cref="BuildContext"/>. Exact PhysBone network ID assignment is covered by
+    /// <c>VRCSDKUtility</c>-level tests, not here; this only covers the branches that decide
+    /// whether assignment or the missing-assigner warning happens at all.
+    /// </summary>
+    public class AssignNetworkIDsPassTests
+    {
+        private GameObject root;
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (root != null)
+            {
+                Object.DestroyImmediate(root);
+                root = null;
+            }
+
+            builder?.Destroy();
+            builder = null;
+        }
+
+        /// <summary>
+        /// Without a VRCAvatarDescriptor at all, the pass must not attempt any assignment.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoAvatarDescriptor()
+        {
+            root = new GameObject("NoDescriptor");
+
+            var context = new BuildContext(root, null);
+            Assert.DoesNotThrow(() => AssignNetworkIDsPass.Instance.RunForTest(context));
+        }
+
+        /// <summary>
+        /// With a VRCAvatarDescriptor but no NetworkIDAssigner and no AvatarConverterSettings, the
+        /// pass has nothing to check assignment against and must not report a warning.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoAssignerAndNoSettings()
+        {
+            builder = new NdmfTestAvatarBuilder();
+
+            var context = new BuildContext(builder.Root, null);
+            Assert.DoesNotThrow(() => AssignNetworkIDsPass.Instance.RunForTest(context));
+        }
+
+        /// <summary>
+        /// With AvatarConverterSettings.assignNetworkIds disabled and a PhysBone whose network ID is
+        /// missing, the pass must report a warning telling the user to add a NetworkIDAssigner instead
+        /// of silently leaving the PhysBone unsynchronized between platforms.
+        /// </summary>
+        [Test]
+        public void Execute_ReportsWarning_WhenIdsAreMissingAndAssignmentIsDisabled()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.assignNetworkIds = false;
+            builder.Root.AddComponent<VRCPhysBone>();
+
+            var context = new BuildContext(builder.Root, null);
+            LogAssert.Expect(LogType.Warning, new Regex(@"^\[NDMF\] Error Reported: "));
+            AssignNetworkIDsPass.Instance.RunForTest(context);
+        }
+
+        /// <summary>
+        /// With AvatarConverterSettings.assignNetworkIds enabled, the pass must attempt assignment
+        /// rather than reporting the missing-assigner warning.
+        /// </summary>
+        [Test]
+        public void Execute_AssignsIds_WhenAssignmentIsEnabled()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.assignNetworkIds = true;
+            builder.Root.AddComponent<VRCPhysBone>();
+
+            var context = new BuildContext(builder.Root, null);
+            Assert.DoesNotThrow(() => AssignNetworkIDsPass.Instance.RunForTest(context));
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AssignNetworkIDsPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AssignNetworkIDsPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06bc78fa097a1884fb72d3732cb01444
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterOptimizingPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterOptimizingPassTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="AvatarConverterOptimizingPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Guard-clause tests for <see cref="AvatarConverterOptimizingPass"/> driven through NDMF's
+    /// <see cref="BuildContext"/>. See <see cref="AvatarConverterTransformingPassTests"/> for why the
+    /// full material conversion is intentionally out of scope here.
+    /// </summary>
+    public class AvatarConverterOptimizingPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+        private Material material;
+        private Mesh mesh;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+
+            if (material != null)
+            {
+                Object.DestroyImmediate(material);
+                material = null;
+            }
+
+            if (mesh != null)
+            {
+                Object.DestroyImmediate(mesh);
+                mesh = null;
+            }
+        }
+
+        /// <summary>
+        /// Without any IMaterialOperatorComponent (e.g. AvatarConverterSettings, MaterialSwap) in the
+        /// hierarchy, the pass must do nothing.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoMaterialOperatorComponent()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            material = new Material(Shader.Find("Standard"));
+            mesh = new Mesh();
+            var smr = builder.AddSkinnedMeshRenderer("Body", mesh, material);
+
+            var context = new BuildContext(builder.Root, null);
+            Assert.DoesNotThrow(() => AvatarConverterOptimizingPass.Instance.RunForTest(context));
+
+            Assert.AreSame(material, smr.sharedMaterial, "Material must be untouched when there is no material operator component.");
+        }
+
+        /// <summary>
+        /// When AvatarConverterSettings.ndmfPhase resolves to Transforming, the Optimizing-phase pass
+        /// must not run the conversion (it's the Transforming-phase pass's job instead).
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNdmfPhaseResolvesToTransforming()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            material = new Material(Shader.Find("Standard"));
+            mesh = new Mesh();
+            var smr = builder.AddSkinnedMeshRenderer("Body", mesh, material);
+
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.ndmfPhase = Models.AvatarConverterNdmfPhase.Transforming;
+
+            var context = new BuildContext(builder.Root, null);
+            using (new ObjectRegistryScope(context.ObjectRegistry))
+            {
+                Assert.DoesNotThrow(() => AvatarConverterOptimizingPass.Instance.RunForTest(context));
+            }
+
+            Assert.AreSame(material, smr.sharedMaterial, "Material must be untouched when the resolved NDMF phase is Transforming, not Optimizing.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterOptimizingPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterOptimizingPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d54244cf705ae2a4198cca3671003c0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterResolvingPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterResolvingPassTests.cs
@@ -1,0 +1,68 @@
+// <copyright file="AvatarConverterResolvingPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Guard-clause tests for <see cref="AvatarConverterResolvingPass"/> driven through NDMF's
+    /// <see cref="BuildContext"/>.
+    /// </summary>
+    public class AvatarConverterResolvingPassTests
+    {
+        private GameObject root;
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (root != null)
+            {
+                Object.DestroyImmediate(root);
+                root = null;
+            }
+
+            builder?.Destroy();
+            builder = null;
+        }
+
+        /// <summary>
+        /// Without a VRCAvatarDescriptor at all, the pass must not attempt any conversion preparation.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoAvatarDescriptor()
+        {
+            root = new GameObject("NoDescriptor");
+
+            var context = new BuildContext(root, null);
+            Assert.DoesNotThrow(() => AvatarConverterResolvingPass.Instance.RunForTest(context));
+
+            Assert.IsNull(root.GetComponent<ConvertedAvatar>(), "No ConvertedAvatar marker should be added without a VRCAvatarDescriptor.");
+        }
+
+        /// <summary>
+        /// With a VRCAvatarDescriptor but no AvatarConverterSettings, the pass must not attempt any
+        /// conversion preparation.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoAvatarConverterSettings()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            var context = new BuildContext(builder.Root, null);
+            Assert.DoesNotThrow(() => AvatarConverterResolvingPass.Instance.RunForTest(context));
+
+            Assert.IsNull(builder.Root.GetComponent<ConvertedAvatar>(), "No ConvertedAvatar marker should be added without AvatarConverterSettings.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterResolvingPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterResolvingPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3215338f22265b849b2463e0892dbbdd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterTransformingPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterTransformingPassTests.cs
@@ -1,0 +1,94 @@
+// <copyright file="AvatarConverterTransformingPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Guard-clause tests for <see cref="AvatarConverterTransformingPass"/> driven through NDMF's
+    /// <see cref="BuildContext"/>. The full material conversion behind
+    /// <see cref="AvatarConverterPassUtility.ConvertAvatarInPass(BuildContext)"/> needs real shader/texture
+    /// assets and is intentionally out of scope here (see NDMF plugin skill's testing guidance);
+    /// only the early-return branches that gate whether conversion runs at all are covered.
+    /// </summary>
+    public class AvatarConverterTransformingPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+        private Material material;
+        private Mesh mesh;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+
+            if (material != null)
+            {
+                Object.DestroyImmediate(material);
+                material = null;
+            }
+
+            if (mesh != null)
+            {
+                Object.DestroyImmediate(mesh);
+                mesh = null;
+            }
+        }
+
+        /// <summary>
+        /// Without any IMaterialOperatorComponent (e.g. AvatarConverterSettings, MaterialSwap) in the
+        /// hierarchy, the pass must do nothing.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoMaterialOperatorComponent()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            material = new Material(Shader.Find("Standard"));
+            mesh = new Mesh();
+            var smr = builder.AddSkinnedMeshRenderer("Body", mesh, material);
+
+            var context = new BuildContext(builder.Root, null);
+            Assert.DoesNotThrow(() => AvatarConverterTransformingPass.Instance.RunForTest(context));
+
+            Assert.AreSame(material, smr.sharedMaterial, "Material must be untouched when there is no material operator component.");
+        }
+
+        /// <summary>
+        /// When AvatarConverterSettings.ndmfPhase resolves to Optimizing, the Transforming-phase pass
+        /// must not run the conversion (it's the Optimizing-phase pass's job instead).
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNdmfPhaseResolvesToOptimizing()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            material = new Material(Shader.Find("Standard"));
+            mesh = new Mesh();
+            var smr = builder.AddSkinnedMeshRenderer("Body", mesh, material);
+
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.ndmfPhase = Models.AvatarConverterNdmfPhase.Optimizing;
+
+            var context = new BuildContext(builder.Root, null);
+            using (new ObjectRegistryScope(context.ObjectRegistry))
+            {
+                Assert.DoesNotThrow(() => AvatarConverterTransformingPass.Instance.RunForTest(context));
+            }
+
+            Assert.AreSame(material, smr.sharedMaterial, "Material must be untouched when the resolved NDMF phase is Optimizing, not Transforming.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterTransformingPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/AvatarConverterTransformingPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcde0e2bee482be49b658b6e92a5159b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/BuildTargetConfigurationPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/BuildTargetConfigurationPassTests.cs
@@ -1,0 +1,70 @@
+// <copyright file="BuildTargetConfigurationPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="BuildTargetConfigurationPass"/> driven through NDMF's <see cref="BuildContext"/>.
+    /// </summary>
+    public class BuildTargetConfigurationPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects and static session state modified during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+
+            // NdmfSessionState.BuildTarget is process/session-wide state; always restore it so a
+            // failed assertion above doesn't leak a non-Auto target into unrelated tests.
+            NdmfSessionState.BuildTarget = Models.BuildTarget.Auto;
+        }
+
+        /// <summary>
+        /// A pending session-wide build target request must be written onto a PlatformTargetSettings
+        /// component on the avatar root, and the session-wide request must then be cleared back to Auto
+        /// so it isn't accidentally reapplied to the next avatar built in the same Editor session.
+        /// </summary>
+        [Test]
+        public void Execute_AppliesSessionBuildTargetAndResetsSessionState()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            NdmfSessionState.BuildTarget = Models.BuildTarget.Android;
+
+            var context = new BuildContext(builder.Root, null);
+            BuildTargetConfigurationPass.Instance.RunForTest(context);
+
+            var targetSettings = builder.Root.GetComponent<PlatformTargetSettings>();
+            Assert.IsNotNull(targetSettings, "A PlatformTargetSettings component must be added to carry the requested build target.");
+            Assert.AreEqual(Models.BuildTarget.Android, targetSettings.buildTarget, "The requested build target must be written onto PlatformTargetSettings.");
+            Assert.AreEqual(Models.BuildTarget.Auto, NdmfSessionState.BuildTarget, "The session-wide request must be reset to Auto after being applied.");
+        }
+
+        /// <summary>
+        /// When no session-wide build target is pending (Auto), the pass must not add a
+        /// PlatformTargetSettings component that wasn't already there.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNotAddSettings_WhenSessionBuildTargetIsAuto()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            NdmfSessionState.BuildTarget = Models.BuildTarget.Auto;
+
+            var context = new BuildContext(builder.Root, null);
+            BuildTargetConfigurationPass.Instance.RunForTest(context);
+
+            var targetSettings = builder.Root.GetComponent<PlatformTargetSettings>();
+            Assert.IsNull(targetSettings, "No PlatformTargetSettings should be added when there is no pending session build target.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/BuildTargetConfigurationPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/BuildTargetConfigurationPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7a8028f88b0acf49841709ff628178e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/CheckTextureFormatPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/CheckTextureFormatPassTests.cs
@@ -1,0 +1,47 @@
+// <copyright file="CheckTextureFormatPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Guard-clause test for <see cref="CheckTextureFormatPass"/> driven through NDMF's
+    /// <see cref="BuildContext"/>. The format-check logic itself branches on
+    /// <c>EditorUserBuildSettings.activeBuildTarget</c>, which a test must not mutate (it's shared,
+    /// session-wide Editor state), so only the avatar-descriptor guard is covered here.
+    /// </summary>
+    public class CheckTextureFormatPassTests
+    {
+        private GameObject root;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (root != null)
+            {
+                Object.DestroyImmediate(root);
+                root = null;
+            }
+        }
+
+        /// <summary>
+        /// Without a VRCAvatarDescriptor at all, the pass must not attempt any texture format check.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoAvatarDescriptor()
+        {
+            root = new GameObject("NoDescriptor");
+
+            var context = new BuildContext(root, null);
+            Assert.DoesNotThrow(() => CheckTextureFormatPass.Instance.RunForTest(context));
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/CheckTextureFormatPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/CheckTextureFormatPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ccc74ccfd7312434c8accd3cf4cf33d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MenuIconResizerPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MenuIconResizerPassTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="MenuIconResizerPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+using VRC.SDK3.Avatars.ScriptableObjects;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Guard-clause tests for <see cref="MenuIconResizerPass"/> driven through NDMF's
+    /// <see cref="BuildContext"/>. Actual icon resizing/compression needs real texture assets and is
+    /// intentionally out of scope here; only the early-return branches are covered.
+    /// </summary>
+    public class MenuIconResizerPassTests
+    {
+        private GameObject root;
+        private NdmfTestAvatarBuilder builder;
+        private VRCExpressionsMenu menu;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (root != null)
+            {
+                Object.DestroyImmediate(root);
+                root = null;
+            }
+
+            builder?.Destroy();
+            builder = null;
+
+            if (menu != null)
+            {
+                Object.DestroyImmediate(menu);
+                menu = null;
+            }
+        }
+
+        /// <summary>
+        /// Without a VRCAvatarDescriptor at all, the pass must not touch anything.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoAvatarDescriptor()
+        {
+            root = new GameObject("NoDescriptor");
+
+            var context = new BuildContext(root, null);
+            Assert.DoesNotThrow(() => MenuIconResizerPass.Instance.RunForTest(context));
+        }
+
+        /// <summary>
+        /// With a VRCAvatarDescriptor but no expressions menu assigned, the pass must do nothing.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNoExpressionsMenu()
+        {
+            builder = new NdmfTestAvatarBuilder();
+
+            var context = new BuildContext(builder.Root, null);
+            Assert.DoesNotThrow(() => MenuIconResizerPass.Instance.RunForTest(context));
+        }
+
+        /// <summary>
+        /// With an expressions menu that has no controls (and therefore no icon textures), the pass
+        /// must do nothing, even without a MenuIconResizer component present.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenMenuHasNoIcons()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            menu = ScriptableObject.CreateInstance<VRCExpressionsMenu>();
+            builder.AvatarDescriptor.expressionsMenu = menu;
+
+            var context = new BuildContext(builder.Root, null);
+            Assert.DoesNotThrow(() => MenuIconResizerPass.Instance.RunForTest(context));
+
+            Assert.AreSame(menu, builder.AvatarDescriptor.expressionsMenu, "The menu must not be duplicated/replaced when there is nothing to resize.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MenuIconResizerPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MenuIconResizerPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7edb855659175104c8a17911abcac51f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperPassTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="MeshFlipperPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="MeshFlipperPass"/> and <see cref="MeshFlipperAfterPolygonReductionPass"/>
+    /// (both backed by <see cref="MeshFlipperPassUtility"/>) driven through NDMF's <see cref="BuildContext"/>.
+    /// </summary>
+    public class MeshFlipperPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+        private Mesh originalMesh;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+
+            if (originalMesh != null)
+            {
+                Object.DestroyImmediate(originalMesh);
+                originalMesh = null;
+            }
+        }
+
+        /// <summary>
+        /// The pass should duplicate the mesh, leave the original untouched, and register the
+        /// replacement in ObjectRegistry.
+        /// </summary>
+        [Test]
+        public void Execute_FlipsMeshAndTracksObjectRegistry()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            originalMesh = new Mesh();
+            originalMesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            originalMesh.triangles = new[] { 0, 1, 2 };
+
+            var smr = builder.AddSkinnedMeshRenderer("Body", originalMesh);
+            var flipper = smr.gameObject.AddComponent<MeshFlipper>();
+            flipper.direction = MeshFlipperMeshDirection.Flip;
+            flipper.processingPhase = MeshFlipperProcessingPhase.BeforePolygonReduction;
+
+            var context = new BuildContext(builder.Root, null);
+            using (new ObjectRegistryScope(context.ObjectRegistry))
+            {
+                MeshFlipperPass.Instance.RunForTest(context);
+
+                var reference = NdmfObjectRegistry.GetReference(smr.sharedMesh);
+                Assert.AreSame(originalMesh, reference.Object, "ObjectRegistry should trace the flipped mesh back to the original.");
+            }
+
+            Assert.AreNotSame(originalMesh, smr.sharedMesh, "Pass should replace the mesh with a flipped duplicate, not mutate it in place.");
+            Assert.AreEqual(new[] { 2, 1, 0 }, smr.sharedMesh.triangles, "Flipped mesh should have reversed winding order.");
+            Assert.AreEqual(new[] { 0, 1, 2 }, originalMesh.triangles, "Original mesh asset must remain untouched.");
+
+            Object.DestroyImmediate(smr.sharedMesh);
+        }
+
+        /// <summary>
+        /// Two MeshFlippers referencing the same original mesh must resolve to the same flipped
+        /// mesh instance instead of each producing its own duplicate.
+        /// </summary>
+        [Test]
+        public void Execute_DeduplicatesFlippedMesh_ForSharedOriginal()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            originalMesh = new Mesh();
+            originalMesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            originalMesh.triangles = new[] { 0, 1, 2 };
+
+            var smrA = builder.AddSkinnedMeshRenderer("BodyA", originalMesh);
+            var flipperA = smrA.gameObject.AddComponent<MeshFlipper>();
+            flipperA.direction = MeshFlipperMeshDirection.Flip;
+            flipperA.processingPhase = MeshFlipperProcessingPhase.BeforePolygonReduction;
+
+            var smrB = builder.AddSkinnedMeshRenderer("BodyB", originalMesh);
+            var flipperB = smrB.gameObject.AddComponent<MeshFlipper>();
+            flipperB.direction = MeshFlipperMeshDirection.Flip;
+            flipperB.processingPhase = MeshFlipperProcessingPhase.BeforePolygonReduction;
+
+            var context = new BuildContext(builder.Root, null);
+            MeshFlipperPass.Instance.RunForTest(context);
+
+            Assert.AreSame(smrA.sharedMesh, smrB.sharedMesh, "Renderers sharing the original mesh must resolve to the same flipped mesh instance.");
+
+            Object.DestroyImmediate(smrA.sharedMesh);
+        }
+
+        /// <summary>
+        /// MeshFlipperAfterPolygonReductionPass must only process MeshFlippers configured for the
+        /// AfterPolygonReduction phase, ignoring ones configured for BeforePolygonReduction.
+        /// </summary>
+        [Test]
+        public void Execute_AfterPolygonReductionPass_IgnoresBeforePhaseFlippers()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            originalMesh = new Mesh();
+            originalMesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            originalMesh.triangles = new[] { 0, 1, 2 };
+
+            var smr = builder.AddSkinnedMeshRenderer("Body", originalMesh);
+            var flipper = smr.gameObject.AddComponent<MeshFlipper>();
+            flipper.direction = MeshFlipperMeshDirection.Flip;
+            flipper.processingPhase = MeshFlipperProcessingPhase.BeforePolygonReduction;
+
+            var context = new BuildContext(builder.Root, null);
+            MeshFlipperAfterPolygonReductionPass.Instance.RunForTest(context);
+
+            Assert.AreSame(originalMesh, smr.sharedMesh, "A BeforePolygonReduction-phase flipper must not be processed by the AfterPolygonReduction pass.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperPassTests.cs
@@ -55,19 +55,32 @@ namespace KRT.VRCQuestTools.Ndmf
             flipper.processingPhase = MeshFlipperProcessingPhase.BeforePolygonReduction;
 
             var context = new BuildContext(builder.Root, null);
-            using (new ObjectRegistryScope(context.ObjectRegistry))
+            Mesh flippedMesh = null;
+            try
             {
-                MeshFlipperPass.Instance.RunForTest(context);
+                using (new ObjectRegistryScope(context.ObjectRegistry))
+                {
+                    MeshFlipperPass.Instance.RunForTest(context);
 
-                var reference = NdmfObjectRegistry.GetReference(smr.sharedMesh);
-                Assert.AreSame(originalMesh, reference.Object, "ObjectRegistry should trace the flipped mesh back to the original.");
+                    // Capture the duplicate before any assertion can throw, so the finally block
+                    // below can always clean it up even if an assertion fails partway through.
+                    flippedMesh = smr.sharedMesh;
+
+                    var reference = NdmfObjectRegistry.GetReference(smr.sharedMesh);
+                    Assert.AreSame(originalMesh, reference.Object, "ObjectRegistry should trace the flipped mesh back to the original.");
+                }
+
+                Assert.AreNotSame(originalMesh, smr.sharedMesh, "Pass should replace the mesh with a flipped duplicate, not mutate it in place.");
+                Assert.AreEqual(new[] { 2, 1, 0 }, smr.sharedMesh.triangles, "Flipped mesh should have reversed winding order.");
+                Assert.AreEqual(new[] { 0, 1, 2 }, originalMesh.triangles, "Original mesh asset must remain untouched.");
             }
-
-            Assert.AreNotSame(originalMesh, smr.sharedMesh, "Pass should replace the mesh with a flipped duplicate, not mutate it in place.");
-            Assert.AreEqual(new[] { 2, 1, 0 }, smr.sharedMesh.triangles, "Flipped mesh should have reversed winding order.");
-            Assert.AreEqual(new[] { 0, 1, 2 }, originalMesh.triangles, "Original mesh asset must remain untouched.");
-
-            Object.DestroyImmediate(smr.sharedMesh);
+            finally
+            {
+                if (flippedMesh != null)
+                {
+                    Object.DestroyImmediate(flippedMesh);
+                }
+            }
         }
 
         /// <summary>
@@ -95,11 +108,34 @@ namespace KRT.VRCQuestTools.Ndmf
             flipperB.processingPhase = MeshFlipperProcessingPhase.BeforePolygonReduction;
 
             var context = new BuildContext(builder.Root, null);
-            MeshFlipperPass.Instance.RunForTest(context);
+            Mesh flippedMeshA = null;
+            Mesh flippedMeshB = null;
+            try
+            {
+                using (new ObjectRegistryScope(context.ObjectRegistry))
+                {
+                    MeshFlipperPass.Instance.RunForTest(context);
+                }
 
-            Assert.AreSame(smrA.sharedMesh, smrB.sharedMesh, "Renderers sharing the original mesh must resolve to the same flipped mesh instance.");
+                // Capture both before asserting: if dedup is broken, each renderer ends up with
+                // its own duplicate, and both must still be cleaned up in that failure case too.
+                flippedMeshA = smrA.sharedMesh;
+                flippedMeshB = smrB.sharedMesh;
 
-            Object.DestroyImmediate(smrA.sharedMesh);
+                Assert.AreSame(flippedMeshA, flippedMeshB, "Renderers sharing the original mesh must resolve to the same flipped mesh instance.");
+            }
+            finally
+            {
+                if (flippedMeshA != null)
+                {
+                    Object.DestroyImmediate(flippedMeshA);
+                }
+
+                if (flippedMeshB != null && !ReferenceEquals(flippedMeshB, flippedMeshA))
+                {
+                    Object.DestroyImmediate(flippedMeshB);
+                }
+            }
         }
 
         /// <summary>

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfd516a3d018d304f8843b1aeec337b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/NdmfTestAvatarBuilder.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/NdmfTestAvatarBuilder.cs
@@ -1,0 +1,79 @@
+// <copyright file="NdmfTestAvatarBuilder.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Builds a minimal, non-prefab avatar GameObject for driving NDMF passes directly
+    /// (via <see cref="nadena.dev.ndmf.BuildContext"/>) in EditMode tests.
+    /// </summary>
+    internal class NdmfTestAvatarBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NdmfTestAvatarBuilder"/> class.
+        /// </summary>
+        /// <param name="name">Name of the root GameObject.</param>
+        internal NdmfTestAvatarBuilder(string name = "NdmfTestAvatar")
+        {
+            Root = new GameObject(name);
+            AvatarDescriptor = Root.AddComponent<VRCAvatarDescriptor>();
+            AvatarDescriptor.customizeAnimationLayers = true;
+            AvatarDescriptor.baseAnimationLayers = new[]
+            {
+                new VRCAvatarDescriptor.CustomAnimLayer { type = VRCAvatarDescriptor.AnimLayerType.Base, isDefault = true },
+                new VRCAvatarDescriptor.CustomAnimLayer { type = VRCAvatarDescriptor.AnimLayerType.Additive, isDefault = true },
+                new VRCAvatarDescriptor.CustomAnimLayer { type = VRCAvatarDescriptor.AnimLayerType.Gesture, isDefault = true },
+                new VRCAvatarDescriptor.CustomAnimLayer { type = VRCAvatarDescriptor.AnimLayerType.Action, isDefault = true },
+                new VRCAvatarDescriptor.CustomAnimLayer { type = VRCAvatarDescriptor.AnimLayerType.FX, isDefault = true },
+            };
+            AvatarDescriptor.specialAnimationLayers = new VRCAvatarDescriptor.CustomAnimLayer[0];
+        }
+
+        /// <summary>
+        /// Gets the root GameObject of the avatar. A plain scene object, not a prefab instance,
+        /// so it can be passed to <see cref="nadena.dev.ndmf.BuildContext"/> directly.
+        /// </summary>
+        internal GameObject Root { get; }
+
+        /// <summary>
+        /// Gets the VRCAvatarDescriptor attached to <see cref="Root"/>.
+        /// </summary>
+        internal VRCAvatarDescriptor AvatarDescriptor { get; }
+
+        /// <summary>
+        /// Adds a child GameObject with a SkinnedMeshRenderer.
+        /// </summary>
+        /// <param name="name">Name of the child GameObject.</param>
+        /// <param name="mesh">Mesh to assign.</param>
+        /// <param name="materials">Materials to assign.</param>
+        /// <returns>The added SkinnedMeshRenderer.</returns>
+        internal SkinnedMeshRenderer AddSkinnedMeshRenderer(string name, Mesh mesh, params Material[] materials)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(Root.transform, false);
+            var smr = go.AddComponent<SkinnedMeshRenderer>();
+            smr.sharedMesh = mesh;
+            if (materials.Length > 0)
+            {
+                smr.sharedMaterials = materials;
+            }
+            return smr;
+        }
+
+        /// <summary>
+        /// Destroys the avatar root and all of its children and components.
+        /// </summary>
+        internal void Destroy()
+        {
+            if (Root != null)
+            {
+                Object.DestroyImmediate(Root);
+            }
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/NdmfTestAvatarBuilder.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/NdmfTestAvatarBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 606644f50a7ac0348a655647dbf3f94e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformComponentRemoverPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformComponentRemoverPassTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="PlatformComponentRemoverPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using KRT.VRCQuestTools.Models;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="PlatformComponentRemoverPass"/> driven through NDMF's <see cref="BuildContext"/>.
+    /// </summary>
+    public class PlatformComponentRemoverPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+        }
+
+        /// <summary>
+        /// A component marked for removal on the resolved platform is destroyed.
+        /// </summary>
+        [Test]
+        public void Execute_RemovesComponent_WhenFlaggedForTargetPlatform()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            var light = builder.Root.AddComponent<Light>();
+            var pcr = builder.Root.AddComponent<PlatformComponentRemover>();
+            pcr.componentSettings = new[]
+            {
+                new PlatformComponentRemoverItem { component = light, removeOnAndroid = true },
+            };
+
+            var context = new BuildContext(builder.Root, null);
+            PlatformComponentRemoverPass.Instance.RunForTest(context);
+
+            Assert.IsTrue(light == null, "Component flagged for removal on the resolved platform must be destroyed.");
+        }
+
+        /// <summary>
+        /// Removing a PhysBone that another PhysBone references as a collider must clear that
+        /// dangling reference, not just destroy the removed component.
+        /// </summary>
+        [Test]
+        public void Execute_ClearsColliderReference_WhenReferencedColliderIsRemoved()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            var colliderGameObject = new GameObject("Collider");
+            colliderGameObject.transform.SetParent(builder.Root.transform, false);
+            var collider = colliderGameObject.AddComponent<VRCPhysBoneCollider>();
+
+            var boneGameObject = new GameObject("Bone");
+            boneGameObject.transform.SetParent(builder.Root.transform, false);
+            var bone = boneGameObject.AddComponent<VRCPhysBone>();
+            bone.colliders.Add(collider);
+
+            var pcr = builder.Root.AddComponent<PlatformComponentRemover>();
+            pcr.componentSettings = new[]
+            {
+                new PlatformComponentRemoverItem { component = collider, removeOnAndroid = true },
+            };
+
+            var context = new BuildContext(builder.Root, null);
+            PlatformComponentRemoverPass.Instance.RunForTest(context);
+
+            Assert.IsTrue(collider == null, "Flagged collider must be destroyed.");
+            Assert.IsTrue(bone != null, "The referencing PhysBone itself must not be destroyed.");
+
+            // Use ReferenceEquals, not Unity's overloaded ==: a destroyed-but-still-referenced
+            // UnityEngine.Object also compares == null (Unity's "fake null"), so == can't tell
+            // "list entry was explicitly cleared" apart from "list still holds a dangling
+            // reference to the now-destroyed collider" -- exactly the bug this test guards against.
+            Assert.IsTrue(ReferenceEquals(bone.colliders[0], null), "The dangling collider reference on the remaining PhysBone must be explicitly cleared, not just left pointing at a destroyed object.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformComponentRemoverPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformComponentRemoverPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d746d416e8a70648b57550fdcfe1d07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformGameObjectRemoverPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformGameObjectRemoverPassTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="PlatformGameObjectRemoverPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="PlatformGameObjectRemoverPass"/> driven through NDMF's <see cref="BuildContext"/>.
+    /// </summary>
+    public class PlatformGameObjectRemoverPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+        }
+
+        /// <summary>
+        /// A GameObject with removeOnAndroid enabled is destroyed when the build target is Android.
+        /// </summary>
+        [Test]
+        public void Execute_RemovesGameObject_WhenRemoveOnAndroidAndTargetIsAndroid()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            var child = new GameObject("Child");
+            child.transform.SetParent(builder.Root.transform, false);
+            child.AddComponent<PlatformGameObjectRemover>().removeOnAndroid = true;
+
+            var context = new BuildContext(builder.Root, null);
+            PlatformGameObjectRemoverPass.Instance.RunForTest(context);
+
+            Assert.IsTrue(child == null, "GameObject with removeOnAndroid must be destroyed for the Android target.");
+        }
+
+        /// <summary>
+        /// A GameObject without removeOnAndroid enabled is left untouched when the build target is Android.
+        /// </summary>
+        [Test]
+        public void Execute_KeepsGameObject_WhenRemoveOnAndroidIsDisabled()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+
+            var child = new GameObject("Child");
+            child.transform.SetParent(builder.Root.transform, false);
+            child.AddComponent<PlatformGameObjectRemover>().removeOnAndroid = false;
+
+            var context = new BuildContext(builder.Root, null);
+            PlatformGameObjectRemoverPass.Instance.RunForTest(context);
+
+            Assert.IsFalse(child == null, "GameObject must not be destroyed when removeOnAndroid is disabled.");
+        }
+
+        /// <summary>
+        /// A GameObject with removeOnPC enabled is destroyed when the build target is PC.
+        /// </summary>
+        [Test]
+        public void Execute_RemovesGameObject_WhenRemoveOnPCAndTargetIsPC()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.PC;
+
+            var child = new GameObject("Child");
+            child.transform.SetParent(builder.Root.transform, false);
+            child.AddComponent<PlatformGameObjectRemover>().removeOnPC = true;
+
+            var context = new BuildContext(builder.Root, null);
+            PlatformGameObjectRemoverPass.Instance.RunForTest(context);
+
+            Assert.IsTrue(child == null, "GameObject with removeOnPC must be destroyed for the PC target.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformGameObjectRemoverPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/PlatformGameObjectRemoverPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0be0a21f3e1d5a74e8d486aa8fa609ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveUnsupportedComponentsPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveUnsupportedComponentsPassTests.cs
@@ -1,0 +1,66 @@
+// <copyright file="RemoveUnsupportedComponentsPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System.Text.RegularExpressions;
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="RemoveUnsupportedComponentsPass"/> driven through NDMF's <see cref="BuildContext"/>.
+    /// </summary>
+    public class RemoveUnsupportedComponentsPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+        }
+
+        /// <summary>
+        /// Without a ConvertedAvatar marker, the avatar hasn't gone through conversion yet, so
+        /// unsupported components must be left untouched.
+        /// </summary>
+        [Test]
+        public void Execute_DoesNothing_WhenNotConverted()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var light = builder.Root.AddComponent<Light>();
+
+            var context = new BuildContext(builder.Root, null);
+            RemoveUnsupportedComponentsPass.Instance.RunForTest(context);
+
+            Assert.IsFalse(light == null, "Unsupported component must not be removed without a ConvertedAvatar marker.");
+        }
+
+        /// <summary>
+        /// With a ConvertedAvatar marker, unsupported components (e.g. Light) must be removed and a
+        /// warning reported for each one.
+        /// </summary>
+        [Test]
+        public void Execute_RemovesUnsupportedComponents_WhenConverted()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<ConvertedAvatar>();
+            var light = builder.Root.AddComponent<Light>();
+
+            var context = new BuildContext(builder.Root, null);
+            LogAssert.Expect(LogType.Warning, new Regex(@"^\[NDMF\] Error Reported: "));
+            RemoveUnsupportedComponentsPass.Instance.RunForTest(context);
+
+            Assert.IsTrue(light == null, "Unsupported component must be removed once the avatar is marked as converted.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveUnsupportedComponentsPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveUnsupportedComponentsPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47174c64430ffa2459c061e977c34fdc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVRCQuestToolsComponentsPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVRCQuestToolsComponentsPassTests.cs
@@ -1,0 +1,47 @@
+// <copyright file="RemoveVRCQuestToolsComponentsPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="RemoveVRCQuestToolsComponentsPass"/> driven through NDMF's <see cref="BuildContext"/>.
+    /// </summary>
+    public class RemoveVRCQuestToolsComponentsPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+        }
+
+        /// <summary>
+        /// All VRCQuestToolsEditorOnly-derived settings components must be destroyed so none of them
+        /// leak into the build output.
+        /// </summary>
+        [Test]
+        public void Execute_DestroysAllVRCQuestToolsEditorOnlyComponents()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            var targetSettings = builder.Root.AddComponent<PlatformTargetSettings>();
+
+            var context = new BuildContext(builder.Root, null);
+            RemoveVRCQuestToolsComponentsPass.Instance.RunForTest(context);
+
+            Assert.IsTrue(settings == null, "AvatarConverterSettings must be destroyed.");
+            Assert.IsTrue(targetSettings == null, "PlatformTargetSettings must be destroyed.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVRCQuestToolsComponentsPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVRCQuestToolsComponentsPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f59b63e2a7c2fa48aa59bd76f2960cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVertexColorPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVertexColorPassTests.cs
@@ -60,21 +60,34 @@ namespace KRT.VRCQuestTools.Ndmf
             var smr = builder.AddSkinnedMeshRenderer("Body", originalMesh);
 
             var context = new BuildContext(builder.Root, null);
-            using (new ObjectRegistryScope(context.ObjectRegistry))
+            Mesh replacedMesh = null;
+            try
             {
-                RemoveVertexColorPass.Instance.RunForTest(context);
+                using (new ObjectRegistryScope(context.ObjectRegistry))
+                {
+                    RemoveVertexColorPass.Instance.RunForTest(context);
 
-                // ObjectRegistry.ActiveRegistry is only set inside this scope, so the lookup
-                // must happen before it (and the registration it reads) goes out of scope.
-                var reference = NdmfObjectRegistry.GetReference(smr.sharedMesh);
-                Assert.AreSame(originalMesh, reference.Object, "ObjectRegistry should trace the replacement mesh back to the original.");
+                    // Capture the duplicate before any assertion can throw, so the finally block
+                    // below can always clean it up even if an assertion fails partway through.
+                    replacedMesh = smr.sharedMesh;
+
+                    // ObjectRegistry.ActiveRegistry is only set inside this scope, so the lookup
+                    // must happen before it (and the registration it reads) goes out of scope.
+                    var reference = NdmfObjectRegistry.GetReference(smr.sharedMesh);
+                    Assert.AreSame(originalMesh, reference.Object, "ObjectRegistry should trace the replacement mesh back to the original.");
+                }
+
+                Assert.AreNotSame(originalMesh, smr.sharedMesh, "Pass should replace the mesh with a duplicate, not mutate it in place.");
+                Assert.IsTrue(originalMesh.colors32 != null && originalMesh.colors32.Length > 0, "Original mesh asset must remain untouched.");
+                Assert.IsTrue(smr.sharedMesh.colors32 == null || smr.sharedMesh.colors32.Length == 0, "Replacement mesh must have vertex colors removed.");
             }
-
-            Assert.AreNotSame(originalMesh, smr.sharedMesh, "Pass should replace the mesh with a duplicate, not mutate it in place.");
-            Assert.IsTrue(originalMesh.colors32 != null && originalMesh.colors32.Length > 0, "Original mesh asset must remain untouched.");
-            Assert.IsTrue(smr.sharedMesh.colors32 == null || smr.sharedMesh.colors32.Length == 0, "Replacement mesh must have vertex colors removed.");
-
-            Object.DestroyImmediate(smr.sharedMesh);
+            finally
+            {
+                if (replacedMesh != null)
+                {
+                    Object.DestroyImmediate(replacedMesh);
+                }
+            }
         }
 
         /// <summary>

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVertexColorPassTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVertexColorPassTests.cs
@@ -1,0 +1,112 @@
+// <copyright file="RemoveVertexColorPassTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="RemoveVertexColorPass"/> driven through NDMF's <see cref="BuildContext"/>
+    /// against a minimal in-code avatar, instead of a Fixtures scene or reflection.
+    /// </summary>
+    public class RemoveVertexColorPassTests
+    {
+        private NdmfTestAvatarBuilder builder;
+        private Mesh originalMesh;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+
+            if (originalMesh != null)
+            {
+                Object.DestroyImmediate(originalMesh);
+                originalMesh = null;
+            }
+        }
+
+        /// <summary>
+        /// The pass should duplicate a mesh with non-white vertex colors, strip the colors on the
+        /// duplicate, leave the original mesh untouched, and register the replacement in ObjectRegistry.
+        /// </summary>
+        [Test]
+        public void Execute_RemovesVertexColorAndTracksObjectRegistry()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.removeVertexColor = true;
+
+            originalMesh = new Mesh();
+            originalMesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            originalMesh.triangles = new[] { 0, 1, 2 };
+            originalMesh.colors32 = new[]
+            {
+                new Color32(255, 0, 0, 255),
+                new Color32(255, 0, 0, 255),
+                new Color32(255, 0, 0, 255),
+            };
+
+            var smr = builder.AddSkinnedMeshRenderer("Body", originalMesh);
+
+            var context = new BuildContext(builder.Root, null);
+            using (new ObjectRegistryScope(context.ObjectRegistry))
+            {
+                RemoveVertexColorPass.Instance.RunForTest(context);
+
+                // ObjectRegistry.ActiveRegistry is only set inside this scope, so the lookup
+                // must happen before it (and the registration it reads) goes out of scope.
+                var reference = NdmfObjectRegistry.GetReference(smr.sharedMesh);
+                Assert.AreSame(originalMesh, reference.Object, "ObjectRegistry should trace the replacement mesh back to the original.");
+            }
+
+            Assert.AreNotSame(originalMesh, smr.sharedMesh, "Pass should replace the mesh with a duplicate, not mutate it in place.");
+            Assert.IsTrue(originalMesh.colors32 != null && originalMesh.colors32.Length > 0, "Original mesh asset must remain untouched.");
+            Assert.IsTrue(smr.sharedMesh.colors32 == null || smr.sharedMesh.colors32.Length == 0, "Replacement mesh must have vertex colors removed.");
+
+            Object.DestroyImmediate(smr.sharedMesh);
+        }
+
+        /// <summary>
+        /// The pass must not touch avatars that don't opt in via AvatarConverterSettings.removeVertexColor.
+        /// </summary>
+        [Test]
+        public void Execute_SkipsWhenRemoveVertexColorIsDisabled()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.Android;
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.removeVertexColor = false;
+
+            originalMesh = new Mesh();
+            originalMesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            originalMesh.triangles = new[] { 0, 1, 2 };
+            originalMesh.colors32 = new[]
+            {
+                new Color32(255, 0, 0, 255),
+                new Color32(255, 0, 0, 255),
+                new Color32(255, 0, 0, 255),
+            };
+
+            var smr = builder.AddSkinnedMeshRenderer("Body", originalMesh);
+
+            var context = new BuildContext(builder.Root, null);
+            using (new ObjectRegistryScope(context.ObjectRegistry))
+            {
+                RemoveVertexColorPass.Instance.RunForTest(context);
+            }
+
+            Assert.AreSame(originalMesh, smr.sharedMesh, "Pass must not replace the mesh when removeVertexColor is disabled.");
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVertexColorPassTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/RemoveVertexColorPassTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7877ea60ec1c2a942bbe658a9d616fd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/VRCQuestTools-EditorTests-Ndmf.asmdef
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/VRCQuestTools-EditorTests-Ndmf.asmdef
@@ -1,0 +1,38 @@
+{
+    "name": "VRCQuestTools-EditorTests-Ndmf",
+    "rootNamespace": "KRT.VRCQuestTools.Ndmf",
+    "references": [
+        "VRCQuestTools",
+        "VRCQuestTools-Editor",
+        "VRCQuestTools-Editor-Ndmf",
+        "nadena.dev.ndmf",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "VRCSDKBase.dll",
+        "VRCSDK3A.dll",
+        "VRC.SDK3.Dynamics.PhysBone.dll",
+        "VRC.Dynamics.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
+        "VQT_HAS_NDMF"
+    ],
+    "versionDefines": [
+        {
+            "name": "nadena.dev.ndmf",
+            "expression": "[1.5.0,2.0.0-a)",
+            "define": "VQT_HAS_NDMF"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/VRCQuestTools-EditorTests-Ndmf.asmdef.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/VRCQuestTools-EditorTests-Ndmf.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ed1318d1e385d274c9a57faf08df3de1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/UnityAnimationUtilityTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/UnityAnimationUtilityTests.cs
@@ -61,5 +61,54 @@ namespace KRT.VRCQuestTools.Utils
 
             Assert.DoesNotThrow(() => UnityAnimationUtility.ReplaceAnimationClips(controller, false, null, new Dictionary<Motion, Motion> { }));
         }
+
+        /// <summary>
+        /// ReplaceAnimationClipMaterials should rewrite a material-swap object reference curve on a
+        /// duplicated clip while leaving the source clip untouched. This is a regression test for the
+        /// non-NDMF-standard animation rewriting used by the NDMF passes (see NDMF/AvatarConverterPassUtility).
+        /// </summary>
+        [Test]
+        public void ReplaceAnimationClipMaterials_RewritesRendererMaterialCurve()
+        {
+            var originalMaterial = new Material(Shader.Find("Standard"));
+            var newMaterial = new Material(Shader.Find("Standard"));
+            AnimationClip clip = null;
+            AnimationClip replaced = null;
+            try
+            {
+                clip = new AnimationClip();
+                var binding = EditorCurveBinding.PPtrCurve("Body", typeof(SkinnedMeshRenderer), "m_Materials.Array.data[0]");
+                var keyframes = new[]
+                {
+                    new ObjectReferenceKeyframe { time = 0, value = originalMaterial },
+                };
+                AnimationUtility.SetObjectReferenceCurve(clip, binding, keyframes);
+
+                replaced = UnityAnimationUtility.ReplaceAnimationClipMaterials(clip, new Dictionary<Material, Material> { [originalMaterial] = newMaterial });
+
+                Assert.AreNotSame(clip, replaced, "The pass must duplicate the clip rather than mutate it in place.");
+
+                var originalKeyframes = AnimationUtility.GetObjectReferenceCurve(clip, binding);
+                Assert.AreSame(originalMaterial, originalKeyframes[0].value, "Source clip must remain untouched.");
+
+                var replacedKeyframes = AnimationUtility.GetObjectReferenceCurve(replaced, binding);
+                Assert.AreSame(newMaterial, replacedKeyframes[0].value, "Duplicated clip's material reference curve must point to the new material.");
+            }
+            finally
+            {
+                if (clip != null)
+                {
+                    Object.DestroyImmediate(clip);
+                }
+
+                if (replaced != null)
+                {
+                    Object.DestroyImmediate(replaced);
+                }
+
+                Object.DestroyImmediate(originalMaterial);
+                Object.DestroyImmediate(newMaterial);
+            }
+        }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/AssemblyInfo.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("VRCQuestTools-Editor-NonDestructive")]
 [assembly: InternalsVisibleTo("VRCQuestTools-DebugUtil-Editor")]
 [assembly: InternalsVisibleTo("VRCQuestTools-EditorTests")]
+[assembly: InternalsVisibleTo("VRCQuestTools-EditorTests-Ndmf")]
 [assembly: InternalsVisibleTo("VRCQuestToolsExtra-Editor")]
 [assembly: InternalsVisibleTo("VRCQuestToolsExtra-EditorTests")]
 #endif

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/AssemblyInfo.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// <copyright file="AssemblyInfo.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("VRCQuestTools-EditorTests-Ndmf")]

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/AssemblyInfo.cs.meta
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e60074f6758670542b22df761f51e460
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AssignNetworkIDsPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AssignNetworkIDsPass.cs
@@ -14,6 +14,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Assign network IDs";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AvatarConverterOptimizingPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AvatarConverterOptimizingPass.cs
@@ -10,6 +10,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Convert avatar for Mobile in optimizing phase";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AvatarConverterResolvingPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AvatarConverterResolvingPass.cs
@@ -15,6 +15,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Prepare converter and build target";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AvatarConverterTransformingPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/AvatarConverterTransformingPass.cs
@@ -10,6 +10,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Convert avatar for Mobile in transforming phase";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/BuildTargetConfigurationPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/BuildTargetConfigurationPass.cs
@@ -12,6 +12,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Configure build target platform";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext ctx)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/CheckTextureFormatPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/CheckTextureFormatPass.cs
@@ -20,6 +20,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc />
         public override string DisplayName => "Check texture format";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc />
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/MenuIconResizerPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/MenuIconResizerPass.cs
@@ -18,6 +18,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Resize menu icons";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/MeshFlipperAfterPolygonReductionPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/MeshFlipperAfterPolygonReductionPass.cs
@@ -11,6 +11,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Flip meshes after polygon reduction";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/MeshFlipperPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/MeshFlipperPass.cs
@@ -11,6 +11,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Flip meshes before polygon reduction";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/PlatformComponentRemoverPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/PlatformComponentRemoverPass.cs
@@ -18,6 +18,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Remove platform components";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/PlatformGameObjectRemoverPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/PlatformGameObjectRemoverPass.cs
@@ -13,6 +13,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Remove platform game objects";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/RemoveUnsupportedComponentsPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/RemoveUnsupportedComponentsPass.cs
@@ -16,6 +16,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Remove unsupported components";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/RemoveVRCQuestToolsComponentsPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/RemoveVRCQuestToolsComponentsPass.cs
@@ -12,6 +12,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Remove VRCQuestTools components";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/RemoveVertexColorPass.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Passes/RemoveVertexColorPass.cs
@@ -13,6 +13,15 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public override string DisplayName => "Remove vertex color";
 
+        /// <summary>
+        /// Runs this pass directly for EditMode tests, bypassing the NDMF pass pipeline.
+        /// </summary>
+        /// <param name="context">BuildContext.</param>
+        internal void RunForTest(BuildContext context)
+        {
+            Execute(context);
+        }
+
         /// <inheritdoc/>
         protected override void Execute(BuildContext context)
         {


### PR DESCRIPTION
Adds a dedicated VQT_HAS_NDMF-gated test assembly and a minimal in-code test-avatar builder so passes can be driven through NDMF's real BuildContext instead of reflection/dummy-object workarounds. Covers RemoveVertexColorPass and the other self-contained Passes with full duplicate/ObjectRegistry/removal assertions, and adds lighter guard-clause tests for the material-conversion-heavy Passes where full integration setup isn't worth the cost.