### PR TITLE
Fix misleading platform-target-settings hint and guard material preview button

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
@@ -549,7 +549,7 @@ msgid "PlatformTargetSettingsEditorDescription"
 msgstr "Components are enforced to use a specific platform settings in NDMF build process."
 
 msgid "PlatformTargetSettingsIsRequiredToEnforcePlatform"
-msgstr "PlatformTargetSettings component is required to the avatar root object in order to enforce a specific platform settings."
+msgstr "To override the platform for this component, add a PlatformTargetSettings component to the avatar root object."
 
 msgid "ComponentRequiresNdmf"
 msgstr "Non-Destructive Modular Framework (NDMF) is required."

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
@@ -549,7 +549,7 @@ msgid "PlatformTargetSettingsEditorDescription"
 msgstr "ビルド時にコンポーネントの設定を特定のプラットフォームに強制します。"
 
 msgid "PlatformTargetSettingsIsRequiredToEnforcePlatform"
-msgstr "特定のプラットフォーム設定を強制するにはアバターのルートオブジェクトに Platform Target Settings コンポーネントが必要です。"
+msgstr "このコンポーネントの対象プラットフォームを上書きするには、アバターのルートオブジェクトに Platform Target Settings コンポーネントを追加してください。"
 
 msgid "ComponentRequiresNdmf"
 msgstr "Non-Destructive Modular Framework (NDMF) が必要です。"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
@@ -484,7 +484,7 @@ msgid "PlatformTargetSettingsEditorDescription"
 msgstr "Компоненты принудительно используют определенные настройки платформы в процессе сборки NDMF."
 
 msgid "PlatformTargetSettingsIsRequiredToEnforcePlatform"
-msgstr "Компонент настройки целевой платформы требуется для корневого объекта аватара, чтобы принудительно применить определенные настройки платформы."
+msgstr "Чтобы переопределить платформу для этого компонента, добавьте компонент PlatformTargetSettings в корневой объект аватара."
 
 msgid "ComponentRequiresNdmf"
 msgstr "Требуется Неразрушаемая Модульная Структура (NDMF)."

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
@@ -311,7 +311,7 @@ namespace KRT.VRCQuestTools.Inspector
 
                     EditorGUILayout.Space();
 
-                    using (var disabledPreview = new EditorGUI.DisabledGroupScope(IsMobileBuildTarget(descriptor)))
+                    using (var disabledPreview = new EditorGUI.DisabledGroupScope(Utils.ComponentUtility.IsMobileBuildTarget(descriptor.gameObject)))
                     {
                         var forceLabel = converterSettings.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableLabel : i18n.ForceMaterialPreviewEnableLabel;
                         var oldBg = GUI.backgroundColor;
@@ -763,25 +763,6 @@ namespace KRT.VRCQuestTools.Inspector
             }
             Logger.LogException(exception, context);
             DisplayErrorDialog(message, dialogException);
-        }
-
-        private static bool IsMobileBuildTarget(VRC_AvatarDescriptor avatar)
-        {
-            if (avatar == null)
-            {
-                return false;
-            }
-
-            var targetSettings = avatar.GetComponent<PlatformTargetSettings>();
-            var buildTarget = targetSettings != null ? targetSettings.buildTarget : Models.BuildTarget.Auto;
-            if (buildTarget == Models.BuildTarget.Auto)
-            {
-                buildTarget = EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.Android || EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.iOS
-                    ? Models.BuildTarget.Android
-                    : Models.BuildTarget.PC;
-            }
-
-            return buildTarget == Models.BuildTarget.Android;
         }
 
         private string GetOutputPath(VRC_AvatarDescriptor avatar)

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
@@ -3,6 +3,7 @@ using KRT.VRCQuestTools.Models;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+using VRC.SDKBase;
 
 namespace KRT.VRCQuestTools.Inspector
 {
@@ -52,22 +53,51 @@ namespace KRT.VRCQuestTools.Inspector
                 }
             }
 
+#if VQT_HAS_NDMF
             // Temporary force preview toggle (non-serialized), shown regardless of Advanced foldout state
-            var comp2 = TargetComponent;
-            var forceLabel2 = comp2.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableLabel : i18n.ForceMaterialPreviewEnableLabel;
-            var oldBg2 = GUI.backgroundColor;
-            if (comp2.ForceMaterialPreview)
+            using (var disabledPreview = new EditorGUI.DisabledGroupScope(IsMobileBuildTarget(TargetComponent.gameObject)))
             {
-                GUI.backgroundColor = Color.green;
+                var component = TargetComponent;
+                var forceLabel = component.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableLabel : i18n.ForceMaterialPreviewEnableLabel;
+                var oldBg = GUI.backgroundColor;
+                if (component.ForceMaterialPreview)
+                {
+                    GUI.backgroundColor = Color.green;
+                }
+                if (GUILayout.Button(new GUIContent("[NDMF] " + forceLabel, i18n.ForceMaterialPreviewTooltip)))
+                {
+                    component.forceMaterialPreview = !component.forceMaterialPreview;
+                }
+                GUI.backgroundColor = oldBg;
             }
-            if (GUILayout.Button(new GUIContent(forceLabel2, i18n.ForceMaterialPreviewTooltip)))
-            {
-                comp2.forceMaterialPreview = !comp2.forceMaterialPreview;
-            }
-            GUI.backgroundColor = oldBg2;
+#endif
 
             serializedObject.ApplyModifiedProperties();
         }
+
+#if VQT_HAS_NDMF
+        // MaterialConversionSettings may be on a child object rather than the avatar root,
+        // so the avatar descriptor is resolved via the parent hierarchy.
+        private static bool IsMobileBuildTarget(GameObject componentGameObject)
+        {
+            var avatarDescriptor = componentGameObject.GetComponentInParent<VRC_AvatarDescriptor>(true);
+            if (avatarDescriptor == null)
+            {
+                return false;
+            }
+
+            var targetSettings = avatarDescriptor.GetComponent<PlatformTargetSettings>();
+            var buildTarget = targetSettings != null ? targetSettings.buildTarget : Models.BuildTarget.Auto;
+            if (buildTarget == Models.BuildTarget.Auto)
+            {
+                buildTarget = EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.Android || EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.iOS
+                    ? Models.BuildTarget.Android
+                    : Models.BuildTarget.PC;
+            }
+
+            return buildTarget == Models.BuildTarget.Android;
+        }
+#endif
 
         private class EditorState : ScriptableSingleton<EditorState>
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
@@ -3,7 +3,6 @@ using KRT.VRCQuestTools.Models;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
-using VRC.SDKBase;
 
 namespace KRT.VRCQuestTools.Inspector
 {
@@ -55,7 +54,7 @@ namespace KRT.VRCQuestTools.Inspector
 
 #if VQT_HAS_NDMF
             // Temporary force preview toggle (non-serialized), shown regardless of Advanced foldout state
-            using (var disabledPreview = new EditorGUI.DisabledGroupScope(IsMobileBuildTarget(TargetComponent.gameObject)))
+            using (var disabledPreview = new EditorGUI.DisabledGroupScope(Utils.ComponentUtility.IsMobileBuildTarget(TargetComponent.gameObject)))
             {
                 var component = TargetComponent;
                 var forceLabel = component.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableLabel : i18n.ForceMaterialPreviewEnableLabel;
@@ -74,30 +73,6 @@ namespace KRT.VRCQuestTools.Inspector
 
             serializedObject.ApplyModifiedProperties();
         }
-
-#if VQT_HAS_NDMF
-        // MaterialConversionSettings may be on a child object rather than the avatar root,
-        // so the avatar descriptor is resolved via the parent hierarchy.
-        private static bool IsMobileBuildTarget(GameObject componentGameObject)
-        {
-            var avatarDescriptor = componentGameObject.GetComponentInParent<VRC_AvatarDescriptor>(true);
-            if (avatarDescriptor == null)
-            {
-                return false;
-            }
-
-            var targetSettings = avatarDescriptor.GetComponent<PlatformTargetSettings>();
-            var buildTarget = targetSettings != null ? targetSettings.buildTarget : Models.BuildTarget.Auto;
-            if (buildTarget == Models.BuildTarget.Auto)
-            {
-                buildTarget = EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.Android || EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.iOS
-                    ? Models.BuildTarget.Android
-                    : Models.BuildTarget.PC;
-            }
-
-            return buildTarget == Models.BuildTarget.Android;
-        }
-#endif
 
         private class EditorState : ScriptableSingleton<EditorState>
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/VRCQuestToolsEditorOnlyEditorBase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/VRCQuestToolsEditorOnlyEditorBase.cs
@@ -3,6 +3,8 @@ using KRT.VRCQuestTools.I18n;
 using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.Utils;
 using UnityEditor;
+using UnityEngine;
+using VRC.SDKBase;
 
 namespace KRT.VRCQuestTools.Inspector
 {
@@ -68,9 +70,9 @@ namespace KRT.VRCQuestTools.Inspector
             }
 
 #if VQT_HAS_NDMF
-            if (target is IPlatformDependentComponent || target is AvatarConverterSettings)
+            if ((target is IPlatformDependentComponent || target is AvatarConverterSettings) && !AvatarHasPlatformTargetSettings(TargetComponent.gameObject))
 #else
-            if (target is IPlatformDependentComponent)
+            if (target is IPlatformDependentComponent && !AvatarHasPlatformTargetSettings(TargetComponent.gameObject))
 #endif
             {
                 EditorGUILayout.HelpBox(i18n.PlatformTargetSettingsIsRequiredToEnforcePlatform, MessageType.Info);
@@ -85,5 +87,14 @@ namespace KRT.VRCQuestTools.Inspector
         /// Called after header GUI is drawed in OnInspectorGUI.
         /// </summary>
         public abstract void OnInspectorGUIInternal();
+
+        // PlatformTargetSettings is looked up on the avatar root rather than gameObject itself,
+        // since platform-dependent components are commonly placed on child objects.
+        private static bool AvatarHasPlatformTargetSettings(GameObject gameObject)
+        {
+            var avatarDescriptor = gameObject.GetComponentInParent<VRC_AvatarDescriptor>(true);
+            var avatarRoot = avatarDescriptor != null ? avatarDescriptor.gameObject : gameObject;
+            return avatarRoot.GetComponent<PlatformTargetSettings>() != null;
+        }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/VRCQuestToolsEditorOnlyEditorBase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/VRCQuestToolsEditorOnlyEditorBase.cs
@@ -4,7 +4,6 @@ using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.Utils;
 using UnityEditor;
 using UnityEngine;
-using VRC.SDKBase;
 
 namespace KRT.VRCQuestTools.Inspector
 {
@@ -70,13 +69,11 @@ namespace KRT.VRCQuestTools.Inspector
             }
 
 #if VQT_HAS_NDMF
-            if ((target is IPlatformDependentComponent || target is AvatarConverterSettings) && !AvatarHasPlatformTargetSettings(TargetComponent.gameObject))
-#else
-            if (target is IPlatformDependentComponent && !AvatarHasPlatformTargetSettings(TargetComponent.gameObject))
-#endif
+            if ((target is IPlatformDependentComponent || target is AvatarConverterSettings) && !ComponentUtility.AvatarHasPlatformTargetSettings(TargetComponent.gameObject))
             {
                 EditorGUILayout.HelpBox(i18n.PlatformTargetSettingsIsRequiredToEnforcePlatform, MessageType.Info);
             }
+#endif
 
             EditorGUILayout.Space();
 
@@ -87,14 +84,5 @@ namespace KRT.VRCQuestTools.Inspector
         /// Called after header GUI is drawed in OnInspectorGUI.
         /// </summary>
         public abstract void OnInspectorGUIInternal();
-
-        // PlatformTargetSettings is looked up on the avatar root rather than gameObject itself,
-        // since platform-dependent components are commonly placed on child objects.
-        private static bool AvatarHasPlatformTargetSettings(GameObject gameObject)
-        {
-            var avatarDescriptor = gameObject.GetComponentInParent<VRC_AvatarDescriptor>(true);
-            var avatarRoot = avatarDescriptor != null ? avatarDescriptor.gameObject : gameObject;
-            return avatarRoot.GetComponent<PlatformTargetSettings>() != null;
-        }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/ComponentUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/ComponentUtility.cs
@@ -1,6 +1,9 @@
 using System.Linq;
 using KRT.VRCQuestTools.Components;
+using KRT.VRCQuestTools.Models;
+using UnityEditor;
 using UnityEngine;
+using VRC.SDKBase;
 
 namespace KRT.VRCQuestTools.Utils
 {
@@ -18,6 +21,43 @@ namespace KRT.VRCQuestTools.Utils
         {
             var components = rootObject.GetComponents<IMaterialConversionComponent>();
             return components.FirstOrDefault(c => c.IsPrimaryRoot);
+        }
+
+        /// <summary>
+        /// Gets whether the avatar for the specified GameObject has a PlatformTargetSettings component.
+        /// </summary>
+        /// <param name="gameObject">GameObject of a component that may be placed on a child of the avatar root.</param>
+        /// <returns><c>true</c> if the avatar root has a PlatformTargetSettings component.</returns>
+        public static bool AvatarHasPlatformTargetSettings(GameObject gameObject)
+        {
+            return GetAvatarRoot(gameObject).GetComponent<PlatformTargetSettings>() != null;
+        }
+
+        /// <summary>
+        /// Gets whether the resolved build target for the avatar of the specified GameObject is Android (Mobile).
+        /// </summary>
+        /// <param name="gameObject">GameObject of a component that may be placed on a child of the avatar root.</param>
+        /// <returns><c>true</c> if the resolved build target is Android.</returns>
+        public static bool IsMobileBuildTarget(GameObject gameObject)
+        {
+            var targetSettings = GetAvatarRoot(gameObject).GetComponent<PlatformTargetSettings>();
+            var buildTarget = targetSettings != null ? targetSettings.buildTarget : Models.BuildTarget.Auto;
+            if (buildTarget == Models.BuildTarget.Auto)
+            {
+                buildTarget = EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.Android || EditorUserBuildSettings.activeBuildTarget == UnityEditor.BuildTarget.iOS
+                    ? Models.BuildTarget.Android
+                    : Models.BuildTarget.PC;
+            }
+
+            return buildTarget == Models.BuildTarget.Android;
+        }
+
+        // PlatformTargetSettings is looked up on the avatar root rather than gameObject itself,
+        // since platform-dependent components are commonly placed on child objects.
+        private static GameObject GetAvatarRoot(GameObject gameObject)
+        {
+            var avatarDescriptor = gameObject.GetComponentInParent<VRC_AvatarDescriptor>(true);
+            return avatarDescriptor != null ? avatarDescriptor.gameObject : gameObject;
         }
     }
 }


### PR DESCRIPTION
Only show the "add PlatformTargetSettings" info box when the avatar doesn't already have one, and soften the wording since the platform is auto-detected without it. Also bring MaterialConversionSettings's Force Material Preview button in line with AvatarConverterSettings's equivalent (NDMF guard, disabled-on-mobile state, "[NDMF] " prefix).