### PR TITLE
Open material/avatar dynamics foldouts by default and enlarge settings button

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
@@ -182,16 +182,19 @@ namespace KRT.VRCQuestTools.Inspector
                 editorState.foldOutAvatarDynamics = Views.EditorGUIUtility.Foldout(i18n.AvatarConverterAvatarDynamicsSettingsLabel, editorState.foldOutAvatarDynamics);
                 if (editorState.foldOutAvatarDynamics)
                 {
-                    EditorGUILayout.PropertyField(so.FindProperty("removeAvatarDynamics"), new GUIContent(i18n.AvatarConverterRemoveAvatarDynamicsLabel, i18n.AvatarConverterRemoveAvatarDynamicsTooltip));
+                    bool isLegacyMode = converterSettings.HasLegacyAvatarDynamicsSettings;
+
+                    if (isLegacyMode)
+                    {
+                        EditorGUILayout.PropertyField(so.FindProperty("removeAvatarDynamics"), new GUIContent(i18n.AvatarConverterRemoveAvatarDynamicsLabel, i18n.AvatarConverterRemoveAvatarDynamicsTooltip));
+                    }
 
                     if (converterSettings.removeAvatarDynamics)
                     {
-                        if (GUILayout.Button(i18n.AvatarConverterAvatarDynamicsSettingsLabel))
+                        if (Views.EditorGUIUtility.LargeButton(i18n.AvatarConverterAvatarDynamicsSettingsLabel))
                         {
                             OnClickSelectAvatarDynamicsComponentsButton(descriptor);
                         }
-
-                        bool isLegacyMode = converterSettings.HasLegacyAvatarDynamicsSettings;
 
                         if (isLegacyMode)
                         {
@@ -253,7 +256,7 @@ namespace KRT.VRCQuestTools.Inspector
                         Views.EditorGUIUtility.HelpBoxGUI(MessageType.Error, () =>
                         {
                             EditorGUILayout.LabelField(i18n.AlertForAvatarDynamicsPerformance, EditorStyles.wordWrappedMiniLabel);
-                            if (GUILayout.Button(i18n.AvatarConverterAvatarDynamicsSettingsLabel))
+                            if (Views.EditorGUIUtility.LargeButton(i18n.AvatarConverterAvatarDynamicsSettingsLabel))
                             {
                                 OnClickSelectAvatarDynamicsComponentsButton(descriptor);
                             }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
@@ -168,6 +168,16 @@ namespace KRT.VRCQuestTools.Inspector
                     canConvert = false;
                 }
 
+                if (!converterSettings.HasLegacyAvatarDynamicsSettings && !converterSettings.removeAvatarDynamics)
+                {
+                    // removeAvatarDynamics is only user-editable in legacy mode (see the foldout below).
+                    // Heal any stale false value from before this avatar's legacy settings were cleared,
+                    // since a hidden false would otherwise disable the Avatar Dynamics section with no
+                    // way to re-enable it from the Inspector.
+                    converterSettings.removeAvatarDynamics = true;
+                    EditorUtility.SetDirty(converterSettings);
+                }
+
                 var avatarDynamicsStats = converterSettings.removeAvatarDynamics ? GetEstimatedPerformanceStats(converterSettings) : null;
 
                 editorState.foldOutMaterialSettings = Views.EditorGUIUtility.Foldout(i18n.AvatarConverterMaterialConvertSettingsLabel, editorState.foldOutMaterialSettings);

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditorState.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditorState.cs
@@ -12,7 +12,7 @@ namespace KRT.VRCQuestTools.Inspector
         /// Whether to show the foldout for material settings.
         /// </summary>
         [SerializeField]
-        internal bool foldOutMaterialSettings = false;
+        internal bool foldOutMaterialSettings = true;
 
         /// <summary>
         /// Whether to show the foldout for additional material settings.
@@ -24,7 +24,7 @@ namespace KRT.VRCQuestTools.Inspector
         /// Whether to show the foldout for avatar dynamics.
         /// </summary>
         [SerializeField]
-        internal bool foldOutAvatarDynamics = false;
+        internal bool foldOutAvatarDynamics = true;
 
         /// <summary>
         /// Whether to show the foldout for estimated performance.


### PR DESCRIPTION
Expand the Material Conversion Settings and Avatar Dynamics sections by default so they are easier to discover, hide the legacy-only "Remove Avatar Dynamics" checkbox for non-legacy avatars (NDMF removal no longer reads this flag), and enlarge the Avatar Dynamics Settings button for easier clicking.