### PR TITLE
Suppress VRCFury material removal when converting in Optimizing phase

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/Compat.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/Compat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22b441d4175a46344a5e2138fe5675bc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatchTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatchTests.cs
@@ -1,0 +1,172 @@
+// <copyright file="VRCFuryMaterialRemovalPatchTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using KRT.VRCQuestTools.Components;
+using KRT.VRCQuestTools.Models;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="VRCFuryMaterialRemovalPatch"/>. The gating-logic tests use fake,
+    /// duck-typed VRCFury-shaped objects so they run without VRCFury being installed; the
+    /// integration test at the bottom only exercises the real VRCFury type when it's present.
+    /// </summary>
+    public class VRCFuryMaterialRemovalPatchTests
+    {
+        private NdmfTestAvatarBuilder builder;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+        }
+
+        /// <summary>
+        /// When the avatar root can't be resolved from the service instance, the original VRCFury
+        /// behavior must not be suppressed.
+        /// </summary>
+        [Test]
+        public void ApplyPrefix_ReturnsTrue_WhenAvatarRootCannotBeResolved()
+        {
+            var fakeService = new FakeRemoveNonQuestMaterialsService { avatarObject = null };
+
+            Assert.IsTrue(VRCFuryMaterialRemovalPatch.ApplyPrefix(fakeService));
+        }
+
+        /// <summary>
+        /// Without any IMaterialOperatorComponent, VRCQuestTools has nothing to convert, so VRCFury's
+        /// removal must proceed as usual.
+        /// </summary>
+        [Test]
+        public void ApplyPrefix_ReturnsTrue_WhenNoMaterialOperatorComponent()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var fakeService = new FakeRemoveNonQuestMaterialsService { avatarObject = builder.Root };
+
+            Assert.IsTrue(VRCFuryMaterialRemovalPatch.ApplyPrefix(fakeService));
+        }
+
+        /// <summary>
+        /// When the resolved NDMF phase is Transforming, VRCQuestTools converts before VRCFury runs,
+        /// so VRCFury's removal must proceed as usual.
+        /// </summary>
+        [Test]
+        public void ApplyPrefix_ReturnsTrue_WhenNdmfPhaseResolvesToTransforming()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.ndmfPhase = AvatarConverterNdmfPhase.Transforming;
+            var fakeService = new FakeRemoveNonQuestMaterialsService { avatarObject = builder.Root };
+
+            Assert.IsTrue(VRCFuryMaterialRemovalPatch.ApplyPrefix(fakeService));
+        }
+
+        /// <summary>
+        /// When the resolved NDMF phase is Optimizing, VRCFury's removal must be suppressed so
+        /// VRCQuestTools can still convert the original materials later.
+        /// </summary>
+        [Test]
+        public void ApplyPrefix_ReturnsFalse_WhenNdmfPhaseResolvesToOptimizing()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.ndmfPhase = AvatarConverterNdmfPhase.Optimizing;
+            var fakeService = new FakeRemoveNonQuestMaterialsService { avatarObject = builder.Root };
+
+            Assert.IsFalse(VRCFuryMaterialRemovalPatch.ApplyPrefix(fakeService));
+        }
+
+        /// <summary>
+        /// GetAvatarRoot must resolve the avatar GameObject through a wrapper type's implicit
+        /// conversion operator, the same way VRCFury's internal VFGameObject wrapper works.
+        /// </summary>
+        [Test]
+        public void GetAvatarRoot_ResolvesThroughImplicitConversionOperator()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var wrapper = new FakeVFGameObject(builder.Root);
+            var fakeService = new FakeWrappedRemoveNonQuestMaterialsService { avatarObject = wrapper };
+
+            Assert.AreSame(builder.Root, VRCFuryMaterialRemovalPatch.GetAvatarRoot(fakeService));
+        }
+
+        /// <summary>
+        /// When VRCFury is actually installed, verify the real RemoveNonQuestMaterialsService.Apply()
+        /// gets patched and is skipped (instead of throwing on its un-initialized dependencies) when
+        /// the resolved NDMF phase is Optimizing. Skips when VRCFury isn't installed.
+        /// </summary>
+        [Test]
+        public void Apply_IsSkipped_ForRealVRCFuryService_WhenNdmfPhaseResolvesToOptimizing()
+        {
+            var serviceType = AppDomain.CurrentDomain.GetAssemblies()
+                .Select(a => a.GetType("VF.Service.RemoveNonQuestMaterialsService"))
+                .FirstOrDefault(t => t != null);
+            if (serviceType == null)
+            {
+                Assert.Ignore("VRCFury is not installed.");
+                return;
+            }
+
+            var applyMethod = serviceType.GetMethod("Apply", BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(applyMethod, "VRCFury may have made breaking changes: Apply() not found.");
+
+            var patchInfo = Harmony.GetPatchInfo(applyMethod);
+            Assert.NotNull(patchInfo, "RemoveNonQuestMaterialsService.Apply() should be patched by VRCFuryMaterialRemovalPatch.");
+            Assert.IsTrue(patchInfo.Prefixes.Any(p => p.owner == "com.github.kurotu.vrc-quest-tools.vrcfury-compat"));
+
+            builder = new NdmfTestAvatarBuilder();
+            var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+            settings.ndmfPhase = AvatarConverterNdmfPhase.Optimizing;
+
+            var avatarObjectField = serviceType.GetField("avatarObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(avatarObjectField, "VRCFury may have made breaking changes: avatarObject field not found.");
+
+            var vfGameObjectType = avatarObjectField.FieldType;
+            var fromGameObject = vfGameObjectType
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(m => m.Name == "op_Implicit" && m.GetParameters().FirstOrDefault()?.ParameterType == typeof(GameObject));
+            Assert.NotNull(fromGameObject, "VRCFury may have made breaking changes: no GameObject -> VFGameObject conversion found.");
+
+            var serviceInstance = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(serviceType);
+            avatarObjectField.SetValue(serviceInstance, fromGameObject.Invoke(null, new object[] { builder.Root }));
+
+            // The "controllers" field is intentionally left unset. If the patch fails to suppress the
+            // original method, it will throw (e.g. a NullReferenceException) when it dereferences it.
+            Assert.DoesNotThrow(() => applyMethod.Invoke(serviceInstance, null));
+        }
+
+        private class FakeRemoveNonQuestMaterialsService
+        {
+            public GameObject avatarObject;
+        }
+
+        private class FakeWrappedRemoveNonQuestMaterialsService
+        {
+            public FakeVFGameObject avatarObject;
+        }
+
+        private class FakeVFGameObject
+        {
+            private readonly GameObject gameObject;
+
+            public FakeVFGameObject(GameObject gameObject)
+            {
+                this.gameObject = gameObject;
+            }
+
+            public static implicit operator GameObject(FakeVFGameObject d) => d?.gameObject;
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatchTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatchTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca469eeb7bcdd784aa89c9436f5c8551
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/VRCQuestTools-EditorTests-Ndmf.asmdef
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/VRCQuestTools-EditorTests-Ndmf.asmdef
@@ -21,7 +21,8 @@
         "VRCSDKBase.dll",
         "VRCSDK3A.dll",
         "VRC.SDK3.Dynamics.PhysBone.dll",
-        "VRC.Dynamics.dll"
+        "VRC.Dynamics.dll",
+        "0Harmony.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Limited stack trace lines shown in avatar conversion failure dialog to keep the dialog operable.
 - Fixed lilToon to Toon Standard conversion producing overly dark results by deriving occlusion strength from the lilToon shadow colors instead of always applying full-strength occlusion.
 - Fixed lilToon to Toon Standard conversion computing gloss/metallic strength from the un-linearized (gamma-space) Reflection Color, which also caused Metallic to be inadvertently gamma-decoded a second time.
+- [NDMF] Fixed converted materials turning pink when VRCFury is present and the NDMF phase resolves to Optimizing, by suppressing VRCFury's own non-mobile material removal for avatars VRCQuestTools is about to convert in that phase. `Auto` now resolves to the Optimizing phase even when VRCFury components exist.
 
 ### Removed
 - Removed support for Unity 2019.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Limited stack trace lines shown in avatar conversion failure dialog to keep the dialog operable.
 - Fixed lilToon to Toon Standard conversion producing overly dark results by deriving occlusion strength from the lilToon shadow colors instead of always applying full-strength occlusion.
 - Fixed lilToon to Toon Standard conversion computing gloss/metallic strength from the un-linearized (gamma-space) Reflection Color, which also caused Metallic to be inadvertently gamma-decoded a second time.
-- [NDMF] Fixed converted materials turning pink when VRCFury is present and the NDMF phase resolves to Optimizing, by suppressing VRCFury's own non-mobile material removal for avatars VRCQuestTools is about to convert in that phase. `Auto` now resolves to the Optimizing phase even when VRCFury components exist.
+- [NDMF] Fixed converted materials turning pink when VRCFury is present and the NDMF phase resolves to Optimizing, by suppressing VRCFury's own non-mobile material removal for avatars VRCQuestTools is about to convert in that phase. `Auto` now resolves to the Optimizing phase even when VRCFury components exist, as long as VRCFury's material removal can be suppressed; otherwise it falls back to the Transforming phase as before.
 
 ### Removed
 - Removed support for Unity 2019.

--- a/CHANGELOG_JP.md
+++ b/CHANGELOG_JP.md
@@ -57,6 +57,7 @@
 - アバター変換失敗ダイアログに表示するスタックトレースの行数を制限し、ダイアログが操作不能になる問題を修正。
 - lilToon から Toon Standard への変換結果が暗くなりすぎる問題を修正。Occlusion の強度を常にフル適用するのではなく、lilToon の陰影色から算出するように変更。
 - lilToon から Toon Standard への変換で、Gloss/Metallic の強度を Reflection Color から算出する際に色空間の線形変換をしていなかった問題を修正。Metallic 側は意図せず二重にガンマデコードされていました。
+- [NDMF] VRCFuryが存在し、かつNDMFフェーズがOptimizingに解決される場合に変換後のマテリアルがピンク色になる問題を修正。VRCQuestToolsがそのフェーズで変換しようとしているアバターについては、VRCFury自身の非モバイルマテリアル削除処理を抑制するようにしました。`Auto`は、VRCFuryのマテリアル削除処理を抑制できる場合に限りOptimizingフェーズに解決されるようになりました（抑制できない場合は従来どおりTransformingフェーズにフォールバックします）。
 
 ### 削除
 - Unity 2019 のサポートを終了。

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Compat.meta
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Compat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eaff63d7be0eba44381d1079f6e50dd7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatch.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatch.cs
@@ -1,0 +1,115 @@
+// <copyright file="VRCFuryMaterialRemovalPatch.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using KRT.VRCQuestTools.Models;
+using UnityEditor;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Suppresses VRCFury's RemoveNonQuestMaterialsService.Apply() while VRCQuestTools is still going to
+    /// convert the same avatar's materials in the NDMF Optimizing phase. VRCFury removes non-mobile materials
+    /// earlier (effectively in the Transforming phase), so without this patch it would strip the original PC
+    /// materials before VRCQuestTools' Optimizing-phase pass can read them.
+    /// See https://github.com/kurotu/VRCQuestTools/issues/31 and https://github.com/kurotu/VRCQuestTools/issues/198.
+    /// </summary>
+    internal static class VRCFuryMaterialRemovalPatch
+    {
+        private const string HarmonyId = "com.github.kurotu.vrc-quest-tools.vrcfury-compat";
+        private const string TargetTypeName = "VF.Service.RemoveNonQuestMaterialsService";
+        private const string TargetMethodName = "Apply";
+
+        [InitializeOnLoadMethod]
+        private static void Initialize()
+        {
+            try
+            {
+                Patch();
+            }
+            catch (Exception e)
+            {
+                Logger.LogException(e);
+            }
+        }
+
+        private static void Patch()
+        {
+            var targetType = AccessTools.TypeByName(TargetTypeName);
+            if (targetType == null)
+            {
+                // VRCFury is not installed.
+                return;
+            }
+
+            var applyMethod = AccessTools.Method(targetType, TargetMethodName);
+            if (applyMethod == null)
+            {
+                Logger.LogWarning($"{TargetTypeName}.{TargetMethodName} was not found. VRCFury may have made breaking changes, so VRCQuestTools can't avoid VRCFury removing non-mobile materials before its own conversion.");
+                return;
+            }
+
+            var harmony = new Harmony(HarmonyId);
+            harmony.Patch(applyMethod, prefix: new HarmonyMethod(typeof(VRCFuryMaterialRemovalPatch), nameof(ApplyPrefix)));
+            AssemblyReloadEvents.beforeAssemblyReload += () => harmony.UnpatchAll(HarmonyId);
+        }
+
+        /// <summary>
+        /// Harmony prefix for RemoveNonQuestMaterialsService.Apply(). Returning false skips the original method.
+        /// </summary>
+        /// <param name="__instance">The RemoveNonQuestMaterialsService instance being invoked.</param>
+        /// <returns>False to skip VRCFury's material removal, true to let it run as usual.</returns>
+        internal static bool ApplyPrefix(object __instance)
+        {
+            var avatarRoot = GetAvatarRoot(__instance);
+            if (avatarRoot == null)
+            {
+                return true;
+            }
+
+            if (!AvatarConverterPassUtility.HasMaterialOperatorComponents(avatarRoot))
+            {
+                return true;
+            }
+
+            return AvatarConverterPassUtility.ResolveAvatarConverterNdmfPhase(avatarRoot) != AvatarConverterNdmfPhase.Optimizing;
+        }
+
+        /// <summary>
+        /// Extracts the avatar root GameObject from a RemoveNonQuestMaterialsService instance's
+        /// private "avatarObject" field (typed as VRCFury's internal VFGameObject wrapper).
+        /// </summary>
+        /// <param name="serviceInstance">The RemoveNonQuestMaterialsService instance.</param>
+        /// <returns>The avatar root GameObject, or null if it could not be resolved.</returns>
+        internal static GameObject GetAvatarRoot(object serviceInstance)
+        {
+            if (serviceInstance == null)
+            {
+                return null;
+            }
+
+            var avatarObjectField = AccessTools.Field(serviceInstance.GetType(), "avatarObject");
+            var avatarObjectValue = avatarObjectField?.GetValue(serviceInstance);
+            if (avatarObjectValue == null)
+            {
+                return null;
+            }
+
+            if (avatarObjectValue is GameObject gameObject)
+            {
+                return gameObject;
+            }
+
+            var toGameObject = avatarObjectValue.GetType()
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(m => m.Name == "op_Implicit" && m.ReturnType == typeof(GameObject));
+            return toGameObject?.Invoke(null, new[] { avatarObjectValue }) as GameObject;
+        }
+    }
+}

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatch.cs.meta
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Compat/VRCFuryMaterialRemovalPatch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ed8357318f74dd4c8c6ad79c94894c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestTools-Editor-Ndmf.asmdef
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/VRCQuestTools-Editor-Ndmf.asmdef
@@ -21,7 +21,8 @@
         "VRCSDKBase.dll",
         "VRCSDKBase-Editor.dll",
         "VRC.Dynamics.dll",
-        "VRC.SDK3.Dynamics.PhysBone.dll"
+        "VRC.SDK3.Dynamics.PhysBone.dll",
+        "0Harmony.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/AvatarConverterNdmfPhase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/AvatarConverterNdmfPhase.cs
@@ -1,5 +1,7 @@
 using System;
+#if VQT_VRCFURY
 using System.Reflection;
+#endif
 using UnityEngine;
 
 namespace KRT.VRCQuestTools.Models

--- a/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/AvatarConverterNdmfPhase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Runtime/Models/AvatarConverterNdmfPhase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using UnityEngine;
 
 namespace KRT.VRCQuestTools.Models
@@ -35,6 +36,15 @@ namespace KRT.VRCQuestTools.Models
             }
             return type;
         });
+
+        // Proxy for whether VRCFuryMaterialRemovalPatch (Editor/NDMF/Compat) can find and patch VRCFury's
+        // material removal service. If VRCFury made breaking changes and this method can no longer be
+        // found, the patch can't be applied either, so Auto must fall back to the Transforming phase.
+        private static Lazy<bool> IsVRCFuryMaterialRemovalPatchable = new Lazy<bool>(() =>
+        {
+            var type = GetTypeByName("VF.Service.RemoveNonQuestMaterialsService");
+            return type?.GetMethod("Apply", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) != null;
+        });
 #endif
 
         /// <summary>
@@ -59,8 +69,10 @@ namespace KRT.VRCQuestTools.Models
                     return AvatarConverterNdmfPhase.Transforming;
                 }
 
-                if (avatarRoot.GetComponentInChildren(VRCFuryComponentType.Value, true) != null)
+                if (avatarRoot.GetComponentInChildren(VRCFuryComponentType.Value, true) != null && !IsVRCFuryMaterialRemovalPatchable.Value)
                 {
+                    // VRCFuryMaterialRemovalPatch can't suppress VRCFury's material removal, so avoid the
+                    // Optimizing phase to prevent VRCFury from stripping materials before conversion.
                     return AvatarConverterNdmfPhase.Transforming;
                 }
 #endif


### PR DESCRIPTION
VRCFury strips non-mobile materials early in the NDMF build, before VRCQuestTools can convert them in the Optimizing phase, resulting in pink materials (#31, #198). Patch VRCFury's RemoveNonQuestMaterialsService.Apply() via Harmony to skip removal only when VRCQuestTools is about to convert that avatar's materials in Optimizing, and let Auto phase resolution use Optimizing again even with VRCFury present.