### PR TITLE
Warn when MA Sync Parameter Sequence / AAO Trace and Optimize is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show warning logs during mobile upload when Avatar Dynamics categories are rated Very Poor.
 - (Experimental) Material conversion from Poiyomi to Toon Standard.
 - Material conversion for particle shaders, particle systems, trail renderers and line renderers.
+- `Avatar Converter Settings` now warns when a MA Sync Parameter Sequence or AAO Trace and Optimize component is missing on the avatar, with a button to add it.
 
 ### Changed
 - Avatar Dynamics Selector now stores keep/remove settings in `Platform Component Remover` instead of the legacy arrays in `Avatar Converter Settings`. Applying the selector migrates settings and clears the legacy arrays to avoid stale references.

--- a/CHANGELOG_JP.md
+++ b/CHANGELOG_JP.md
@@ -22,6 +22,7 @@
 - Mobile向けアップロード時、Avatar Dynamics のカテゴリが Very Poor の場合に警告ログを表示するよう追加。
 - (実験的機能) Poiyomi から Toon Standard へのマテリアル変換を追加。
 - パーティクルシェーダー、パーティクルシステム、Trail Renderer、Line Renderer 専用のマテリアル変換を追加。
+- `Avatar Converter Settings` で、アバターに MA Sync Parameter Sequence または AAO Trace and Optimize コンポーネントがない場合に警告と追加ボタンを表示するように追加。
 
 ### 変更
 - Avatar Dynamics Selector の保持/削除設定を `Avatar Converter Settings` のレガシー配列ではなく `Platform Component Remover` に保存するように変更。適用時に設定を移行し、古い参照が残らないようレガシー配列をクリアします。

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
@@ -126,6 +126,8 @@ namespace KRT.VRCQuestTools.I18n
         internal string AlertForDynamicBoneConversion => GetText("AlertForDynamicBoneConversion");
         internal string AlertForMAConvertConstraints => GetText("AlertForMAConvertConstraints");
         internal string AlertForUnityConstraintsConversion => GetText("AlertForUnityConstraintsConversion");
+        internal string AlertForMASyncParameterSequence => GetText("AlertForMASyncParameterSequence");
+        internal string AlertForAaoTraceAndOptimize => GetText("AlertForAaoTraceAndOptimize");
         internal string AlertForMultiplePhysBones => GetText("AlertForMultiplePhysBones");
         internal string AlertForAvatarDynamicsPerformance => GetText("AlertForAvatarDynamicsPerformance");
         internal string AlertForComponents => GetText("AlertForComponents");

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
@@ -216,10 +216,16 @@ msgid "AlertForDynamicBoneConversion"
 msgstr "VRCQuestTools doesn't convert Dynamic Bones to PhysBones. Please set up PhysBones before converting the avatar."
 
 msgid "AlertForMAConvertConstraints"
-msgstr "Unity Constraints cannot be used on Mobile. You can non-destructively convert Unity Constraints to VRChat Constraints by adding a MA Convert Constraints component to the avatar."
+msgstr "Unity Constraints cannot be used on Mobile. Adding a MA Convert Constraints component to the avatar non-destructively converts Unity Constraints to VRChat Constraints."
 
 msgid "AlertForUnityConstraintsConversion"
-msgstr "VRCQuestTools doesn't convert Unity constraints to VRChat constraints. Please set up VRChat constraints before converting the avatar."
+msgstr "VRCQuestTools doesn't convert Unity Constraints to VRChat Constraints. Please set up VRChat Constraints before converting the avatar."
+
+msgid "AlertForMASyncParameterSequence"
+msgstr "Adding a MA Sync Parameter Sequence component prevents parameter synchronization mismatches between platforms."
+
+msgid "AlertForAaoTraceAndOptimize"
+msgstr "Adding an AAO Trace and Optimize component automatically optimizes the avatar."
 
 msgid "AlertForAvatarDynamicsPerformance"
 msgstr "Avatar Dynamics (PhysBones and Contacts) performance rating will be \"Very Poor\", so components will be removed even if you upload to Mobile. Please keep \"Poor\" rating in avatar dynamics categories."

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
@@ -216,10 +216,16 @@ msgid "AlertForDynamicBoneConversion"
 msgstr "VRCQuestTools は Dynamic Bone を PhysBone に変換しません。アバターを変換する前に PhysBone を設定してください。"
 
 msgid "AlertForMAConvertConstraints"
-msgstr "Mobile では Unity Constraints を使用できません。アバターに MA Convert Constraints コンポーネントを追加することで非破壊的に Unity Constraints を VRChat Constraints に変換することができます。"
+msgstr "Mobile では Unity Constraints を使用できません。アバターに MA Convert Constraints コンポーネントを追加することで Unity Constraints を VRChat Constraints に非破壊的に変換します。"
 
 msgid "AlertForUnityConstraintsConversion"
 msgstr "VRCQuestTools は Unity Constraints を VRChat Constraints に変換しません。アバターを変換する前に VRChat Constraints を設定してください。"
+
+msgid "AlertForMASyncParameterSequence"
+msgstr "MA Sync Parameter Sequence コンポーネントを追加すると、プラットフォーム間でのパラメーターの同期ずれを防ぎます。"
+
+msgid "AlertForAaoTraceAndOptimize"
+msgstr "AAO Trace and Optimize コンポーネントを追加すると、アバターを自動的に最適化します。"
 
 msgid "AlertForAvatarDynamicsPerformance"
 msgstr "Avatar Dynamics (PhysBones, Contacts) のパフォーマンスランクが Very Poor になっており、 Mobile 用にアップロードしてもコンポーネントが削除されます。 Avatar Dynamics のパフォーマンスランクが Poor に収まるようコンポーネントを削減してください。"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
@@ -112,6 +112,30 @@ namespace KRT.VRCQuestTools.Inspector
                         }
                     }
 
+                    if (ModularAvatarUtility.SupportsSyncParameterSequenceComponent() && !ModularAvatarUtility.HasSyncParameterSequenceComponent(avatar.GameObject))
+                    {
+                        using (var horizontal = new EditorGUILayout.HorizontalScope())
+                        {
+                            EditorGUILayout.HelpBox(i18n.AlertForMASyncParameterSequence, MessageType.Warning);
+                            if (GUILayout.Button(i18n.AddLabel, GUILayout.Height(38), GUILayout.Width(60)))
+                            {
+                                OnClickAddSyncParameterSequenceButton(descriptor);
+                            }
+                        }
+                    }
+
+                    if (AvatarOptimizerUtility.IsAvatarOptimizerImported() && !AvatarOptimizerUtility.HasTraceAndOptimizeComponent(avatar.GameObject))
+                    {
+                        using (var horizontal = new EditorGUILayout.HorizontalScope())
+                        {
+                            EditorGUILayout.HelpBox(i18n.AlertForAaoTraceAndOptimize, MessageType.Warning);
+                            if (GUILayout.Button(i18n.AddLabel, GUILayout.Height(38), GUILayout.Width(60)))
+                            {
+                                OnClickAddTraceAndOptimizeButton(descriptor);
+                            }
+                        }
+                    }
+
                     var pbs = descriptor.GetComponentsInChildren<VRCPhysBone>(true);
                     var multiPbObjs = pbs
                         .Select(pb => pb.gameObject)
@@ -135,6 +159,8 @@ namespace KRT.VRCQuestTools.Inspector
                             EditorGUILayout.Space(2);
                         });
                     }
+
+                    EditorGUILayout.Space(12);
                 }
                 else
                 {
@@ -532,6 +558,16 @@ namespace KRT.VRCQuestTools.Inspector
         private void OnClickAddConvertConstraintsButton(VRC_AvatarDescriptor avatar)
         {
             ModularAvatarUtility.AddConvertConstraintsComponent(avatar.gameObject);
+        }
+
+        private void OnClickAddSyncParameterSequenceButton(VRC_AvatarDescriptor avatar)
+        {
+            ModularAvatarUtility.AddSyncParameterSequenceComponent(avatar.gameObject);
+        }
+
+        private void OnClickAddTraceAndOptimizeButton(VRC_AvatarDescriptor avatar)
+        {
+            AvatarOptimizerUtility.AddTraceAndOptimizeComponent(avatar.gameObject);
         }
 
         private void OnClickAssignNetIdsButton(VRC_AvatarDescriptor avatar)


### PR DESCRIPTION
AvatarConverterSettings normally gains these companion components through the "Setup Avatar for Mobile" wizard's opt-in toggles, but nothing warned users who attach it directly via the Inspector. Mirror the existing MA Convert Constraints warning so the Inspector offers the same warning and Add button for these two components.

Also align capitalization of "Unity Constraints" / "VRChat Constraints" in the existing English alerts and rephrase AlertForMAConvertConstraints as a direct statement, matching the tone of the newly added alerts.