### PR TITLE
Add Enable Debug Log menu to the shipped package

### DIFF
--- a/Assets/VRCQuestTools-DebugUtil/Editor/DebugMenu.cs
+++ b/Assets/VRCQuestTools-DebugUtil/Editor/DebugMenu.cs
@@ -11,6 +11,20 @@ namespace KRT.VRCQuestTools.Debug
     internal static class DebugMenu
     {
         private const string DebugMenuRoot = VRCQuestToolsMenus.MenuPaths.RootMenu + "Debug/";
+        private const string DevDebugLogDefaultAppliedKey = "KRT.VRCQuestTools.Debug.DevDebugLogDefaultApplied";
+
+        // Debug logging defaults to on in this dev project (unlike the shipped package, which defaults to off).
+        // Only applied once so a later manual toggle via the Settings menu sticks.
+        [InitializeOnLoadMethod]
+        private static void EnableDebugLogByDefault()
+        {
+            if (EditorUserSettings.GetConfigValue(DevDebugLogDefaultAppliedKey) == null)
+            {
+                VRCQuestToolsSettings.IsDebugLogEnabled = true;
+                Logger.UseDebug = true;
+                EditorUserSettings.SetConfigValue(DevDebugLogDefaultAppliedKey, "TRUE");
+            }
+        }
 
         [MenuItem(DebugMenuRoot + "Clear Skipped Version")]
         private static void ClearSkippedVersion()

--- a/Assets/VRCQuestTools-DebugUtil/Editor/DebugMenu.cs
+++ b/Assets/VRCQuestTools-DebugUtil/Editor/DebugMenu.cs
@@ -11,22 +11,6 @@ namespace KRT.VRCQuestTools.Debug
     internal static class DebugMenu
     {
         private const string DebugMenuRoot = VRCQuestToolsMenus.MenuPaths.RootMenu + "Debug/";
-        private const string UseDebugKey = "KRT.VRCQuestTools.UseDebug";
-
-        [InitializeOnLoadMethod]
-        private static void Init()
-        {
-            Logger.UseDebug = SessionState.GetBool(UseDebugKey, true);
-            Menu.SetChecked(DebugMenuRoot + "Use Debug", Logger.UseDebug);
-        }
-
-        [MenuItem(DebugMenuRoot + "Use Debug")]
-        private static void ToggleDebug()
-        {
-            Logger.UseDebug = !Logger.UseDebug;
-            SessionState.SetBool(UseDebugKey, Logger.UseDebug);
-            Menu.SetChecked(DebugMenuRoot + "Use Debug", Logger.UseDebug);
-        }
 
         [MenuItem(DebugMenuRoot + "Clear Skipped Version")]
         private static void ClearSkippedVersion()

--- a/Assets/VRCQuestTools-Tests/Editor/Models/VRCQuestToolsSettingsTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Models/VRCQuestToolsSettingsTests.cs
@@ -69,12 +69,34 @@ namespace KRT.VRCQuestTools.Models
         {
             var folder1 = VRCQuestToolsSettings.TextureCacheFolder;
             var folder2 = VRCQuestToolsSettings.TextureCacheFolder;
-            
+
             // Should always return the same path
             Assert.AreEqual(folder1, folder2);
-            
+
             // Should be a relative path
             Assert.IsFalse(Path.IsPathRooted(folder1), "Cache folder should be a relative path");
+        }
+
+        /// <summary>
+        /// Test that debug log setting can be set and retrieved, and round-trips through both values.
+        /// </summary>
+        [Test]
+        public void DebugLogEnabledCanBeSetAndRetrieved()
+        {
+            var originalValue = VRCQuestToolsSettings.IsDebugLogEnabled;
+
+            try
+            {
+                VRCQuestToolsSettings.IsDebugLogEnabled = true;
+                Assert.IsTrue(VRCQuestToolsSettings.IsDebugLogEnabled);
+
+                VRCQuestToolsSettings.IsDebugLogEnabled = false;
+                Assert.IsFalse(VRCQuestToolsSettings.IsDebugLogEnabled);
+            }
+            finally
+            {
+                VRCQuestToolsSettings.IsDebugLogEnabled = originalValue;
+            }
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Experimental) Material conversion from Poiyomi to Toon Standard.
 - Material conversion for particle shaders, particle systems, trail renderers and line renderers.
 - `Avatar Converter Settings` now warns when a MA Sync Parameter Sequence or AAO Trace and Optimize component is missing on the avatar, with a button to add it.
+- Added `Enable Debug Log` menu under `Tools/VRCQuestTools/Settings` to enable verbose debug logging in real projects.
 
 ### Changed
 - Avatar Dynamics Selector now stores keep/remove settings in `Platform Component Remover` instead of the legacy arrays in `Avatar Converter Settings`. Applying the selector migrates settings and clears the legacy arrays to avoid stale references.

--- a/CHANGELOG_JP.md
+++ b/CHANGELOG_JP.md
@@ -23,6 +23,7 @@
 - (実験的機能) Poiyomi から Toon Standard へのマテリアル変換を追加。
 - パーティクルシェーダー、パーティクルシステム、Trail Renderer、Line Renderer 専用のマテリアル変換を追加。
 - `Avatar Converter Settings` で、アバターに MA Sync Parameter Sequence または AAO Trace and Optimize コンポーネントがない場合に警告と追加ボタンを表示するように追加。
+- `Tools/VRCQuestTools/Settings` に `Enable Debug Log` メニューを追加し、実プロジェクトでもデバッグログを有効化できるようにしました。
 
 ### 変更
 - Avatar Dynamics Selector の保持/削除設定を `Avatar Converter Settings` のレガシー配列ではなく `Platform Component Remover` に保存するように変更。適用時に設定を移行し、古い参照が残らないようレガシー配列をクリアします。

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/SettingsMenu.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/SettingsMenu.cs
@@ -13,6 +13,12 @@ namespace KRT.VRCQuestTools.Menus
     /// </summary>
     internal static class SettingsMenu
     {
+        [InitializeOnLoadMethod]
+        private static void InitDebugLog()
+        {
+            Logger.UseDebug = VRCQuestToolsSettings.IsDebugLogEnabled;
+        }
+
         [MenuItem(VRCQuestToolsMenus.MenuPaths.EnableValidationAutomator, false, (int)VRCQuestToolsMenus.MenuPriorities.EnableValidationAutomator)]
         private static void ToggleValidationAutomator()
         {
@@ -36,6 +42,20 @@ namespace KRT.VRCQuestTools.Menus
         private static bool ToggleTextureFormatCheckOnStandaloneValidation()
         {
             Menu.SetChecked(VRCQuestToolsMenus.MenuPaths.EnableTextureFormatCheckOnStandalone, VRCQuestToolsSettings.IsCheckTextureFormatOnStandaloneEnabled);
+            return true;
+        }
+
+        [MenuItem(VRCQuestToolsMenus.MenuPaths.EnableDebugLog, false, (int)VRCQuestToolsMenus.MenuPriorities.EnableDebugLog)]
+        private static void ToggleDebugLog()
+        {
+            VRCQuestToolsSettings.IsDebugLogEnabled = !VRCQuestToolsSettings.IsDebugLogEnabled;
+            Logger.UseDebug = VRCQuestToolsSettings.IsDebugLogEnabled;
+        }
+
+        [MenuItem(VRCQuestToolsMenus.MenuPaths.EnableDebugLog, true)]
+        private static bool ToggleDebugLogValidation()
+        {
+            Menu.SetChecked(VRCQuestToolsMenus.MenuPaths.EnableDebugLog, VRCQuestToolsSettings.IsDebugLogEnabled);
             return true;
         }
     }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/VRCQuestToolsMenus.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/VRCQuestToolsMenus.cs
@@ -30,6 +30,7 @@ namespace KRT.VRCQuestTools.Menus
             private const string SettingsMenu = RootMenu + "Settings/";
             internal const string EnableValidationAutomator = SettingsMenu + "Enable Validation Automator";
             internal const string EnableTextureFormatCheckOnStandalone = SettingsMenu + "[NDMF] Enable Texture Format Check on Windows Build";
+            internal const string EnableDebugLog = SettingsMenu + "Enable Debug Log";
             private const string LanguageMenu = RootMenu + "Languages/";
             internal const string LanguageAuto = LanguageMenu + "Auto (default)";
             internal const string LanguageEnglish = LanguageMenu + "English";
@@ -54,6 +55,7 @@ namespace KRT.VRCQuestTools.Menus
             ClearTextureCache,
             EnableValidationAutomator = 950,
             EnableTextureFormatCheckOnStandalone,
+            EnableDebugLog,
             LanguageAuto = 1000,
             LanguageEnglish,
             LanguageJapanese,

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRCQuestToolsSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRCQuestToolsSettings.cs
@@ -173,6 +173,15 @@ namespace KRT.VRCQuestTools.Models
             set { SetBooleanConfigValue(Keys.CheckTextureFormatOnStandalone, value); }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether debug logging is enabled.
+        /// </summary>
+        internal static bool IsDebugLogEnabled
+        {
+            get { return GetBooleanConfigValue(Keys.DebugLogEnabled, false); }
+            set { SetBooleanConfigValue(Keys.DebugLogEnabled, value); }
+        }
+
         private static DateTime UnixEpoch => new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
         /// <summary>
@@ -233,6 +242,7 @@ namespace KRT.VRCQuestTools.Models
             internal const string TextureCacheDirectory = PREFIX + "TextureCacheDirectory";
             internal const string ValidationAutomatorEnabled = PREFIX + "ValidationAutomatorEnabled";
             internal const string CheckTextureFormatOnStandalone = PREFIX + "CheckTextureFormatOnStandalone";
+            internal const string DebugLogEnabled = PREFIX + "DebugLogEnabled";
             private const string PREFIX = "dev.kurotu.VRCQuestTools.";
         }
     }

--- a/Website/docs/menu-reference.md
+++ b/Website/docs/menu-reference.md
@@ -69,6 +69,7 @@ Toggles the behavior of VRCQuestTools.
 
 - **Enable Validation Automator**: Automatically validates avatars in the scene and notifies you of problems.
 - **[NDMF] Enable Texture Format Check on Windows Build**: Checks Windows builds for texture formats which can't be used on Mobile.
+- **Enable Debug Log**: Outputs verbose debug logs to the Console for troubleshooting.
 
 ## Languages
 

--- a/Website/i18n/ja/docusaurus-plugin-content-docs/current/menu-reference.md
+++ b/Website/i18n/ja/docusaurus-plugin-content-docs/current/menu-reference.md
@@ -69,6 +69,7 @@ VRCQuestTools の動作設定を切り替えます。
 
 - **Enable Validation Automator**：シーン内のアバターを自動で検証し、問題があれば通知します。
 - **[NDMF] Enable Texture Format Check on Windows Build**：Windows 向けビルド時に、Mobile で使用できないテクスチャ形式が含まれていないかを確認します。
+- **Enable Debug Log**：不具合調査用に、詳細なデバッグログを Console に出力します。
 
 ## Languages
 


### PR DESCRIPTION
Move the dev-only "Use Debug" toggle into Tools/VRCQuestTools/Settings so Logger.LogDebug output can be enabled for troubleshooting in real projects, not just in the development environment. The setting now persists via EditorUserSettings instead of SessionState.