### PR TITLE
Change default material conversion type to Toon Standard

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialConversionSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Components/MaterialConversionSettings.cs
@@ -13,10 +13,10 @@ namespace KRT.VRCQuestTools.Components
     public class MaterialConversionSettings : VRCQuestToolsEditorOnly, IMaterialConversionComponent, IPlatformDependentComponent, INdmfComponent
     {
         /// <summary>
-        /// Default material convert setting. The default value is <see cref="ToonLitConvertSettings"/>.
+        /// Default material convert setting. The default value is <see cref="ToonStandardConvertSettings"/>.
         /// </summary>
         [SerializeReference]
-        public IMaterialConvertSettings defaultMaterialConvertSettings = new ToonLitConvertSettings();
+        public IMaterialConvertSettings defaultMaterialConvertSettings = ToonStandardConvertSettings.SimpleFeatures;
 
         /// <summary>
         /// Additional material convert settings.

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/AdditionalMaterialConvertSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/MaterialConvertSettings/AdditionalMaterialConvertSettings.cs
@@ -21,7 +21,7 @@ namespace KRT.VRCQuestTools.Models
         /// Material convert settings.
         /// </summary>
         [SerializeReference]
-        public IMaterialConvertSettings materialConvertSettings = new ToonLitConvertSettings();
+        public IMaterialConvertSettings materialConvertSettings = ToonStandardConvertSettings.SimpleFeatures;
 
         /// <summary>
         /// Load default assets for the material convert settings.


### PR DESCRIPTION
Additional material conversion settings and MaterialConversionSettings's default conversion setting still defaulted to Toon Lit, inconsistent with AvatarConverterSettings's default of Toon Standard.