### PR TITLE
Improve texture cache size handling and storage format

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/TextureDiskCacheTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/TextureDiskCacheTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="TextureDiskCacheTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System.IO;
+using KRT.VRCQuestTools.Models.Unity;
+using KRT.VRCQuestTools.Utils;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Models
+{
+    /// <summary>
+    /// Tests for the texture disk cache behind <see cref="MaterialGeneratorUtility"/>: a generated texture is
+    /// written to <see cref="CacheManager.Texture"/> and restored from it on the next identical request.
+    /// </summary>
+    public class TextureDiskCacheTests
+    {
+        /// <summary>
+        /// Setup test.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            CacheManager.Texture.Clear();
+        }
+
+        /// <summary>
+        /// Test that generating the same texture twice writes one cache entry and restores it byte for byte,
+        /// covering the whole disk round trip (compressed result -> binary entry -> restored texture) rather
+        /// than just the serialization in isolation.
+        /// </summary>
+        [Test]
+        public void GeneratedTextureIsRestoredFromDiskCache()
+        {
+            var settings = new ToonLitConvertSettings
+            {
+                generateQuestTextures = true,
+                mainTextureBrightness = 1.0f,
+            };
+            var generator = new ToonLitGenerator(settings);
+            var cacheFolder = VRCQuestToolsSettings.TextureCacheFolder;
+
+            Material generatedMaterial = null;
+            generator.GenerateMaterial(TestUtils.LoadMaterialWrapper("Standard_NoEmission.mat"), UnityEditor.BuildTarget.Android, false, string.Empty, (m) => { generatedMaterial = m; })
+                .WaitForCompletion();
+
+            var entriesAfterGeneration = Directory.GetFiles(cacheFolder, "*.bin").Length;
+            Assert.Greater(entriesAfterGeneration, 0, "Generating a texture should write a binary disk cache entry.");
+
+            Material restoredMaterial = null;
+            generator.GenerateMaterial(TestUtils.LoadMaterialWrapper("Standard_NoEmission.mat"), UnityEditor.BuildTarget.Android, false, string.Empty, (m) => { restoredMaterial = m; })
+                .WaitForCompletion();
+
+            using (var generated = DisposableObject.New(generatedMaterial))
+            using (var restored = DisposableObject.New(restoredMaterial))
+            using (var generatedTexture = DisposableObject.New(generated.Object.mainTexture as Texture2D))
+            using (var restoredTexture = DisposableObject.New(restored.Object.mainTexture as Texture2D))
+            {
+                Assert.AreEqual(entriesAfterGeneration, Directory.GetFiles(cacheFolder, "*.bin").Length, "The second request should reuse the existing entry instead of writing another one.");
+                Assert.IsNotNull(generatedTexture.Object);
+                Assert.IsNotNull(restoredTexture.Object);
+                Assert.AreEqual(generatedTexture.Object.width, restoredTexture.Object.width);
+                Assert.AreEqual(generatedTexture.Object.height, restoredTexture.Object.height);
+                Assert.AreEqual(generatedTexture.Object.format, restoredTexture.Object.format);
+                Assert.AreEqual(generatedTexture.Object.mipmapCount, restoredTexture.Object.mipmapCount);
+                Assert.AreEqual(generatedTexture.Object.GetRawTextureData(), restoredTexture.Object.GetRawTextureData(), "The restored texture should hold exactly the bytes that were cached.");
+            }
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/TextureDiskCacheTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/Models/MaterialGenerators/TextureDiskCacheTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3fe947607b5fe7439b7fed54cd8c6ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/Models/VRCQuestToolsSettingsTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Models/VRCQuestToolsSettingsTests.cs
@@ -40,10 +40,10 @@ namespace KRT.VRCQuestTools.Models
         }
 
         /// <summary>
-        /// Test that default texture cache size is 128MB.
+        /// Test that default texture cache size is 1GB.
         /// </summary>
         [Test]
-        public void DefaultTextureCacheSizeIs128MB()
+        public void DefaultTextureCacheSizeIs1GB()
         {
             var originalSize = VRCQuestToolsSettings.TextureCacheSize;
 
@@ -52,8 +52,28 @@ namespace KRT.VRCQuestTools.Models
                 // Reset to defaults
                 VRCQuestToolsSettings.ResetPreferences();
 
-                var expectedSize = 128UL * 1024 * 1024;
+                var expectedSize = 1024UL * 1024 * 1024;
                 Assert.AreEqual(expectedSize, VRCQuestToolsSettings.TextureCacheSize);
+            }
+            finally
+            {
+                VRCQuestToolsSettings.TextureCacheSize = originalSize;
+            }
+        }
+
+        /// <summary>
+        /// Test that an out-of-range texture cache size is clamped instead of stored as-is, so eviction can
+        /// never be handed a limit it cannot act on.
+        /// </summary>
+        [Test]
+        public void TextureCacheSizeIsClampedToMaximum()
+        {
+            var originalSize = VRCQuestToolsSettings.TextureCacheSize;
+
+            try
+            {
+                VRCQuestToolsSettings.TextureCacheSize = ulong.MaxValue;
+                Assert.AreEqual(VRCQuestToolsSettings.MaxTextureCacheSize, VRCQuestToolsSettings.TextureCacheSize);
             }
             finally
             {

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/CacheManagerTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/CacheManagerTests.cs
@@ -377,6 +377,35 @@ namespace KRT.VRCQuestTools.Utils
         }
 
         /// <summary>
+        /// Test that a corrupt data length in an otherwise well-formed entry is rejected before a buffer of that
+        /// size is allocated, rather than after the read has already been attempted.
+        /// </summary>
+        [Test]
+        public void TextureCache_ReadFromRejectsImplausibleDataLength()
+        {
+            using (var stream = new MemoryStream())
+            {
+                // Mirrors TextureCache.WriteTo's layout, but declares far more texture data than the entry holds.
+                using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
+                {
+                    writer.Write(new byte[] { (byte)'V', (byte)'Q', (byte)'T', (byte)'C' });
+                    writer.Write(CacheUtility.TextureCache.FormatVersion);
+                    writer.Write(16);
+                    writer.Write(16);
+                    writer.Write((int)TextureFormat.RGBA32);
+                    writer.Write((int)BuildTarget.Android);
+                    writer.Write(false);
+                    writer.Write(false);
+                    writer.Write(false);
+                    writer.Write(int.MaxValue);
+                }
+                stream.Position = 0;
+
+                Assert.Throws<InvalidDataException>(() => CacheUtility.TextureCache.ReadFrom(stream));
+            }
+        }
+
+        /// <summary>
         /// Test that TextureCache.ToTexture2D falls back to building the normal map container directly
         /// (instead of throwing) when the pre-baked blank normal map asset used as a container doesn't match
         /// the texture attributes recorded at cache-save time.

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/CacheManagerTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/CacheManagerTests.cs
@@ -79,6 +79,91 @@ namespace KRT.VRCQuestTools.Utils
         }
 
         /// <summary>
+        /// Test that binary entries survive a save/load round trip without going through a string.
+        /// </summary>
+        [Test]
+        public void SaveAndLoadBinary()
+        {
+            var testFileName = "binary.bin";
+            var testData = new byte[] { 0x00, 0x01, 0xFE, 0xFF, 0x7F, 0x80 };
+
+            testCacheManager.SaveBinary(testFileName, stream => stream.Write(testData, 0, testData.Length));
+            Assert.IsTrue(testCacheManager.Exists(testFileName));
+
+            var loaded = testCacheManager.LoadBinary(testFileName, stream =>
+            {
+                var buffer = new byte[testData.Length];
+                var read = stream.Read(buffer, 0, buffer.Length);
+                Assert.AreEqual(testData.Length, read);
+                Assert.AreEqual(-1, stream.ReadByte(), "Entry should contain exactly the written bytes.");
+                return buffer;
+            });
+
+            Assert.AreEqual(testData, loaded);
+        }
+
+        /// <summary>
+        /// Test that eviction removes the least recently accessed entries until the total fits the given size.
+        /// </summary>
+        [Test]
+        public void ClearToFitSizeEvictsLeastRecentlyAccessed()
+        {
+            var data = new string('x', 1000);
+            var names = new[] { "oldest.txt", "middle.txt", "newest.txt" };
+            for (int i = 0; i < names.Length; i++)
+            {
+                testCacheManager.Save(names[i], data);
+                File.SetLastAccessTimeUtc(Path.Combine(testCacheFolder, names[i]), new System.DateTime(2020, 1, 1 + i, 0, 0, 0, System.DateTimeKind.Utc));
+            }
+
+            // Fits the two most recently accessed entries (2000 bytes), but not the third.
+            testCacheManager.Clear(2500);
+
+            Assert.IsFalse(testCacheManager.Exists("oldest.txt"), "The least recently accessed entry should be evicted.");
+            Assert.IsTrue(testCacheManager.Exists("middle.txt"));
+            Assert.IsTrue(testCacheManager.Exists("newest.txt"));
+        }
+
+        /// <summary>
+        /// Test that entries written under a different stamp (e.g. by another tool version, or in another cache
+        /// entry format) are discarded on first access, since their file names are hashed and cannot be
+        /// recognized individually.
+        /// </summary>
+        [Test]
+        public void StampMismatchDiscardsEntries()
+        {
+            var name = "stamped.bin";
+            var oldStampManager = new CacheManager(() => testCacheFolder, true, () => "stamp-a");
+            oldStampManager.Save(name, "data");
+            Assert.IsTrue(oldStampManager.Exists(name));
+
+            // A fresh instance stands in for the next domain reload, this time expecting another stamp.
+            var newStampManager = new CacheManager(() => testCacheFolder, true, () => "stamp-b");
+            Assert.IsFalse(newStampManager.Exists(name), "Entries written under the previous stamp should be discarded.");
+        }
+
+        /// <summary>
+        /// Test that entries are kept when the recorded stamp still matches, and that clearing the cache does
+        /// not lose the recorded stamp (which would make the next access discard perfectly valid entries).
+        /// </summary>
+        [Test]
+        public void StampMatchKeepsEntries()
+        {
+            var name = "stamped.bin";
+            var manager = new CacheManager(() => testCacheFolder, true, () => "stamp-a");
+            manager.Save(name, "data");
+
+            var sameStampManager = new CacheManager(() => testCacheFolder, true, () => "stamp-a");
+            Assert.IsTrue(sameStampManager.Exists(name), "Entries written under the same stamp should be kept.");
+
+            sameStampManager.Clear();
+            sameStampManager.Save(name, "data again");
+
+            var afterClearManager = new CacheManager(() => testCacheFolder, true, () => "stamp-a");
+            Assert.IsTrue(afterClearManager.Exists(name), "Clearing the cache should not lose the recorded stamp.");
+        }
+
+        /// <summary>
         /// Test that cache uses lock for thread-safety.
         /// </summary>
         [Test]
@@ -226,6 +311,68 @@ namespace KRT.VRCQuestTools.Utils
                 {
                     File.Delete(destPath);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Test that a texture cache entry survives a binary write/read round trip with its attributes and its
+        /// raw bytes intact.
+        /// </summary>
+        [Test]
+        public void TextureCache_BinaryRoundTrip()
+        {
+            Texture2D source = null;
+            Texture2D restored = null;
+            try
+            {
+                source = new Texture2D(8, 8, TextureFormat.RGBA32, false, false);
+                var pixels = new Color32[8 * 8];
+                for (int i = 0; i < pixels.Length; i++)
+                {
+                    pixels[i] = new Color32((byte)i, (byte)(255 - i), (byte)(i * 2), 255);
+                }
+                source.SetPixels32(pixels);
+                source.Apply();
+
+                var expectedBytes = source.GetRawTextureData();
+
+                CacheUtility.TextureCache readBack;
+                using (var stream = new MemoryStream())
+                {
+                    new CacheUtility.TextureCache(source, false, false, BuildTarget.Android).WriteTo(stream);
+                    stream.Position = 0;
+                    readBack = CacheUtility.TextureCache.ReadFrom(stream);
+                }
+
+                restored = readBack.ToTexture2D();
+                Assert.AreEqual(source.width, restored.width);
+                Assert.AreEqual(source.height, restored.height);
+                Assert.AreEqual(source.format, restored.format);
+                Assert.AreEqual(source.mipmapCount, restored.mipmapCount);
+                Assert.AreEqual(expectedBytes, restored.GetRawTextureData());
+            }
+            finally
+            {
+                if (source != null)
+                {
+                    Object.DestroyImmediate(source);
+                }
+                if (restored != null)
+                {
+                    Object.DestroyImmediate(restored);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Test that a file which is not a texture cache entry is rejected instead of being interpreted as one.
+        /// </summary>
+        [Test]
+        public void TextureCache_ReadFromRejectsForeignData()
+        {
+            using (var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }))
+            {
+                Assert.Throws<InvalidDataException>(() => CacheUtility.TextureCache.ReadFrom(stream));
             }
         }
 

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/PreviewTextureCompressionQueueTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/PreviewTextureCompressionQueueTests.cs
@@ -82,7 +82,7 @@ namespace KRT.VRCQuestTools.Utils
                 return 1;
             });
 
-            var cacheFile = $"test_progressive_{Guid.NewGuid():N}.json";
+            var cacheFile = $"test_progressive_{Guid.NewGuid():N}.bin";
             var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
             Assert.IsTrue(enqueued, "TryEnqueue should succeed when a replacer is registered and the pending-bytes cap has headroom.");
             Assert.AreEqual(1, PreviewTextureCompressionQueue.PendingCountForTesting);
@@ -117,7 +117,7 @@ namespace KRT.VRCQuestTools.Utils
                 return 1;
             });
 
-            var cacheFile = $"test_progressive_normal_{Guid.NewGuid():N}.json";
+            var cacheFile = $"test_progressive_normal_{Guid.NewGuid():N}.bin";
             var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, true, false, null, cacheFile, false);
             Assert.IsTrue(enqueued);
 
@@ -146,7 +146,7 @@ namespace KRT.VRCQuestTools.Utils
 
             PreviewTextureCompressionQueue.RegisterMaterialTextureReplacer((from, to) => 0);
 
-            var cacheFile = $"test_progressive_orphan_{Guid.NewGuid():N}.json";
+            var cacheFile = $"test_progressive_orphan_{Guid.NewGuid():N}.bin";
             PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
 
             var task = PreviewTextureCompressionQueue.ProcessNextForTesting();
@@ -171,7 +171,7 @@ namespace KRT.VRCQuestTools.Utils
             {
                 PreviewTextureCompressionQueue.RegisterMaterialTextureReplacer(null);
 
-                var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, "test_progressive_none.json", true);
+                var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, "test_progressive_none.bin", true);
 
                 Assert.IsFalse(enqueued);
                 Assert.AreEqual(0, PreviewTextureCompressionQueue.PendingCountForTesting);
@@ -207,7 +207,7 @@ namespace KRT.VRCQuestTools.Utils
             {
                 field.SetValue(null, PreviewTextureCompressionQueue.MaxPendingBytes);
 
-                var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, "test_progressive_cap.json", true);
+                var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, "test_progressive_cap.bin", true);
 
                 Assert.IsFalse(enqueued, "TryEnqueue must refuse once the pending-bytes cap would be exceeded.");
                 Assert.AreEqual(0, PreviewTextureCompressionQueue.PendingCountForTesting);
@@ -246,7 +246,7 @@ namespace KRT.VRCQuestTools.Utils
                 return 1;
             });
 
-            var cacheFile = $"test_progressive_fallback_{Guid.NewGuid():N}.json";
+            var cacheFile = $"test_progressive_fallback_{Guid.NewGuid():N}.bin";
             var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, brokenCompressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
             Assert.IsTrue(enqueued);
 
@@ -291,7 +291,7 @@ namespace KRT.VRCQuestTools.Utils
 
             PreviewTextureCompressionQueue.RegisterMaterialTextureReplacer((from, to) => 1);
 
-            var cacheFile = $"test_progressive_predestroyed_{Guid.NewGuid():N}.json";
+            var cacheFile = $"test_progressive_predestroyed_{Guid.NewGuid():N}.bin";
             var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
             Assert.IsTrue(enqueued);
 
@@ -346,7 +346,7 @@ namespace KRT.VRCQuestTools.Utils
 
             PreviewTextureCompressionQueue.RegisterMaterialTextureReplacer((from, to) => 1);
 
-            var cacheFile = $"test_progressive_underflow_{Guid.NewGuid():N}.json";
+            var cacheFile = $"test_progressive_underflow_{Guid.NewGuid():N}.bin";
             var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
             Assert.IsTrue(enqueued);
 
@@ -402,7 +402,7 @@ namespace KRT.VRCQuestTools.Utils
             {
                 for (var i = 0; i < placeholders.Length; i++)
                 {
-                    var cacheFile = $"test_progressive_parallel_{i}_{Guid.NewGuid():N}.json";
+                    var cacheFile = $"test_progressive_parallel_{i}_{Guid.NewGuid():N}.bin";
                     var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholders[i], compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
                     Assert.IsTrue(enqueued);
                 }
@@ -488,7 +488,7 @@ namespace KRT.VRCQuestTools.Utils
             {
                 foreach (var placeholder in placeholders)
                 {
-                    var cacheFile = $"test_progressive_capbound_{Guid.NewGuid():N}.json";
+                    var cacheFile = $"test_progressive_capbound_{Guid.NewGuid():N}.bin";
                     Assert.IsTrue(PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true));
                 }
 
@@ -563,8 +563,8 @@ namespace KRT.VRCQuestTools.Utils
 
             try
             {
-                Assert.IsTrue(PreviewTextureCompressionQueue.TryEnqueue(placeholderA, compressor, TextureFormat.ASTC_4x4, false, false, null, $"test_progressive_capone_a_{Guid.NewGuid():N}.json", true));
-                Assert.IsTrue(PreviewTextureCompressionQueue.TryEnqueue(placeholderB, compressor, TextureFormat.ASTC_4x4, false, false, null, $"test_progressive_capone_b_{Guid.NewGuid():N}.json", true));
+                Assert.IsTrue(PreviewTextureCompressionQueue.TryEnqueue(placeholderA, compressor, TextureFormat.ASTC_4x4, false, false, null, $"test_progressive_capone_a_{Guid.NewGuid():N}.bin", true));
+                Assert.IsTrue(PreviewTextureCompressionQueue.TryEnqueue(placeholderB, compressor, TextureFormat.ASTC_4x4, false, false, null, $"test_progressive_capone_b_{Guid.NewGuid():N}.bin", true));
 
                 var firstBatch = PreviewTextureCompressionQueue.DispatchAvailableForTesting();
                 Assert.AreEqual(1, firstBatch.Length, "Only one item should be dispatched at a time when the cap is 1.");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integrated menu icon settings into `Avatar Converter Settings`, and aligned NDMF icon processing with `VQT Menu Icon Resizer`.
 - Renamed `Convert Avatar for Mobile` to `Setup Avatar for Mobile` and updated setup to use availability-aware MA/AAO options with disabled already-added items and `MA Sync Parameter Sequence` defaulting `PrimaryPlatform` to `PC`.
 - Improved `Avatar Converter Settings` inspector layout.
+- The default texture cache size limit is now 1GB instead of 128MB, so generated textures survive long enough to actually be reused. Projects which never changed the setting are updated to the new default automatically.
+- Texture cache entries are now stored in a compact binary format instead of base64-encoded JSON, which makes the cache about 25% smaller on disk and reduces memory use while converting. Entries written by other versions are discarded automatically instead of occupying the size limit.
+- The texture cache size limit is now applied after NDMF material conversion previews as well, which previously could grow the cache beyond the limit until an avatar was actually converted.
 
 ### Fixed
 - `InvalidMaterialSwapNullException` did not properly return the invalid mapping.
+- Fixed `Texture Cache Size (MB)` in Project Settings accepting an out-of-range value, where a negative value disabled the size limit entirely.
 - Fixed RenderTexture and Material memory leaks in texture generation pipeline during avatar conversion.
 - Fixed an issue where texture generation failed when a material used an un-rendered RenderTexture as a texture.
 - Limited stack trace lines shown in avatar conversion failure dialog to keep the dialog operable.

--- a/CHANGELOG_JP.md
+++ b/CHANGELOG_JP.md
@@ -48,9 +48,13 @@
 - メニューアイコン設定を `Avatar Converter Settings` に統合し、NDMFのアイコン処理を `VQT Menu Icon Resizer` に統一。
 - `Convert Avatar for Mobile` を `Setup Avatar for Mobile` に改名し、初期セットアップをMA/AAOの利用可否対応・既存コンポーネント無効化表示・`MA Sync Parameter Sequence` の `PrimaryPlatform=PC` 設定を含む挙動へ統合。
 - `Avatar Converter Settings` インスペクターのレイアウトを改善。
+- テクスチャキャッシュの上限のデフォルトを 128MB から 1GB に変更。生成したテクスチャが再利用される前に破棄されにくくなります。設定を変更していないプロジェクトは自動的に新しいデフォルトへ更新されます。
+- テクスチャキャッシュの保存形式を base64 の JSON からバイナリ形式に変更。ディスク使用量が約 25% 減り、変換中のメモリ使用量も減ります。他のバージョンが書き込んだキャッシュは上限を占有せず自動的に破棄されます。
+- NDMF のマテリアル変換プレビューの後にもテクスチャキャッシュの上限を適用するように変更。従来はアバターを変換するまで上限を超えて増え続けていました。
 
 ### 修正
 - `InvalidMaterialSwapNullException` が問題のあるマッピングを返さない問題を修正。
+- Project Settings の `Texture Cache Size (MB)` が範囲外の値を受け付け、負の値を入力すると上限が無効になる問題を修正。
 - アバター変換時のテクスチャ生成処理における RenderTexture と Material のメモリリークを修正。
 - 一度も描画されていない RenderTexture をテクスチャとして使用しているマテリアルのテクスチャ生成が失敗する問題を修正。
 - アバター変換失敗ダイアログに表示するスタックトレースの行数を制限し、ダイアログが操作不能になる問題を修正。

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/MaterialGeneratorUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/MaterialGeneratorUtility.cs
@@ -1,3 +1,8 @@
+// <copyright file="MaterialGeneratorUtility.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 using System;
 using System.IO;
 using KRT.VRCQuestTools.Utils;
@@ -105,7 +110,7 @@ namespace KRT.VRCQuestTools.Models
                 compressorKeyComponent = "_" + TextureCompressorProvider.GetCompressor(compressionFormat).CacheKeyComponent;
             }
 
-            var cacheFile = $"texture_{VRCQuestTools.Version}_{settings.GetType()}_{textureType}_{EditorUserBuildSettings.activeBuildTarget}{compressorKeyComponent}_{assetHash}" + (saveAsPng ? ".png" : ".json");
+            var cacheFile = $"texture_{VRCQuestTools.Version}_{settings.GetType()}_{textureType}_{EditorUserBuildSettings.activeBuildTarget}{compressorKeyComponent}_{assetHash}" + (saveAsPng ? ".png" : ".bin");
             var texName = $"{material.name}_{textureType}";
             string outFile = null;
             if (saveAsPng)
@@ -245,7 +250,7 @@ namespace KRT.VRCQuestTools.Models
                     }
                     else
                     {
-                        var cache = JsonUtility.FromJson<CacheUtility.TextureCache>(CacheManager.Texture.LoadString(cacheFile));
+                        var cache = CacheManager.Texture.LoadBinary(cacheFile, CacheUtility.TextureCache.ReadFrom);
                         var tex = cache.ToTexture2D();
                         TextureUtility.SetStreamingMipMaps(tex, true);
                         return tex;
@@ -303,7 +308,8 @@ namespace KRT.VRCQuestTools.Models
                 // instance (e.g. the astcenc path always returns a new Texture2D on success), which would silently
                 // drop a flag set on the pre-compression instance.
                 TextureUtility.SetStreamingMipMaps(texToWrite, true);
-                CacheManager.Texture.Save(cacheFile, JsonUtility.ToJson(new CacheUtility.TextureCache(texToWrite, !config.isSRGB, config.isNormalMap, EditorUserBuildSettings.activeBuildTarget)));
+                var cache = new CacheUtility.TextureCache(texToWrite, !config.isSRGB, config.isNormalMap, EditorUserBuildSettings.activeBuildTarget);
+                CacheManager.Texture.SaveBinary(cacheFile, cache.WriteTo);
             }
 
             return texToWrite;

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRCQuestToolsProjectSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRCQuestToolsProjectSettings.cs
@@ -1,4 +1,9 @@
-﻿using System;
+// <copyright file="VRCQuestToolsProjectSettings.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System;
 
 namespace KRT.VRCQuestTools.Models
 {
@@ -9,14 +14,36 @@ namespace KRT.VRCQuestTools.Models
     internal class VRCQuestToolsProjectSettings
     {
         /// <summary>
+        /// Schema version written by the current implementation. Bump this when a stored value needs a
+        /// migration in <see cref="VRCQuestToolsSettings"/>.
+        /// </summary>
+        internal const int CurrentSettingsVersion = 1;
+
+        /// <summary>
+        /// Default texture cache size in bytes (1GB).
+        /// </summary>
+        /// <remarks>
+        /// Deliberately generous: the folder lives under <c>Library/</c> (regenerable, not source controlled),
+        /// while a single cache entry ranges from well under a megabyte (1024x1024 ASTC 6x6) to several megabytes
+        /// (2048x2048 ASTC 4x4). A limit that only holds a dozen or so entries would evict an avatar's textures
+        /// before they are ever reused, spending disk I/O for no cache hits at all.
+        /// </remarks>
+        internal const ulong DefaultTextureCacheSize = 1024UL * 1024 * 1024;
+
+        /// <summary>
+        /// Schema version of the loaded settings. 0 means the settings were written before versioning was
+        /// introduced, which drives the one-time migrations in <see cref="VRCQuestToolsSettings"/>.
+        /// </summary>
+        public int SettingsVersion = 0;
+
+        /// <summary>
         /// Enable Auto Remove Vertex Colors.
         /// </summary>
         public bool AutoRemoveVertexColors = true;
 
         /// <summary>
         /// Texture cache size in bytes.
-        /// Default: 128MB.
         /// </summary>
-        public ulong TextureCacheSize = 128 * 1024 * 1024;
+        public ulong TextureCacheSize = DefaultTextureCacheSize;
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRCQuestToolsSettings.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRCQuestToolsSettings.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="VRCQuestToolsSettings.cs" company="kurotu">
+// <copyright file="VRCQuestToolsSettings.cs" company="kurotu">
 // Copyright (c) kurotu.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 // </copyright>
@@ -20,7 +20,21 @@ namespace KRT.VRCQuestTools.Models
         private const string FALSE = "FALSE";
         private const string TRUE = "TRUE";
         private const string ProjectSettingsFile = "ProjectSettings/VRCQuestToolsSettings.json";
-        private const ulong DefaultTextureCacheSize = 128 * 1024 * 1024; // 128MB
+
+        /// <summary>
+        /// Upper bound accepted for <see cref="TextureCacheSize"/> (1TB). Guards against a value large enough
+        /// to overflow the byte arithmetic in the settings UI, and against a nonsensical limit reached by
+        /// hand-editing the settings file.
+        /// </summary>
+        internal const ulong MaxTextureCacheSize = 1024UL * 1024 * 1024 * 1024;
+
+        /// <summary>
+        /// Texture cache size default used before <see cref="VRCQuestToolsProjectSettings.CurrentSettingsVersion"/>
+        /// 1 (128MB). Kept only to recognize stored values that came from that default rather than from a
+        /// deliberate choice; see <see cref="MigrateProjectSettings"/>.
+        /// </summary>
+        private const ulong LegacyDefaultTextureCacheSize = 128UL * 1024 * 1024;
+
         private static readonly string DefaultTextureCacheDirectory = Path.Combine("Library", "VRCQuestTools", "Cache", "TextureCache");
 
         private static I18nBase i18n = null;
@@ -126,20 +140,22 @@ namespace KRT.VRCQuestTools.Models
         }
 
         /// <summary>
-        /// Gets or sets the total size of texture cache.
+        /// Gets or sets the total size of texture cache. Clamped to <see cref="MaxTextureCacheSize"/> on both
+        /// read and write, so neither a caller nor a hand-edited settings file can install a limit that breaks
+        /// eviction.
         /// </summary>
         internal static ulong TextureCacheSize
         {
             get
             {
                 var settings = GetProjectSettings();
-                return settings.TextureCacheSize;
+                return ClampTextureCacheSize(settings.TextureCacheSize);
             }
 
             set
             {
                 var settings = GetProjectSettings();
-                settings.TextureCacheSize = value;
+                settings.TextureCacheSize = ClampTextureCacheSize(value);
                 SaveProjectSettings(settings);
             }
         }
@@ -190,8 +206,13 @@ namespace KRT.VRCQuestTools.Models
         internal static void ResetPreferences()
         {
             var settings = GetProjectSettings();
-            settings.TextureCacheSize = DefaultTextureCacheSize;
+            settings.TextureCacheSize = VRCQuestToolsProjectSettings.DefaultTextureCacheSize;
             SaveProjectSettings(settings);
+        }
+
+        private static ulong ClampTextureCacheSize(ulong size)
+        {
+            return size > MaxTextureCacheSize ? MaxTextureCacheSize : size;
         }
 
         private static void SetBooleanConfigValue(string name, bool value)
@@ -221,11 +242,44 @@ namespace KRT.VRCQuestTools.Models
                 SaveProjectSettings(settings);
             }
             var json = File.ReadAllText(ProjectSettingsFile);
-            return JsonUtility.FromJson<VRCQuestToolsProjectSettings>(json);
+            var loaded = JsonUtility.FromJson<VRCQuestToolsProjectSettings>(json);
+            if (MigrateProjectSettings(loaded))
+            {
+                SaveProjectSettings(loaded);
+            }
+            return loaded;
+        }
+
+        /// <summary>
+        /// Brings settings written by an older schema version up to date.
+        /// </summary>
+        /// <param name="settings">Settings just loaded from the settings file.</param>
+        /// <returns>true when something changed and the settings should be written back.</returns>
+        private static bool MigrateProjectSettings(VRCQuestToolsProjectSettings settings)
+        {
+            if (settings.SettingsVersion >= VRCQuestToolsProjectSettings.CurrentSettingsVersion)
+            {
+                return false;
+            }
+
+            // Adopt the new, larger texture cache default for anyone who never chose a size themselves.
+            // GetProjectSettings writes the whole settings file the first time anything reads a setting, so an
+            // unversioned file always carries a texture cache size even when the user never opened the settings
+            // UI -- meaning "stored value == the old default" cannot be told apart from "user deliberately
+            // picked the old default", and is treated as the former. Any other value is left untouched.
+            if (settings.TextureCacheSize == LegacyDefaultTextureCacheSize)
+            {
+                settings.TextureCacheSize = VRCQuestToolsProjectSettings.DefaultTextureCacheSize;
+            }
+
+            return true;
         }
 
         private static void SaveProjectSettings(VRCQuestToolsProjectSettings settings)
         {
+            // Stamped here rather than by each caller so every write records the schema the file was written
+            // with, which is what keeps MigrateProjectSettings a one-time operation.
+            settings.SettingsVersion = VRCQuestToolsProjectSettings.CurrentSettingsVersion;
             var json = JsonUtility.ToJson(settings, true);
             File.WriteAllText(ProjectSettingsFile, json);
         }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRChat/AvatarConverter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/VRChat/AvatarConverter.cs
@@ -137,7 +137,6 @@ namespace KRT.VRCQuestTools.Models.VRChat
             // Convert materials and generate textures.
             var convertSettingsMap = CreateMaterialConvertSettingsMap(avatar);
             var convertedMaterials = ConvertMaterialsForMobile(convertSettingsMap, saveAssetsAsFile, assetsDirectory, progressCallback.onTextureProgress, forEditorPreview: false, avatarRoot: questAvatarObject);
-            CacheManager.Texture.Clear(VRCQuestToolsSettings.TextureCacheSize);
 
             ApplyConvertedMaterials(questAvatarObject, convertedMaterials, saveAssetsAsFile, assetsDirectory, progressCallback);
 
@@ -465,6 +464,12 @@ namespace KRT.VRCQuestTools.Models.VRChat
                     throw new MaterialConversionException("Failed to convert material", material, e);
                 }
             }
+
+            // Trimmed here rather than in ConvertForMobile alone, because this method is also the entry point
+            // the NDMF editor preview uses (MaterialConversionFilter). A preview session writes cache entries
+            // just like a real conversion does, so trimming only after a real conversion let previews grow the
+            // cache past its configured limit for as long as the user never built anything.
+            CacheManager.Texture.Clear(VRCQuestToolsSettings.TextureCacheSize);
 
             return convertedMaterials;
         }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheManager.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheManager.cs
@@ -1,3 +1,8 @@
+// <copyright file="CacheManager.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 using System;
 using System.IO;
 using System.Linq;
@@ -13,18 +18,37 @@ namespace KRT.VRCQuestTools.Utils
         /// <summary>
         /// Cache manager for textures.
         /// </summary>
-        internal static readonly CacheManager Texture = new CacheManager(() => VRCQuestToolsSettings.TextureCacheFolder, true);
+        /// <remarks>
+        /// The stamp combines the tool version with the cache entry layout revision. Every texture cache key
+        /// already embeds <see cref="VRCQuestTools.Version"/> (see <see cref="Models.MaterialGeneratorUtility"/>),
+        /// so after an update no existing entry can ever be hit again -- but the file names on disk are hashed,
+        /// so the stale entries cannot be recognized individually and would just sit there occupying the size
+        /// budget until eviction happened to reach them. The stamp turns that into a single wipe on first use.
+        /// </remarks>
+        internal static readonly CacheManager Texture = new CacheManager(
+            () => VRCQuestToolsSettings.TextureCacheFolder,
+            true,
+            () => $"{VRCQuestTools.Version} texture{CacheUtility.TextureCache.FormatVersion}");
+
+        /// <summary>
+        /// Name of the file recording the stamp of the entries currently in the cache folder. Not a cache entry
+        /// itself, so it is excluded from lookups, eviction and clearing.
+        /// </summary>
+        private const string StampFileName = "cache_stamp.txt";
 
         private readonly object lockObject = new object();
         private readonly Func<string> getCachePath;
         private readonly bool hashFileNames;
+        private readonly Func<string> getCacheStamp;
+
+        private bool isStampVerified;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CacheManager"/> class.
         /// </summary>
         /// <param name="cachePathFunc">Function to get cache path.</param>
         public CacheManager(Func<string> cachePathFunc)
-            : this(cachePathFunc, false)
+            : this(cachePathFunc, false, null)
         {
         }
 
@@ -34,12 +58,280 @@ namespace KRT.VRCQuestTools.Utils
         /// <param name="cachePathFunc">Function to get cache path.</param>
         /// <param name="hashFileNames">Whether to hash file names when storing/looking up files.</param>
         public CacheManager(Func<string> cachePathFunc, bool hashFileNames = false)
+            : this(cachePathFunc, hashFileNames, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CacheManager"/> class with a stamp identifying the
+        /// layout of the entries it stores.
+        /// </summary>
+        /// <param name="cachePathFunc">Function to get cache path.</param>
+        /// <param name="hashFileNames">Whether to hash file names when storing/looking up files.</param>
+        /// <param name="cacheStampFunc">Function to get the stamp the stored entries must match, or null to never discard entries by stamp. On the first access after the stamp changes, every entry in the folder is deleted.</param>
+        public CacheManager(Func<string> cachePathFunc, bool hashFileNames, Func<string> cacheStampFunc)
         {
             getCachePath = cachePathFunc;
             this.hashFileNames = hashFileNames;
+            getCacheStamp = cacheStampFunc;
         }
 
         private string CachePath => getCachePath();
+
+        /// <summary>
+        /// Save data to cache.
+        /// </summary>
+        /// <param name="fileName">File name to save.</param>
+        /// <param name="data">Data to save.</param>
+        internal void Save(string fileName, string data)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                Directory.CreateDirectory(CachePath);
+                var target = MapFileNameForSave(fileName);
+                File.WriteAllText(Path.Combine(CachePath, target), data);
+            }
+        }
+
+        /// <summary>
+        /// Load data from cache.
+        /// </summary>
+        /// <param name="fileName">File name to load.</param>
+        /// <returns>Loaded string.</returns>
+        internal string LoadString(string fileName)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                var resolved = ResolveExistingFileName(fileName);
+                var file = Path.Combine(CachePath, resolved);
+                var data = File.ReadAllText(file);
+                File.SetLastAccessTimeUtc(file, DateTime.UtcNow);
+                return data;
+            }
+        }
+
+        /// <summary>
+        /// Save binary data to cache, writing it straight into the cache file instead of buffering the whole
+        /// entry in memory first.
+        /// </summary>
+        /// <param name="fileName">File name to save.</param>
+        /// <param name="writeAction">Action writing the entry to the given (still open) stream.</param>
+        internal void SaveBinary(string fileName, Action<Stream> writeAction)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                Directory.CreateDirectory(CachePath);
+                var target = MapFileNameForSave(fileName);
+                using (var stream = File.Create(Path.Combine(CachePath, target)))
+                {
+                    writeAction(stream);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Load binary data from cache, reading it straight from the cache file instead of buffering the whole
+        /// entry in memory first.
+        /// </summary>
+        /// <typeparam name="T">Type read from the entry.</typeparam>
+        /// <param name="fileName">File name to load.</param>
+        /// <param name="readAction">Function reading the entry from the given (still open) stream.</param>
+        /// <returns>Value returned by <paramref name="readAction"/>.</returns>
+        internal T LoadBinary<T>(string fileName, Func<Stream, T> readAction)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                var resolved = ResolveExistingFileName(fileName);
+                var file = Path.Combine(CachePath, resolved);
+                T result;
+                using (var stream = File.OpenRead(file))
+                {
+                    result = readAction(stream);
+                }
+                File.SetLastAccessTimeUtc(file, DateTime.UtcNow);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Copy file to cache.
+        /// </summary>
+        /// <param name="srcPath">Source path.</param>
+        /// <param name="fileName">File name to copy.</param>
+        internal void CopyToCache(string srcPath, string fileName)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                Directory.CreateDirectory(CachePath);
+                var target = MapFileNameForSave(fileName);
+                File.Copy(srcPath, Path.Combine(CachePath, target), true);
+            }
+        }
+
+        /// <summary>
+        /// Copy file from cache.
+        /// </summary>
+        /// <param name="fileName">File name to copy.</param>
+        /// <param name="destPath">Destination path.</param>
+        internal void CopyFromCache(string fileName, string destPath)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                var resolved = ResolveExistingFileName(fileName);
+                var file = Path.Combine(CachePath, resolved);
+                File.Copy(file, destPath, true);
+                File.SetLastAccessTimeUtc(file, DateTime.UtcNow);
+            }
+        }
+
+        /// <summary>
+        /// Check whether the file exists in cache.
+        /// </summary>
+        /// <param name="fileName">File name to check.</param>
+        /// <returns>true when the file exists.</returns>
+        internal bool Exists(string fileName)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                if (!hashFileNames)
+                {
+                    return File.Exists(Path.Combine(CachePath, fileName));
+                }
+                var hashed = Path.Combine(CachePath, CacheUtility.HashFileName(fileName));
+                if (File.Exists(hashed))
+                {
+                    return true;
+                }
+                return File.Exists(Path.Combine(CachePath, fileName));
+            }
+        }
+
+        /// <summary>
+        /// Clear cache.
+        /// </summary>
+        internal void Clear()
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                foreach (var file in GetEntryFiles())
+                {
+                    file.Delete();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clear cache to fit the total size.
+        /// Files are deleted in order of last access time.
+        /// </summary>
+        /// <param name="totalSize">Total size to fit.</param>
+        internal void Clear(ulong totalSize)
+        {
+            lock (lockObject)
+            {
+                DiscardEntriesOnStampMismatch();
+                var files = GetEntryFiles()
+                    .OrderByDescending(f => f.LastAccessTime)
+                    .ToArray();
+                ulong size = 0;
+                foreach (var file in files)
+                {
+                    size += (ulong)file.Length;
+                    if (size > totalSize)
+                    {
+                        try
+                        {
+                            file.Delete();
+                        }
+                        catch (Exception e)
+                        {
+                            // Opportunistic maintenance, not something a conversion or a preview should fail
+                            // over: an entry that cannot be deleted right now (e.g. locked by another process)
+                            // is simply left for the next trim.
+                            Logger.LogWarning($"Failed to evict cache file {file.Name}. {e.Message}");
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the cache entry files, excluding the bookkeeping stamp file.
+        /// </summary>
+        /// <returns>Cache entry files, or an empty array when the cache folder does not exist yet.</returns>
+        private FileInfo[] GetEntryFiles()
+        {
+            if (!Directory.Exists(CachePath))
+            {
+                return new FileInfo[0];
+            }
+            return new DirectoryInfo(CachePath).GetFiles()
+                .Where(f => f.Name != StampFileName)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Deletes every entry in the cache folder when its stamp file does not match the current stamp, then
+        /// records the current stamp. Runs at most once per instance (i.e. once per domain reload for
+        /// <see cref="Texture"/>) and does nothing when the manager has no stamp function.
+        /// Callers must hold <see cref="lockObject"/>.
+        /// </summary>
+        private void DiscardEntriesOnStampMismatch()
+        {
+            if (getCacheStamp == null || isStampVerified)
+            {
+                return;
+            }
+
+            // Set upfront so a failure below is not retried on every single cache access afterwards.
+            isStampVerified = true;
+
+            try
+            {
+                var expected = getCacheStamp();
+                var stampPath = Path.Combine(CachePath, StampFileName);
+                if (File.Exists(stampPath) && File.ReadAllText(stampPath) == expected)
+                {
+                    return;
+                }
+
+                var files = GetEntryFiles();
+                var deleted = 0;
+                foreach (var file in files)
+                {
+                    try
+                    {
+                        file.Delete();
+                        deleted++;
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.LogWarning($"Failed to delete outdated cache file {file.Name}. {e.Message}");
+                    }
+                }
+
+                if (deleted > 0)
+                {
+                    Logger.Log($"Discarded {deleted} outdated cache file(s) in {CachePath} because they were written for a different version or format ({expected} expected).");
+                }
+
+                Directory.CreateDirectory(CachePath);
+                File.WriteAllText(stampPath, expected);
+            }
+            catch (Exception e)
+            {
+                // Cache bookkeeping must never break the operation that happened to touch the cache first.
+                Logger.LogException(e);
+            }
+        }
 
         private string MapFileNameForSave(string fileName)
         {
@@ -65,132 +357,6 @@ namespace KRT.VRCQuestTools.Utils
             }
             // If neither exists, return the hashed name as the preferred save target.
             return hashed;
-        }
-
-        /// <summary>
-        /// Save data to cache.
-        /// </summary>
-        /// <param name="fileName">File name to save.</param>
-        /// <param name="data">Data to save.</param>
-        internal void Save(string fileName, string data)
-        {
-            lock (lockObject)
-            {
-                Directory.CreateDirectory(CachePath);
-                var target = MapFileNameForSave(fileName);
-                File.WriteAllText(Path.Combine(CachePath, target), data);
-            }
-        }
-
-        /// <summary>
-        /// Load data from cache.
-        /// </summary>
-        /// <param name="fileName">File name to load.</param>
-        /// <returns>Loaded string.</returns>
-        internal string LoadString(string fileName)
-        {
-            lock (lockObject)
-            {
-                var resolved = ResolveExistingFileName(fileName);
-                var file = Path.Combine(CachePath, resolved);
-                var data = File.ReadAllText(file);
-                File.SetLastAccessTimeUtc(file, System.DateTime.UtcNow);
-                return data;
-            }
-        }
-
-        /// <summary>
-        /// Copy file to cache.
-        /// </summary>
-        /// <param name="srcPath">Source path.</param>
-        /// <param name="fileName">File name to copy.</param>
-        internal void CopyToCache(string srcPath, string fileName)
-        {
-            lock (lockObject)
-            {
-                Directory.CreateDirectory(CachePath);
-                var target = MapFileNameForSave(fileName);
-                File.Copy(srcPath, Path.Combine(CachePath, target), true);
-            }
-        }
-
-        /// <summary>
-        /// Copy file from cache.
-        /// </summary>
-        /// <param name="fileName">File name to copy.</param>
-        /// <param name="destPath">Destination path.</param>
-        internal void CopyFromCache(string fileName, string destPath)
-        {
-            lock (lockObject)
-            {
-                var resolved = ResolveExistingFileName(fileName);
-                var file = Path.Combine(CachePath, resolved);
-                File.Copy(file, destPath, true);
-                File.SetLastAccessTimeUtc(file, System.DateTime.UtcNow);
-            }
-        }
-
-        /// <summary>
-        /// Check whether the file exists in cache.
-        /// </summary>
-        /// <param name="fileName">File name to check.</param>
-        /// <returns>true when the file exists.</returns>
-        internal bool Exists(string fileName)
-        {
-            if (!hashFileNames)
-            {
-                return File.Exists(Path.Combine(CachePath, fileName));
-            }
-            var hashed = Path.Combine(CachePath, CacheUtility.HashFileName(fileName));
-            if (File.Exists(hashed))
-            {
-                return true;
-            }
-            return File.Exists(Path.Combine(CachePath, fileName));
-        }
-
-        /// <summary>
-        /// Clear cache.
-        /// </summary>
-        internal void Clear()
-        {
-            lock (lockObject)
-            {
-                if (!Directory.Exists(CachePath))
-                {
-                    return;
-                }
-                Directory.GetFiles(CachePath).ToList().ForEach(File.Delete);
-            }
-        }
-
-        /// <summary>
-        /// Clear cache to fit the total size.
-        /// Files are deleted in order of last access time.
-        /// </summary>
-        /// <param name="totalSize">Total size to fit.</param>
-        internal void Clear(ulong totalSize)
-        {
-            lock (lockObject)
-            {
-                if (!Directory.Exists(CachePath))
-                {
-                    return;
-                }
-                var files = new DirectoryInfo(CachePath).GetFiles()
-                    .OrderBy(f => f.LastAccessTime)
-                    .Reverse()
-                    .ToArray();
-                ulong size = 0;
-                foreach (var file in files)
-                {
-                    size += (ulong)file.Length;
-                    if (size > totalSize)
-                    {
-                        file.Delete();
-                    }
-                }
-            }
         }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheUtility.cs
@@ -1,3 +1,8 @@
+// <copyright file="CacheUtility.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 using System;
 using System.IO;
 using System.Text;
@@ -92,32 +97,36 @@ namespace KRT.VRCQuestTools.Utils
         /// <summary>
         /// Content cache for texture.
         /// </summary>
-        [Serializable]
+        /// <remarks>
+        /// Entries are persisted as a small binary header followed by the texture's raw bytes verbatim (see
+        /// <see cref="WriteTo"/>), deliberately not as JSON with base64-encoded pixel data. Base64 inflated every
+        /// entry by 4/3 on disk, and encoding/decoding it meant a multi-megabyte string existing alongside the
+        /// byte array for every single texture, on top of the JSON string built around it.
+        /// </remarks>
         internal class TextureCache
         {
-            [SerializeField]
-            private int width;
+            /// <summary>
+            /// Revision of the binary layout written by <see cref="WriteTo"/>. Bump this whenever the layout
+            /// changes: it is part of the texture cache's stamp (see <see cref="CacheManager.Texture"/>), so a
+            /// bump discards every existing entry at once instead of making <see cref="ReadFrom"/> reject them
+            /// one by one as they are looked up.
+            /// </summary>
+            internal const int FormatVersion = 1;
 
-            [SerializeField]
-            private int height;
+            /// <summary>
+            /// Magic number at the head of every entry, so an unrelated or truncated file is rejected before
+            /// its contents are interpreted as texture attributes.
+            /// </summary>
+            private static readonly byte[] MagicBytes = { (byte)'V', (byte)'Q', (byte)'T', (byte)'C' };
 
-            [SerializeField]
-            private TextureFormat format;
-
-            [SerializeField]
-            private bool linear;
-
-            [SerializeField]
-            private bool normalMap;
-
-            [SerializeField]
-            private BuildTarget buildTarget;
-
-            [SerializeField]
-            private bool mipmap;
-
-            [SerializeField]
-            private string base64Data;
+            private readonly int width;
+            private readonly int height;
+            private readonly TextureFormat format;
+            private readonly bool linear;
+            private readonly bool normalMap;
+            private readonly BuildTarget buildTarget;
+            private readonly bool mipmap;
+            private readonly byte[] rawData;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="TextureCache"/> class.
@@ -135,7 +144,99 @@ namespace KRT.VRCQuestTools.Utils
                 this.normalMap = normalMap;
                 this.buildTarget = buildTarget;
                 mipmap = texture.mipmapCount > 1;
-                base64Data = Convert.ToBase64String(texture.GetRawTextureData());
+
+                // The byte[] overload, not GetRawTextureData<byte>(): the NativeArray version throws for a
+                // non-readable texture while this one succeeds, and compressed results are not readable.
+                rawData = texture.GetRawTextureData();
+            }
+
+            private TextureCache(int width, int height, TextureFormat format, bool linear, bool normalMap, BuildTarget buildTarget, bool mipmap, byte[] rawData)
+            {
+                this.width = width;
+                this.height = height;
+                this.format = format;
+                this.linear = linear;
+                this.normalMap = normalMap;
+                this.buildTarget = buildTarget;
+                this.mipmap = mipmap;
+                this.rawData = rawData;
+            }
+
+            /// <summary>
+            /// Reads an entry previously written by <see cref="WriteTo"/>.
+            /// </summary>
+            /// <param name="stream">Stream positioned at the head of an entry.</param>
+            /// <returns>Restored cache entry.</returns>
+            /// <exception cref="InvalidDataException">The stream does not hold an entry of the current format.</exception>
+            internal static TextureCache ReadFrom(Stream stream)
+            {
+                // leaveOpen: true -- the stream belongs to the caller (CacheManager), which closes it itself.
+                using (var reader = new BinaryReader(stream, Encoding.UTF8, true))
+                {
+                    var magic = reader.ReadBytes(MagicBytes.Length);
+                    if (magic.Length != MagicBytes.Length)
+                    {
+                        throw new InvalidDataException("Not a texture cache entry: the file is shorter than its magic number.");
+                    }
+                    for (int i = 0; i < MagicBytes.Length; i++)
+                    {
+                        if (magic[i] != MagicBytes[i])
+                        {
+                            throw new InvalidDataException("Not a texture cache entry: magic number mismatch.");
+                        }
+                    }
+
+                    var formatVersion = reader.ReadInt32();
+                    if (formatVersion != FormatVersion)
+                    {
+                        throw new InvalidDataException($"Unsupported texture cache format version {formatVersion} (expected {FormatVersion}).");
+                    }
+
+                    var width = reader.ReadInt32();
+                    var height = reader.ReadInt32();
+                    var format = (TextureFormat)reader.ReadInt32();
+                    var buildTarget = (BuildTarget)reader.ReadInt32();
+                    var linear = reader.ReadBoolean();
+                    var normalMap = reader.ReadBoolean();
+                    var mipmap = reader.ReadBoolean();
+
+                    var dataLength = reader.ReadInt32();
+                    if (dataLength < 0)
+                    {
+                        throw new InvalidDataException($"Invalid texture cache data length: {dataLength}.");
+                    }
+
+                    var rawData = reader.ReadBytes(dataLength);
+                    if (rawData.Length != dataLength)
+                    {
+                        throw new InvalidDataException($"Truncated texture cache entry: expected {dataLength} bytes of texture data but found {rawData.Length}.");
+                    }
+
+                    return new TextureCache(width, height, format, linear, normalMap, buildTarget, mipmap, rawData);
+                }
+            }
+
+            /// <summary>
+            /// Writes this entry to <paramref name="stream"/> in the layout <see cref="ReadFrom"/> expects.
+            /// </summary>
+            /// <param name="stream">Stream to write to.</param>
+            internal void WriteTo(Stream stream)
+            {
+                // leaveOpen: true -- the stream belongs to the caller (CacheManager), which closes it itself.
+                using (var writer = new BinaryWriter(stream, Encoding.UTF8, true))
+                {
+                    writer.Write(MagicBytes);
+                    writer.Write(FormatVersion);
+                    writer.Write(width);
+                    writer.Write(height);
+                    writer.Write((int)format);
+                    writer.Write((int)buildTarget);
+                    writer.Write(linear);
+                    writer.Write(normalMap);
+                    writer.Write(mipmap);
+                    writer.Write(rawData.Length);
+                    writer.Write(rawData);
+                }
             }
 
             /// <summary>
@@ -147,7 +248,7 @@ namespace KRT.VRCQuestTools.Utils
                 var tex = normalMap ?
                     CreateCompressedNormalMap(width, height) :
                     new Texture2D(width, height, format, mipmap, linear);
-                tex.LoadRawTextureData(Convert.FromBase64String(base64Data));
+                tex.LoadRawTextureData(rawData);
                 tex.Apply(true, true);
                 return tex;
             }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/CacheUtility.cs
@@ -206,6 +206,22 @@ namespace KRT.VRCQuestTools.Utils
                         throw new InvalidDataException($"Invalid texture cache data length: {dataLength}.");
                     }
 
+                    // Compared against what the file actually holds *before* ReadBytes below, which allocates a
+                    // buffer of exactly this size upfront: a corrupt length field would otherwise ask for an
+                    // arbitrarily large allocation, and the post-read truncation check would only notice once
+                    // that allocation had already been attempted. BinaryReader consumes exactly the bytes it is
+                    // asked for (it never reads ahead), so the stream position here is the real read position.
+                    // Streams passed in by CacheManager are always seekable (FileStream); for anything else the
+                    // truncation check below remains the only guard.
+                    if (stream.CanSeek)
+                    {
+                        var remaining = stream.Length - stream.Position;
+                        if (dataLength > remaining)
+                        {
+                            throw new InvalidDataException($"Truncated texture cache entry: the header declares {dataLength} bytes of texture data but only {remaining} bytes remain.");
+                        }
+                    }
+
                     var rawData = reader.ReadBytes(dataLength);
                     if (rawData.Length != dataLength)
                     {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/PreviewTextureCompressionQueue.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/PreviewTextureCompressionQueue.cs
@@ -86,8 +86,8 @@ namespace KRT.VRCQuestTools.Utils
         /// <c>jobs</c> parameter), so a single item alone can already saturate the machine while it is running. The
         /// problem is that a single item is not always running astcenc: <see cref="ProcessItemAsync"/> also does
         /// real main-thread work before and after the astcenc call (pixel extraction / normal map mip generation
-        /// beforehand, <see cref="Texture2D"/> construction, <c>LoadRawTextureData</c>, the disk cache's base64
-        /// encode, and a repaint afterward) during which no astcenc process is running at all -- CPU sits idle
+        /// beforehand, <see cref="Texture2D"/> construction, <c>LoadRawTextureData</c>, the disk cache write,
+        /// and a repaint afterward) during which no astcenc process is running at all -- CPU sits idle
         /// during that gap. Allowing a small number of items to be in flight together means the next item's astcenc
         /// process can be starting (or already running) while the previous item is still doing that main-thread
         /// work, filling the gap instead of leaving it empty.
@@ -334,6 +334,29 @@ namespace KRT.VRCQuestTools.Utils
             {
                 EditorApplication.update -= OnUpdate;
                 updateHooked = false;
+
+                // The batch just finished. Every item in it wrote its own disk cache entry
+                // (ApplyCompressedResult), all of them after the conversion that enqueued them already returned
+                // and trimmed the cache -- so without trimming here too, a preview-only session (which never
+                // runs a real conversion) would keep growing the cache past its configured limit.
+                TrimTextureCache();
+            }
+        }
+
+        /// <summary>
+        /// Trims the texture cache down to the configured limit, ignoring failures: this is opportunistic
+        /// maintenance running inside an <c>EditorApplication.update</c> callback, where a throw would just
+        /// spam the console every tick.
+        /// </summary>
+        private static void TrimTextureCache()
+        {
+            try
+            {
+                CacheManager.Texture.Clear(Models.VRCQuestToolsSettings.TextureCacheSize);
+            }
+            catch (Exception e)
+            {
+                Logger.LogWarning($"Failed to trim the texture cache after progressive preview compression. {e.Message}");
             }
         }
 
@@ -511,7 +534,8 @@ namespace KRT.VRCQuestTools.Utils
 
             try
             {
-                CacheManager.Texture.Save(item.CacheFile, JsonUtility.ToJson(new CacheUtility.TextureCache(compressed, !item.IsSRGB, item.IsNormalMap, item.BuildTarget)));
+                var cache = new CacheUtility.TextureCache(compressed, !item.IsSRGB, item.IsNormalMap, item.BuildTarget);
+                CacheManager.Texture.SaveBinary(item.CacheFile, cache.WriteTo);
             }
             catch (Exception e)
             {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/VRCQuestToolsSettingsProvider.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/VRCQuestToolsSettingsProvider.cs
@@ -1,3 +1,8 @@
+// <copyright file="VRCQuestToolsSettingsProvider.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.Utils;
 using UnityEditor;
@@ -11,6 +16,11 @@ namespace KRT.VRCQuestTools.Views
     internal static class VRCQuestToolsSettingsProvider
     {
         private const ulong MegaBytes = 1024 * 1024;
+
+        /// <summary>
+        /// Largest value accepted in the texture cache size field, in megabytes.
+        /// </summary>
+        private static readonly int MaxCacheSizeMegaBytes = (int)(VRCQuestToolsSettings.MaxTextureCacheSize / MegaBytes);
 
         [SettingsProvider]
         private static SettingsProvider CreateProjectSettingsProvider()
@@ -30,6 +40,12 @@ namespace KRT.VRCQuestTools.Views
                             var cacheSize = EditorGUILayout.IntField("Texture Cache Size (MB)", (int)(VRCQuestToolsSettings.TextureCacheSize / MegaBytes));
                             if (check.changed)
                             {
+                                // Clamped before the unsigned cast, which is where an out-of-range value does its
+                                // damage: a negative megabyte count would wrap around into a limit of nearly
+                                // 2^64 bytes and silently disable eviction entirely, and a large positive one
+                                // would overflow while being scaled to bytes. The field shows the clamped value
+                                // back on the next repaint, since it is read from the stored setting.
+                                cacheSize = Mathf.Clamp(cacheSize, 0, MaxCacheSizeMegaBytes);
                                 VRCQuestToolsSettings.TextureCacheSize = (ulong)cacheSize * MegaBytes;
                                 CacheManager.Texture.Clear(VRCQuestToolsSettings.TextureCacheSize);
                             }


### PR DESCRIPTION
- Raise the default texture cache size limit from 128MB to 1GB. Entries range from well under a megabyte to several megabytes each, so the old limit could evict an avatar's textures before they were ever reused. Settings files written before schema versioning adopt the new default automatically.
- Clamp the texture cache size to a valid range. A negative value in the Project Settings field wrapped around the unsigned cast and disabled eviction entirely.
- Store cache entries as a binary header plus the raw texture bytes instead of base64-encoded JSON: about 25% less disk per entry, and no multi-megabyte base64/JSON strings alongside the byte array while converting.
- Discard entries left by another tool version or entry format on first access. Every cache key embeds the tool version, so those entries can never be hit again, but their file names are hashed and cannot be recognized individually, leaving them to occupy the size limit until eviction reached them.
- Trim the cache after material conversion instead of only after a full avatar conversion, so the NDMF preview path (which writes entries just like a real conversion) stays within the limit too, including the entries its background compression queue writes after the conversion returns.