### PR TITLE
Avoid redundant recompression and main-thread stalls in NDMF material preview

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterCacheTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterCacheTests.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.Models.Unity;
 using KRT.VRCQuestTools.Models.VRChat;
+using nadena.dev.ndmf.preview;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -166,6 +167,65 @@ namespace KRT.VRCQuestTools.Ndmf
                     Object.DestroyImmediate(replacement);
                 }
             }
+        }
+
+        /// <summary>
+        /// The preview filter node may only hand itself back to a new pipeline generation for changes that cannot
+        /// affect which material a renderer slot uses. Returning itself for anything else would keep a stale
+        /// conversion on screen; returning null merely costs a rebuild, so this asserts the safe direction for
+        /// every aspect. Zero is included because NDMF passes it when the node's own ComputeContext was
+        /// invalidated -- i.e. exactly when the convert settings or a source material changed.
+        /// </summary>
+        [Test]
+        public void FilterNode_Refresh_ReturnsSelfOnlyForShapeChanges()
+        {
+            var nodeType = typeof(MaterialConversionFilter).GetNestedType("MaterialConversionFilterNode", BindingFlags.NonPublic);
+            Assert.IsNotNull(nodeType, "MaterialConversionFilter.MaterialConversionFilterNode was not found.");
+
+            var lease = new SharedMaterialMapLease(new Dictionary<Material, Material>(), new HashSet<string>());
+            var node = (IRenderFilterNode)System.Activator.CreateInstance(
+                nodeType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                new object[] { new Dictionary<Material, Material>(), false, lease, null, null, new Material[0] },
+                null);
+
+            var proxyPairs = new (Renderer, Renderer)[0];
+
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes), "Blendshape/bone updates cannot change material assignment, so the node must be reusable.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Material), "A material change upstream must force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Texture), "A texture change upstream must force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Mesh), "A mesh change alters the submesh count, and therefore which slots are remapped, so it must force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Shapes | RenderAspects.Mesh), "A reusable aspect combined with a non-reusable one must still force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, 0), "Zero means this node's own context was invalidated, which must force a rebuild.");
+        }
+
+        /// <summary>
+        /// A node returned by one of MaterialConversionFilter.Instantiate's early exits (wrong phase, non-mobile
+        /// target, or a conversion that threw) holds no lease, and must always rebuild so the condition that made
+        /// it a no-op is re-evaluated.
+        /// </summary>
+        [Test]
+        public void FilterNode_Refresh_NoOpNodeWithoutLease_AlwaysRebuilds()
+        {
+            var nodeType = typeof(MaterialConversionFilter).GetNestedType("MaterialConversionFilterNode", BindingFlags.NonPublic);
+            Assert.IsNotNull(nodeType, "MaterialConversionFilter.MaterialConversionFilterNode was not found.");
+
+            var node = (IRenderFilterNode)System.Activator.CreateInstance(
+                nodeType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                new object[] { new Dictionary<Material, Material>(), false, null, null, null, null },
+                null);
+
+            Assert.IsNull(Refresh(node, new (Renderer, Renderer)[0], RenderAspects.Shapes));
+        }
+
+        private static IRenderFilterNode Refresh(IRenderFilterNode node, IEnumerable<(Renderer, Renderer)> proxyPairs, RenderAspects updatedAspects)
+        {
+            var task = node.Refresh(proxyPairs, new ComputeContext($"test {updatedAspects}"), updatedAspects);
+            Assert.IsTrue(task.IsCompleted, "MaterialConversionFilterNode.Refresh is synchronous and must complete immediately.");
+            return task.Result;
         }
 
         private static MethodInfo GetSharedCacheMethod(string methodName)

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterCacheTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterCacheTests.cs
@@ -170,34 +170,41 @@ namespace KRT.VRCQuestTools.Ndmf
         }
 
         /// <summary>
-        /// The preview filter node may only hand itself back to a new pipeline generation for changes that cannot
-        /// affect which material a renderer slot uses. Returning itself for anything else would keep a stale
-        /// conversion on screen; returning null merely costs a rebuild, so this asserts the safe direction for
-        /// every aspect. Zero is included because NDMF passes it when the node's own ComputeContext was
-        /// invalidated -- i.e. exactly when the convert settings or a source material changed.
+        /// With extra material slots kept, OnFrame takes proxy.sharedMaterials.Length slots, so no mesh change
+        /// can move which slots are remapped and Mesh is reusable alongside Shapes. Material and Texture never
+        /// are -- returning the node for those would keep a stale conversion on screen. Zero is included because
+        /// NDMF passes it when the node's own ComputeContext was invalidated, i.e. exactly when the convert
+        /// settings or a source material changed.
         /// </summary>
         [Test]
-        public void FilterNode_Refresh_ReturnsSelfOnlyForShapeChanges()
+        public void FilterNode_Refresh_KeepingExtraSlots_ReusesForShapeAndMeshChanges()
         {
-            var nodeType = typeof(MaterialConversionFilter).GetNestedType("MaterialConversionFilterNode", BindingFlags.NonPublic);
-            Assert.IsNotNull(nodeType, "MaterialConversionFilter.MaterialConversionFilterNode was not found.");
-
-            var lease = new SharedMaterialMapLease(new Dictionary<Material, Material>(), new HashSet<string>());
-            var node = (IRenderFilterNode)System.Activator.CreateInstance(
-                nodeType,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                null,
-                new object[] { new Dictionary<Material, Material>(), false, lease, null, null, new Material[0] },
-                null);
-
+            var node = CreateFilterNode(removeExtraMaterialSlots: false);
             var proxyPairs = new (Renderer, Renderer)[0];
 
             Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes), "Blendshape/bone updates cannot change material assignment, so the node must be reusable.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Mesh), "With extra material slots kept, the slot count comes from sharedMaterials.Length, so a mesh change cannot invalidate the conversion.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes | RenderAspects.Mesh), "RenderAspects is a flag set; a combination of reusable aspects must still be reusable.");
             Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Material), "A material change upstream must force a rebuild.");
             Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Texture), "A texture change upstream must force a rebuild.");
-            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Mesh), "A mesh change alters the submesh count, and therefore which slots are remapped, so it must force a rebuild.");
-            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Shapes | RenderAspects.Mesh), "A reusable aspect combined with a non-reusable one must still force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Mesh | RenderAspects.Material), "A reusable aspect combined with a non-reusable one must still force a rebuild.");
             Assert.IsNull(Refresh(node, proxyPairs, 0), "Zero means this node's own context was invalidated, which must force a rebuild.");
+        }
+
+        /// <summary>
+        /// With extra material slots removed, OnFrame takes as many slots as the mesh has submeshes. An upstream
+        /// node that raises that count would reach a slot that was an extra slot when Instantiate ran, whose
+        /// material was therefore never converted, so a mesh change has to force a rebuild here.
+        /// </summary>
+        [Test]
+        public void FilterNode_Refresh_RemovingExtraSlots_RebuildsForMeshChanges()
+        {
+            var node = CreateFilterNode(removeExtraMaterialSlots: true);
+            var proxyPairs = new (Renderer, Renderer)[0];
+
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes), "Blendshape/bone updates stay reusable regardless of the slot handling.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Mesh), "The submesh count decides the slot count here, so a mesh change must force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Shapes | RenderAspects.Mesh), "A reusable aspect combined with a non-reusable one must still force a rebuild.");
         }
 
         /// <summary>
@@ -221,7 +228,21 @@ namespace KRT.VRCQuestTools.Ndmf
             Assert.IsNull(Refresh(node, new (Renderer, Renderer)[0], RenderAspects.Shapes));
         }
 
-        private static IRenderFilterNode Refresh(IRenderFilterNode node, IEnumerable<(Renderer, Renderer)> proxyPairs, RenderAspects updatedAspects)
+        private static IRenderFilterNode CreateFilterNode(bool removeExtraMaterialSlots)
+        {
+            var nodeType = typeof(MaterialConversionFilter).GetNestedType("MaterialConversionFilterNode", BindingFlags.NonPublic);
+            Assert.IsNotNull(nodeType, "MaterialConversionFilter.MaterialConversionFilterNode was not found.");
+
+            var lease = new SharedMaterialMapLease(new Dictionary<Material, Material>(), new HashSet<string>());
+            return (IRenderFilterNode)System.Activator.CreateInstance(
+                nodeType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                new object[] { new Dictionary<Material, Material>(), removeExtraMaterialSlots, lease, null, null, new Material[0] },
+                null);
+        }
+
+        private static IRenderFilterNode Refresh(IRenderFilterNode node, IEnumerable<(Renderer Original, Renderer Proxy)> proxyPairs, RenderAspects updatedAspects)
         {
             var task = node.Refresh(proxyPairs, new ComputeContext($"test {updatedAspects}"), updatedAspects);
             Assert.IsTrue(task.IsCompleted, "MaterialConversionFilterNode.Refresh is synchronous and must complete immediately.");

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/PreviewTextureCompressionQueueTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/PreviewTextureCompressionQueueTests.cs
@@ -84,7 +84,7 @@ namespace KRT.VRCQuestTools.Utils
 
             var cacheFile = $"test_progressive_{Guid.NewGuid():N}.bin";
             var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
-            Assert.IsTrue(enqueued, "TryEnqueue should succeed when a replacer is registered and the pending-bytes cap has headroom.");
+            Assert.IsTrue(enqueued, "TryEnqueue should succeed when a replacer is registered.");
             Assert.AreEqual(1, PreviewTextureCompressionQueue.PendingCountForTesting);
 
             var task = PreviewTextureCompressionQueue.ProcessNextForTesting();
@@ -183,19 +183,23 @@ namespace KRT.VRCQuestTools.Utils
         }
 
         /// <summary>
-        /// Verifies the pending-bytes memory safety valve: once the accumulated pending bytes would exceed
-        /// <see cref="PreviewTextureCompressionQueue.MaxPendingBytes"/>, TryEnqueue refuses instead of growing
-        /// the queue further. Reaches the cap via reflection into the private pendingBytes counter (restored
-        /// afterwards) rather than actually allocating hundreds of megabytes of placeholder textures, which would
-        /// make this test slow and liable to flake on memory-constrained CI runners.
+        /// Verifies that a large backlog no longer refuses the enqueue. Passing
+        /// <see cref="PreviewTextureCompressionQueue.MaxPendingBytes"/> used to make TryEnqueue return false, which
+        /// sent <c>MaterialGeneratorUtility</c> into synchronous compression -- stalling the main thread at the
+        /// same astcenc preset while background astcenc processes were already saturating the CPU, and not even
+        /// saving the memory it was meant to save, since the placeholder is baked and assigned before TryEnqueue
+        /// is ever called. The threshold now only produces a warning, which this test asserts is still logged
+        /// exactly once for the batch. Reaches the threshold via reflection into the private pendingBytes counter
+        /// (restored afterwards) rather than actually allocating hundreds of megabytes of placeholder textures,
+        /// which would make this test slow and liable to flake on memory-constrained CI runners.
         /// </summary>
-        [Test]
-        public void TryEnqueue_PendingBytesCapReached_ReturnsFalse()
+        [UnityTest]
+        public IEnumerator TryEnqueue_BacklogOverHighWaterMark_StillAcceptsAndWarnsOnce()
         {
             var compressor = TestUtils.CreateAstcencCompressorOrIgnore();
             var placeholder = CreateColorTexture(4, 4);
 
-            // Register a (non-null) replacer explicitly so this test exercises the pending-bytes cap
+            // Register a (non-null) replacer explicitly so this test exercises the backlog threshold
             // specifically, regardless of whether NDMF happens to be installed in this environment (which
             // determines what SetUp's saved/restored replacer actually is).
             PreviewTextureCompressionQueue.RegisterMaterialTextureReplacer((from, to) => 1);
@@ -203,20 +207,101 @@ namespace KRT.VRCQuestTools.Utils
             var field = typeof(PreviewTextureCompressionQueue).GetField("pendingBytes", BindingFlags.NonPublic | BindingFlags.Static);
             Assert.IsNotNull(field, "PreviewTextureCompressionQueue.pendingBytes field must exist for this test to drive it.");
             var originalPendingBytes = (long)field.GetValue(null);
+
+            var replaced = new List<Texture>();
+            PreviewTextureCompressionQueue.RegisterMaterialTextureReplacer((from, to) =>
+            {
+                replaced.Add(to);
+                return 1;
+            });
+
+            // Only this queue's own backlog warning is counted; unrelated warnings from whatever else the running
+            // editor session happens to log while this test runs must not make it flake.
+            var warnings = new List<string>();
+            void OnLogMessage(string condition, string stackTrace, LogType type)
+            {
+                if (type == LogType.Warning && condition.Contains("uncompressed placeholder textures"))
+                {
+                    warnings.Add(condition);
+                }
+            }
+
+            // Suspends the production dispatch loop, which TryEnqueue below hooks to EditorApplication.update:
+            // the running editor fires that for real, including during the `yield return`s in the drain loop
+            // below, so without this it would dequeue and dispatch these very items in parallel with the drain
+            // -- leaving an item still in flight when the drain loop sees an empty queue and exits, and that
+            // leaked in-flight item then breaks every later test that asserts on the dispatch counters.
+            // TearDown restores this unconditionally.
+            PreviewTextureCompressionQueue.SuspendAutoDispatchForTesting = true;
+
+            field.SetValue(null, PreviewTextureCompressionQueue.MaxPendingBytes);
+
+            bool enqueued;
+            bool enqueuedAgain;
+            Application.logMessageReceived += OnLogMessage;
             try
             {
-                field.SetValue(null, PreviewTextureCompressionQueue.MaxPendingBytes);
+                enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, $"test_progressive_backlog_{Guid.NewGuid():N}.bin", true);
 
-                var enqueued = PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, "test_progressive_cap.bin", true);
-
-                Assert.IsFalse(enqueued, "TryEnqueue must refuse once the pending-bytes cap would be exceeded.");
-                Assert.AreEqual(0, PreviewTextureCompressionQueue.PendingCountForTesting);
+                // A second item over the same threshold must not warn again: the warning is latched per batch,
+                // otherwise a large avatar would emit one warning per baked texture.
+                enqueuedAgain = PreviewTextureCompressionQueue.TryEnqueue(CreateColorTexture(4, 4), compressor, TextureFormat.ASTC_4x4, false, false, null, $"test_progressive_backlog_{Guid.NewGuid():N}.bin", true);
             }
             finally
             {
-                field.SetValue(null, originalPendingBytes);
-                UnityEngine.Object.DestroyImmediate(placeholder);
+                Application.logMessageReceived -= OnLogMessage;
             }
+
+            var pendingAfterEnqueue = PreviewTextureCompressionQueue.PendingCountForTesting;
+
+            // Drained (and the counter restored) before asserting: a failed assertion below must not leave this
+            // test's items, its forced pendingBytes value, or the latched warning state behind for later tests in
+            // the same editor session. `yield return` cannot appear inside a finally block, hence the ordering.
+            while (PreviewTextureCompressionQueue.PendingCountForTesting > 0 || PreviewTextureCompressionQueue.InFlightCountForTesting > 0)
+            {
+                var drain = PreviewTextureCompressionQueue.ProcessNextForTesting();
+                yield return TestUtils.WaitForTask(drain);
+            }
+
+            field.SetValue(null, originalPendingBytes);
+            foreach (var texture in replaced)
+            {
+                UnityEngine.Object.DestroyImmediate(texture);
+            }
+
+            Assert.IsTrue(enqueued, "TryEnqueue must accept even past the backlog threshold, rather than pushing the caller into synchronous compression.");
+            Assert.IsTrue(enqueuedAgain);
+            Assert.AreEqual(2, pendingAfterEnqueue, "Both items must have been queued.");
+            Assert.AreEqual(1, warnings.Count, $"Exactly one backlog warning must be logged per batch. Got: {string.Join(" | ", warnings)}");
+        }
+
+        /// <summary>
+        /// Verifies that a finished compression is written to the disk texture cache even when nothing on screen
+        /// wants it anymore -- the replacer reporting zero replacements, i.e. every preview material lease
+        /// referencing the placeholder was released while astcenc was running (routine: editing a convert setting
+        /// changes the cache key, which drops the old entry's last reference). The bytes are valid and keyed by
+        /// material content plus convert settings, not by what happens to be displayed, so skipping the write
+        /// here used to throw away a whole astcenc run and guarantee it was redone the next time that same
+        /// material and settings combination came back.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ProcessNextForTesting_ReplacerReportsZero_StillWritesDiskCacheEntry()
+        {
+            var compressor = TestUtils.CreateAstcencCompressorOrIgnore();
+            var placeholder = CreateColorTexture(8, 8);
+
+            PreviewTextureCompressionQueue.RegisterMaterialTextureReplacer((from, to) => 0);
+
+            var cacheFile = $"test_progressive_orphan_cache_{Guid.NewGuid():N}.bin";
+            Assert.IsFalse(CacheManager.Texture.Exists(cacheFile), "The unique cache file must not exist before the test runs.");
+
+            PreviewTextureCompressionQueue.TryEnqueue(placeholder, compressor, TextureFormat.ASTC_4x4, false, false, null, cacheFile, true);
+
+            var task = PreviewTextureCompressionQueue.ProcessNextForTesting();
+            yield return TestUtils.WaitForTask(task);
+
+            Assert.IsTrue(task.Result);
+            Assert.IsTrue(CacheManager.Texture.Exists(cacheFile), "The compressed result must be cached to disk even when no preview material references it anymore.");
         }
 
         /// <summary>
@@ -335,8 +420,8 @@ namespace KRT.VRCQuestTools.Utils
         /// item would otherwise do. Only asserts the counter never goes negative (rather than an exact final
         /// value) and restores whatever was there beforehand: <c>pendingBytes</c> is process-wide static state,
         /// potentially shared with real (non-test) preview activity in the running editor session, not scoped to
-        /// this test -- same accommodation <see cref="TryEnqueue_PendingBytesCapReached_ReturnsFalse"/> already
-        /// makes for the same reason.
+        /// this test -- same accommodation <see cref="TryEnqueue_BacklogOverHighWaterMark_StillAcceptsAndWarnsOnce"/>
+        /// already makes for the same reason.
         /// </summary>
         [UnityTest]
         public IEnumerator ProcessNextForTesting_PendingBytesWouldUnderflow_ClampsToZero()

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/MaterialGeneratorUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Models/MaterialGenerators/MaterialGeneratorUtility.cs
@@ -138,7 +138,9 @@ namespace KRT.VRCQuestTools.Models
                     // is handed to PreviewTextureCompressionQueue for background compression, disk cache save,
                     // and eventual material texture replacement. TryEnqueueProgressiveCompression returns false
                     // (falling through to the normal synchronous path below) when astcenc is unavailable for this
-                    // format or the queue's pending-bytes safety valve is full.
+                    // format, or when the queue cannot take ownership at all (NDMF not installed, so nothing
+                    // would ever swap the result in; or an assembly reload about to discard the queue). A large
+                    // backlog is deliberately not one of those cases -- see PreviewTextureCompressionQueue.MaxPendingBytes.
                     if (!saveAsPng && forEditorPreview && TryEnqueueProgressiveCompression(compressionFormat, config, cacheFile, platformOverride, ref texToWrite))
                     {
                         completion?.Invoke(texToWrite);
@@ -176,7 +178,7 @@ namespace KRT.VRCQuestTools.Models
         /// <param name="cacheFile">Disk cache file name the compressed result should eventually be saved under.</param>
         /// <param name="platformOverride">Optional platform override; only its MaxTextureSize is used here (its Format already went into <paramref name="compressionFormat"/>).</param>
         /// <param name="texToWrite">The freshly baked, uncompressed texture. For color textures with a maxTextureSize override, replaced in place with a resized instance (mirroring <see cref="TextureUtility.CompressTextureForBuildTarget"/>'s own maxTextureSize handling) before being enqueued as the placeholder; normal maps are left untouched here since <see cref="AstcencTextureCompressor.CompressNormalMapAsync"/> applies its own maxTextureSize shrink internally, mirroring <see cref="TextureUtility.CompressNormalMap"/>.</param>
-        /// <returns>True when the texture was successfully enqueued for background compression (the caller must treat <paramref name="texToWrite"/> as the new placeholder and do nothing further to it). False when astcenc is unavailable for <paramref name="compressionFormat"/>, or the queue's pending-bytes cap was reached, in which case the caller must fall back to synchronous compression.</returns>
+        /// <returns>True when the texture was successfully enqueued for background compression (the caller must treat <paramref name="texToWrite"/> as the new placeholder and do nothing further to it). False when astcenc is unavailable for <paramref name="compressionFormat"/>, or the queue declined to take ownership of the placeholder, in which case the caller must fall back to synchronous compression.</returns>
         private static bool TryEnqueueProgressiveCompression(TextureFormat? compressionFormat, TextureConfig config, string cacheFile, (int MaxTextureSize, TextureFormat Format)? platformOverride, ref Texture2D texToWrite)
         {
             bool enqueued;

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
@@ -213,16 +213,6 @@ namespace KRT.VRCQuestTools.Ndmf
 
         private class MaterialConversionFilterNode : IRenderFilterNode
         {
-            /// <summary>
-            /// The only upstream change this node's output survives. Blendshape and bone updates cannot affect
-            /// which material a slot uses, so the conversion result stays valid. Everything else can:
-            /// Material and Texture change the very things the material map is keyed by and built from, and Mesh
-            /// changes the submesh count, which decides how many slots <see cref="OnFrame"/> takes -- and
-            /// therefore whether a material that was never converted (because it sat in an extra slot) starts
-            /// being rendered.
-            /// </summary>
-            private const RenderAspects ReusableAspects = RenderAspects.Shapes;
-
             private readonly Dictionary<Material, Material> materialMap;
             private readonly bool removeExtraMaterialSlots;
             private readonly SharedMaterialMapLease materialLease;
@@ -248,6 +238,26 @@ namespace KRT.VRCQuestTools.Ndmf
             }
 
             public RenderAspects WhatChanged => RenderAspects.Material;
+
+            /// <summary>
+            /// Gets the set of upstream changes this node's output survives, as a <see cref="RenderAspects"/>
+            /// flag set. Material and Texture are never in it: they change the very things the material map is
+            /// keyed by and built from. Blendshape and bone updates always are, since they cannot affect which
+            /// material a renderer slot uses.
+            /// </summary>
+            /// <remarks>
+            /// Mesh depends on <see cref="removeExtraMaterialSlots"/>, which is what decides how
+            /// <see cref="OnFrame"/> counts slots. With it off, the count is <c>proxy.sharedMaterials.Length</c>,
+            /// which no mesh change can move, so the conversion stays valid. With it on, the count is the
+            /// submesh count: an upstream node that raises it makes <see cref="OnFrame"/> reach a slot that was
+            /// an extra slot when <see cref="Instantiate"/> ran, and the material sitting there was therefore
+            /// never collected or converted -- it would render unconverted. Rebuilding in that case is the only
+            /// way to pick it up, and renderers carrying extra material slots are common enough in real avatars
+            /// to be worth the rebuild.
+            /// </remarks>
+            private RenderAspects ReusableAspects => removeExtraMaterialSlots
+                ? RenderAspects.Shapes
+                : RenderAspects.Shapes | RenderAspects.Mesh;
 
             /// <summary>
             /// Lets the preview pipeline carry this node over to a new generation instead of running

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
@@ -102,7 +102,12 @@ namespace KRT.VRCQuestTools.Ndmf
                 settings = avatarRoot.GetComponent<MaterialConversionSettings>();
             }
             context.Observe(settings as Object, s => (s as IMaterialConversionComponent).GetCacheKey());
-            if (settings is Component c && c.TryGetComponent<PlatformTargetSettings>(out var targetSettings))
+
+            // Hoisted out of the `if` below (rather than declared by its `out var`) so it stays in scope, and
+            // definitely assigned, for the MaterialConversionFilterNode built at the end of this method: the node
+            // has to re-observe it in Refresh. TryGetComponent leaves it null when there is no such component.
+            PlatformTargetSettings targetSettings = null;
+            if (settings is Component c && c.TryGetComponent<PlatformTargetSettings>(out targetSettings))
             {
                 context.Observe(targetSettings);
             }
@@ -189,7 +194,13 @@ namespace KRT.VRCQuestTools.Ndmf
                     NdmfObjectRegistry.TryRegisterReplacedObjectToActiveRegistry(original, converted);
                 }
 
-                return Task.FromResult<IRenderFilterNode>(new MaterialConversionFilterNode(materialLease.MaterialMap, removeExtraMaterialSlots, materialLease));
+                return Task.FromResult<IRenderFilterNode>(new MaterialConversionFilterNode(
+                    materialLease.MaterialMap,
+                    removeExtraMaterialSlots,
+                    materialLease,
+                    settings as Object,
+                    targetSettings,
+                    avatarMaterials.ToArray()));
             }
             catch (System.Exception e)
             {
@@ -202,19 +213,96 @@ namespace KRT.VRCQuestTools.Ndmf
 
         private class MaterialConversionFilterNode : IRenderFilterNode
         {
+            /// <summary>
+            /// The only upstream change this node's output survives. Blendshape and bone updates cannot affect
+            /// which material a slot uses, so the conversion result stays valid. Everything else can:
+            /// Material and Texture change the very things the material map is keyed by and built from, and Mesh
+            /// changes the submesh count, which decides how many slots <see cref="OnFrame"/> takes -- and
+            /// therefore whether a material that was never converted (because it sat in an extra slot) starts
+            /// being rendered.
+            /// </summary>
+            private const RenderAspects ReusableAspects = RenderAspects.Shapes;
+
             private readonly Dictionary<Material, Material> materialMap;
             private readonly bool removeExtraMaterialSlots;
             private readonly SharedMaterialMapLease materialLease;
+            private readonly Object settingsComponent;
+            private readonly PlatformTargetSettings platformTargetSettings;
+            private readonly Material[] observedMaterials;
             private bool disposedValue;
 
-            public MaterialConversionFilterNode(Dictionary<Material, Material> materialMap, bool removeExtraMaterialSlots, SharedMaterialMapLease materialLease)
+            public MaterialConversionFilterNode(
+                Dictionary<Material, Material> materialMap,
+                bool removeExtraMaterialSlots,
+                SharedMaterialMapLease materialLease,
+                Object settingsComponent = null,
+                PlatformTargetSettings platformTargetSettings = null,
+                Material[] observedMaterials = null)
             {
                 this.materialMap = materialMap;
                 this.removeExtraMaterialSlots = removeExtraMaterialSlots;
                 this.materialLease = materialLease;
+                this.settingsComponent = settingsComponent;
+                this.platformTargetSettings = platformTargetSettings;
+                this.observedMaterials = observedMaterials;
             }
 
             public RenderAspects WhatChanged => RenderAspects.Material;
+
+            /// <summary>
+            /// Lets the preview pipeline carry this node over to a new generation instead of running
+            /// <see cref="Instantiate"/> -- and therefore the whole material conversion -- again. Without this,
+            /// NDMF's default implementation returns null and every upstream change, however unrelated, forces a
+            /// full re-conversion of the avatar.
+            /// </summary>
+            /// <remarks>
+            /// Returning <c>this</c> is safe for the shared converted materials: NDMF increments its own
+            /// reference count on the reused node (NodeController.Refresh) and only disposes it once both the old
+            /// and the new generation are gone, which is exactly the lifetime <see cref="SharedMaterialMapLease"/>
+            /// needs. The observations, however, are not carried over: the NodeController built around a reused
+            /// node takes the *new* ComputeContext passed in here, so everything <see cref="Instantiate"/>
+            /// observed has to be observed again on it. Miss one and this node is never invalidated again --
+            /// editing the avatar's convert settings would silently stop updating the preview.
+            /// </remarks>
+            public Task<IRenderFilterNode> Refresh(IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context, RenderAspects updatedAspects)
+            {
+                // updatedAspects == 0 means this node's own ComputeContext was invalidated -- the convert
+                // settings or one of the source materials changed -- so the conversion has to be redone.
+                // A node without a lease is one of the no-op nodes Instantiate returns early (wrong phase,
+                // non-mobile target, or a conversion that threw); rebuilding those is cheap and re-evaluates
+                // the condition that made them no-ops in the first place.
+                if (disposedValue || materialLease == null || updatedAspects == 0 || (updatedAspects & ~ReusableAspects) != 0)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                // Re-register every observation Instantiate made, onto the new context. See the remarks above.
+                if (settingsComponent != null)
+                {
+                    context.Observe(settingsComponent, s => (s as IMaterialConversionComponent).GetCacheKey());
+                }
+                if (platformTargetSettings != null)
+                {
+                    context.Observe(platformTargetSettings);
+                }
+                foreach (var (original, proxy) in proxyPairs)
+                {
+                    context.Observe(original);
+                    context.Observe(proxy);
+                }
+                if (observedMaterials != null)
+                {
+                    foreach (var m in observedMaterials)
+                    {
+                        if (m != null)
+                        {
+                            context.Observe(m);
+                        }
+                    }
+                }
+
+                return Task.FromResult<IRenderFilterNode>(this);
+            }
 
             public void OnFrame(Renderer original, Renderer proxy)
             {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/PreviewTextureCompressionQueue.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/PreviewTextureCompressionQueue.cs
@@ -35,16 +35,24 @@ namespace KRT.VRCQuestTools.Utils
     internal static class PreviewTextureCompressionQueue
     {
         /// <summary>
-        /// Maximum total estimated bytes of placeholder textures allowed to be pending (enqueued but not yet
-        /// compressed) at once. Progressive keeps each placeholder (an uncompressed baked RGBA32 texture, with
-        /// mips) alive in memory until its compressed replacement is ready; a 2048x2048 RGBA32 texture with a
-        /// full mip chain is about 22 MB (2048*2048*4 * 4/3 for the mip chain overhead). 512 MB allows roughly
-        /// 23 such textures to be in flight -- generous for normal preview activity (see
-        /// <see cref="MaxConcurrentCompressions"/> for how many of those are actually compressing at once; the
-        /// rest simply wait their turn) -- while still bounding the worst case (e.g. toggling material preview
-        /// for many avatars at once) so it cannot balloon editor memory unboundedly. Enqueue attempts beyond this
-        /// cap fall back to synchronous compression.
+        /// Estimated total bytes of pending (enqueued but not yet compressed) placeholder textures at which a
+        /// single warning is logged per batch. Progressive keeps each placeholder (an uncompressed baked RGBA32
+        /// texture, with mips) alive in memory until its compressed replacement is ready; a 2048x2048 RGBA32
+        /// texture with a full mip chain is about 22 MB (2048*2048*4 * 4/3 for the mip chain overhead), so this
+        /// is roughly 23 such textures held at once (see <see cref="MaxConcurrentCompressions"/> for how many of
+        /// those are actually compressing at any moment; the rest simply wait their turn).
         /// </summary>
+        /// <remarks>
+        /// This is a diagnostic threshold, not a cap: passing it does not refuse the enqueue. It used to, with
+        /// <see cref="Models.MaterialGeneratorUtility"/> falling back to synchronous compression -- but that
+        /// traded a bounded amount of memory for the worst available outcome, a main-thread stall running
+        /// astcenc at the same preset while up to <see cref="MaxConcurrentCompressions"/> background astcenc
+        /// processes were already asking for every core each. It also did not actually save the memory it was
+        /// meant to save, except for as long as that stall lasted: the placeholder has already been baked and
+        /// assigned to the preview material by the time <see cref="TryEnqueue"/> is called, so it occupies
+        /// memory either way until something replaces it. What remains is the warning, so that an unexpectedly
+        /// large backlog is visible rather than silent.
+        /// </remarks>
         internal const long MaxPendingBytes = 512L * 1024 * 1024;
 
         /// <summary>
@@ -67,6 +75,7 @@ namespace KRT.VRCQuestTools.Utils
         private static bool updateHooked;
         private static int inFlight;
         private static bool assemblyReloading;
+        private static bool highWaterWarned;
         private static CancellationTokenSource cts = new CancellationTokenSource();
 
         static PreviewTextureCompressionQueue()
@@ -157,7 +166,7 @@ namespace KRT.VRCQuestTools.Utils
         /// <param name="maxTextureSize">Normal map only: optional max texture size override.</param>
         /// <param name="cacheFile">Disk cache file name to save the compressed result under once ready, matching what the synchronous path would have used.</param>
         /// <param name="isSRGB">Whether the texture is sRGB data; recorded into the disk cache entry as <c>!isSRGB</c> (linear), matching <see cref="Models.MaterialGeneratorUtility"/>'s synchronous save.</param>
-        /// <returns>True when the texture was enqueued (the caller must not touch <paramref name="placeholder"/> or fall back to synchronous compression); false when no material-texture-replacer is registered (e.g. NDMF is not installed), or the pending-bytes cap would be exceeded, in which case the caller must fall back to synchronous compression itself and <paramref name="placeholder"/> remains entirely the caller's responsibility.</returns>
+        /// <returns>True when the texture was enqueued (the caller must not touch <paramref name="placeholder"/> or fall back to synchronous compression); false when the queue cannot take ownership at all -- no material-texture-replacer is registered (e.g. NDMF is not installed), so nothing would ever swap the compressed result in, or an assembly reload is in progress, which is about to discard the queue -- in which case the caller must fall back to synchronous compression itself and <paramref name="placeholder"/> remains entirely the caller's responsibility. A large backlog is no longer a refusal reason; see <see cref="MaxPendingBytes"/>.</returns>
         internal static bool TryEnqueue(Texture2D placeholder, AstcencTextureCompressor compressor, TextureFormat? format, bool isNormalMap, bool readable, int? maxTextureSize, string cacheFile, bool isSRGB)
         {
             if (assemblyReloading)
@@ -173,11 +182,6 @@ namespace KRT.VRCQuestTools.Utils
             }
 
             var estimatedBytes = EstimatePlaceholderBytes(placeholder);
-            if (pendingBytes + estimatedBytes > MaxPendingBytes)
-            {
-                Logger.LogDebug($"Progressive compression queue declined \"{placeholder.name}\" (pending bytes cap reached: {pendingBytes + estimatedBytes} > {MaxPendingBytes}); the caller will fall back to synchronous compression.", placeholder);
-                return false;
-            }
 
             Pending.Add(new PendingItem
             {
@@ -201,8 +205,26 @@ namespace KRT.VRCQuestTools.Utils
             });
             pendingBytes += estimatedBytes;
             EnsureUpdateHooked();
+            WarnOnceIfBacklogIsLarge();
             Logger.LogDebug($"Progressive compression queue accepted \"{placeholder.name}\" (estimated {estimatedBytes} bytes, queue length {Pending.Count}).", placeholder);
             return true;
+        }
+
+        /// <summary>
+        /// Logs a single warning per batch once <see cref="pendingBytes"/> passes <see cref="MaxPendingBytes"/>.
+        /// Latched via <see cref="highWaterWarned"/> and cleared when the batch drains (see
+        /// <see cref="ProcessItemAsync"/>) or work is abandoned (see <see cref="StopAllWork"/>), so one oversized
+        /// batch warns once rather than once per texture, while a later batch can warn again.
+        /// </summary>
+        private static void WarnOnceIfBacklogIsLarge()
+        {
+            if (highWaterWarned || pendingBytes <= MaxPendingBytes)
+            {
+                return;
+            }
+
+            highWaterWarned = true;
+            Logger.LogWarning($"Progressive preview compression is holding about {pendingBytes / (1024 * 1024)} MB of uncompressed placeholder textures ({Pending.Count} queued, {inFlight} compressing). They are freed as compression completes; the preview shows the uncompressed textures until then.");
         }
 
         /// <summary>
@@ -430,6 +452,14 @@ namespace KRT.VRCQuestTools.Utils
                 // (or, with several in-flight items, several times over) time.
                 pendingBytes = Math.Max(0, pendingBytes - item.EstimatedBytes);
                 inFlight = Math.Max(0, inFlight - 1);
+
+                // Batch drained: re-arm the backlog warning for the next one. Keyed on the item counts rather
+                // than pendingBytes, so it also re-arms under the test hooks, which can leave the byte counter
+                // at an arbitrary forced value.
+                if (inFlight == 0 && Pending.Count == 0)
+                {
+                    highWaterWarned = false;
+                }
             }
         }
 
@@ -492,9 +522,19 @@ namespace KRT.VRCQuestTools.Utils
 
         /// <summary>
         /// Shared success path for both the background compression attempt and its synchronous fallback: enables
-        /// streaming mipmaps on the result, replaces every cached preview material reference to the placeholder,
-        /// saves the disk cache entry, destroys the placeholder, and repaints every editor view.
+        /// streaming mipmaps on the result, saves the disk cache entry, replaces every cached preview material
+        /// reference to the placeholder, destroys the placeholder, and repaints every editor view.
         /// </summary>
+        /// <remarks>
+        /// The disk cache entry is written before -- and independently of -- everything to do with the preview
+        /// materials, because the two are unrelated: the entry is keyed by the source material's content and the
+        /// convert settings (see <see cref="Models.MaterialGeneratorUtility"/>), not by whether anything happens
+        /// to be displaying the result right now. Both early exits below are reached routinely (a settings edit
+        /// releases every lease on the old key while its textures are still compressing, so the placeholder is
+        /// destroyed and no material references it anymore), and skipping the write there used to throw away a
+        /// whole finished astcenc run -- guaranteeing it would be redone from scratch the next time that exact
+        /// material and settings combination came back, e.g. when the user undid the edit.
+        /// </remarks>
         /// <param name="item">The item that finished compressing.</param>
         /// <param name="compressed">The compressed result. Destroyed by this method if it ends up unused (the placeholder was destroyed mid-flight, or nothing references it anymore).</param>
         /// <param name="checkPlaceholderStillAlive">Whether to treat <c>item.Placeholder</c> reading as destroyed
@@ -505,10 +545,19 @@ namespace KRT.VRCQuestTools.Utils
         /// <see cref="FallbackToSynchronousCompression"/>'s call site for why that is still safe).</param>
         private static void ApplyCompressedResult(PendingItem item, Texture2D compressed, bool checkPlaceholderStillAlive)
         {
+            // Matches what the synchronous path (MaterialGeneratorUtility.SaveTexture) does for both color and
+            // normal map textures; AstcencTextureCompressor.CompressNormalMap(Async) already does this itself for
+            // the normal map path, so doing it again here is a harmless no-op for that case. Runs before the disk
+            // cache write so the flag is set on the very instance whose raw bytes get stored, exactly as the
+            // synchronous path does.
+            TextureUtility.SetStreamingMipMaps(compressed, true);
+            SaveToDiskCache(item, compressed);
+
             if (checkPlaceholderStillAlive && item.Placeholder == null)
             {
                 // Destroyed while compression was in flight (e.g. a full domain reload recovery, or every
-                // preview material lease was released mid-compression).
+                // preview material lease was released mid-compression). The entry is already saved above, so
+                // the compression itself was not wasted.
                 TextureUtility.DestroyTexture(compressed);
                 return;
             }
@@ -519,7 +568,7 @@ namespace KRT.VRCQuestTools.Utils
             {
                 // No cached preview material references the placeholder anymore (e.g. every lease was
                 // released while this was compressing in the background, or the replacer was unregistered
-                // mid-flight). Nothing left to update.
+                // mid-flight). Nothing left to update on screen -- but, again, the entry is already saved.
                 TextureUtility.DestroyTexture(compressed);
                 DestroyPlaceholderUnlessItIsTheResult(item, compressed);
                 return;
@@ -527,11 +576,23 @@ namespace KRT.VRCQuestTools.Utils
 
             Logger.LogDebug($"Progressive compression replaced \"{compressed.name}\" in {replacedCount} cached preview material propert{(replacedCount == 1 ? "y" : "ies")}.", compressed);
 
-            // Matches what the synchronous path (MaterialGeneratorUtility.SaveTexture) does for both color and
-            // normal map textures; AstcencTextureCompressor.CompressNormalMap(Async) already does this itself for
-            // the normal map path, so doing it again here is a harmless no-op for that case.
-            TextureUtility.SetStreamingMipMaps(compressed, true);
+            DestroyPlaceholderUnlessItIsTheResult(item, compressed);
 
+            // InternalEditorUtility.RepaintAllViews() (rather than just SceneView.RepaintAll()) also repaints the
+            // Game view and the material preview thumbnails, both of which can also be displaying the just-replaced texture.
+            UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+        }
+
+        /// <summary>
+        /// Stores <paramref name="compressed"/> under <paramref name="item"/>'s cache file name, so a later
+        /// preview generation (or a real conversion, which shares the same key space) reuses it instead of
+        /// running astcenc again. Failures are logged and swallowed: the compressed texture is still perfectly
+        /// usable on screen, only the reuse of it later is lost.
+        /// </summary>
+        /// <param name="item">The item that finished compressing; supplies the cache file name and the attributes recorded alongside the bytes.</param>
+        /// <param name="compressed">The compressed result whose raw bytes are stored.</param>
+        private static void SaveToDiskCache(PendingItem item, Texture2D compressed)
+        {
             try
             {
                 var cache = new CacheUtility.TextureCache(compressed, !item.IsSRGB, item.IsNormalMap, item.BuildTarget);
@@ -539,16 +600,8 @@ namespace KRT.VRCQuestTools.Utils
             }
             catch (Exception e)
             {
-                // The material already displays the compressed texture (replaced above); only the disk cache
-                // write failed, so the next preview generation just re-does the work instead of reusing a cache hit.
                 Logger.LogWarning($"Failed to save the disk cache entry for progressively compressed preview texture \"{compressed.name}\". {e.Message}");
             }
-
-            DestroyPlaceholderUnlessItIsTheResult(item, compressed);
-
-            // InternalEditorUtility.RepaintAllViews() (rather than just SceneView.RepaintAll()) also repaints the
-            // Game view and the material preview thumbnails, both of which can also be displaying the just-replaced texture.
-            UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
         }
 
         /// <summary>
@@ -644,6 +697,7 @@ namespace KRT.VRCQuestTools.Utils
             Pending.Clear();
             pendingBytes = 0;
             inFlight = 0;
+            highWaterWarned = false;
 
             // The placeholder texture(s) still referenced by preview materials are deliberately NOT destroyed
             // here: they are live Unity objects owned by those materials, and the next preview regeneration


### PR DESCRIPTION
## Summary

Three fixes to the NDMF material conversion preview, all found while investigating why a second avatar in the scene took so long to have its materials swapped in and appeared to recompress textures it had already compressed once.

- **A finished compression is always cached to disk.** `PreviewTextureCompressionQueue.ApplyCompressedResult` used to write the disk cache entry only after a preview material accepted the result, so its two early exits threw away a whole completed astcenc run. Both are reached routinely — editing a convert setting changes the cache key, which drops the last lease on the old key while its textures are still compressing, destroying the placeholder and leaving nothing referencing it. The entry is keyed by material content plus convert settings, not by what happens to be on screen, so it is now written first and independently.

- **A large backlog no longer forces synchronous compression.** `TryEnqueue` refused once `pendingBytes` passed `MaxPendingBytes`, which sent `MaterialGeneratorUtility` into main-thread compression at the same `-thorough` preset while up to `MaxConcurrentCompressions` background astcenc processes were already asking for every core each — the worst available outcome. It also did not save the memory it was meant to save, except for as long as that stall lasted: the placeholder is baked and assigned to the preview material before `TryEnqueue` is ever called, so it occupies memory either way. `MaxPendingBytes` becomes a diagnostic threshold that warns once per batch. Enqueueing is still refused when the queue cannot take ownership at all (no replacer registered, i.e. NDMF absent, or an assembly reload in progress).

- **The preview filter node survives changes that cannot affect it.** `MaterialConversionFilterNode` did not implement `IRenderFilterNode.Refresh`, so NDMF's default (return `null`) forced a full `Instantiate` — and therefore a full material conversion — on every upstream change, however unrelated. It now returns itself when `updatedAspects` stays within a reusable set. `Shapes` is always in it, since blendshape and bone updates cannot affect which material a renderer slot uses. `Mesh` is in it too, except when `removeExtraMaterialSlots` is on: the conversion itself does not depend on the mesh, but that setting makes `OnFrame` count slots from the submesh count, so an upstream node raising it would reach a slot that was an extra slot when `Instantiate` ran — whose material was therefore never collected or converted, and would render unconverted. `Material` and `Texture` are never reusable; they change what the material map is keyed by and built from. Neither is `updatedAspects == 0`, which NDMF passes when the node's own `ComputeContext` was invalidated, i.e. exactly when the convert settings or a source material changed.

## Verification

- Full EditMode suite locally: 419 tests, 406 passed, 0 failed, 13 skipped (skips are optional packages not installed: DynamicBone, FinalIK, lilToon, VRCFury).
- CI green across all 15 SDK × dependency matrix combinations, including `deps-nothing`. That combination matters here: `PreviewTextureCompressionQueue` lives in the unconditionally compiled `VRCQuestTools-Editor` assembly, and this PR changes its enqueue contract.
- Five new tests: the backlog threshold accepts and warns exactly once per batch; a result the replacer reports zero replacements for is still written to the disk cache; `Refresh` reuses the node for `Shapes`, `Mesh` and their combination while rebuilding for `Material`, `Texture`, mixed sets and zero; the same node rebuilds for `Mesh` once `removeExtraMaterialSlots` is on; a lease-less no-op node always rebuilds.
- StyleCop warning profile for the changed source files compared against `master` — no new violations.

## Notes

- **Reusing a node means re-observing on a new `ComputeContext`.** The `NodeController` built around a reused node takes the new context passed to `Refresh`, not the one `Instantiate` observed on. `Refresh` therefore re-registers every observation `Instantiate` made (settings cache key, `PlatformTargetSettings`, both renderers of each proxy pair, every avatar material). Missing one would leave the node permanently un-invalidatable and silently freeze the preview against later settings edits. `targetSettings` was hoisted out of its `out var` so the node can keep it for that purpose.

- **This does not make two avatars share converted materials when their convert settings differ.** In the scene that prompted the investigation, two copies of the same avatar referenced the same 12 material assets but had opposite `ToonStandard` feature toggles, so `SharedPreviewMaterialCache` produced 24 distinct keys and nothing was shared — working as designed. What this PR fixes is the cost of the resulting rebuild, not the fact that a rebuild happens.

- **No changelog entry.** Everything touched here belongs to features still under `## [Unreleased]` (the NDMF material conversion preview and its background compression), and the existing entries already describe the intended behavior. Happy to add one if you would rather record it.