### PR TITLE
Document worktree package resolution and search-first vrc-get workflow

### DIFF
--- a/.claude/skills/vrc-get/SKILL.md
+++ b/.claude/skills/vrc-get/SKILL.md
@@ -105,7 +105,7 @@ Repository: `https://kurotu.github.io/vpm-repos/vpm.json`
 
 ```bash
 vrc-get search nadena.dev.ndmf
-# Not found -> repo isn't registered yet:
+# If not found, the repo isn't registered yet:
 vrc-get repo add https://vpm.nadena.dev/vpm.json
 vrc-get search nadena.dev.ndmf   # confirm it resolves now
 vrc-get install -y nadena.dev.ndmf 1.5.0

--- a/.claude/skills/vrc-get/SKILL.md
+++ b/.claude/skills/vrc-get/SKILL.md
@@ -23,15 +23,28 @@ description: Install, remove, and manage VRChat VPM packages using the vrc-get C
 
 ## Installation Workflow
 
-### Step 1: Add the repository (if not yet added)
+### Step 1: Search for the package
 
-Third-party packages need their repository registered first. Check with `vrc-get repo list` — if the vendor isn't listed, add it:
+`vrc-get search` only looks through repositories that are already registered, so start here rather than assuming a repo add is needed — most official and previously-used third-party repos are already registered, and searching first avoids adding duplicate or unnecessary repositories.
+
+```bash
+vrc-get search <package-name-or-id>
+```
+
+- **Found** — note the exact package ID from the results and skip to Step 3.
+- **Not found** — the vendor's repository is probably not registered yet; go to Step 2.
+
+### Step 2: Add the repository (only if the search came up empty)
+
+Look up the vendor in "Common Repositories & Packages" below for the repository URL. If it's not listed there, ask the user for the URL rather than guessing one.
 
 ```bash
 vrc-get repo add <repository-url>
 ```
 
-### Step 2: Install the package
+Re-run `vrc-get search <package-name-or-id>` to confirm the package now resolves before installing.
+
+### Step 3: Install the package
 
 ```bash
 vrc-get install -y <package-id>               # latest stable version
@@ -41,7 +54,7 @@ vrc-get install -y --prerelease <package-id>  # include prerelease builds
 
 The `-y` flag skips the interactive confirmation prompt — always include it in scripts or automated contexts.
 
-### Step 3: Verify
+### Step 4: Verify
 
 ```bash
 vrc-get info project
@@ -91,15 +104,19 @@ Repository: `https://kurotu.github.io/vpm-repos/vpm.json`
 ## Example: Install NDMF 1.5.0
 
 ```bash
+vrc-get search nadena.dev.ndmf
+# Not found -> repo isn't registered yet:
 vrc-get repo add https://vpm.nadena.dev/vpm.json
+vrc-get search nadena.dev.ndmf   # confirm it resolves now
 vrc-get install -y nadena.dev.ndmf 1.5.0
 vrc-get info project
 ```
 
-## Example: Install the latest lilToon
+## Example: Install the latest lilToon (repo already registered)
 
 ```bash
-vrc-get repo add https://lilxyzw.github.io/vpm-repos/vpm.json
+vrc-get search jp.lilxyzw.liltoon
+# Found -> repo add is unnecessary, install directly:
 vrc-get install -y jp.lilxyzw.liltoon
 ```
 
@@ -107,6 +124,9 @@ vrc-get install -y jp.lilxyzw.liltoon
 
 ```bash
 vrc-get search "avatar optimizer"
-# Find the package ID from results, then:
+# Not found in any registered repo -> check "Common Repositories & Packages"
+# for the vendor's URL (or ask the user), then add it and search again:
+vrc-get repo add https://vpm.anatawa12.com/vpm.json
+vrc-get search "avatar optimizer"
 vrc-get install -y <found-package-id>
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Unity editor extension for converting VRChat PC avatars to Android (Quest/PICO) 
 **Preferred** for compilation and testing when Unity Editor is running. Uses [unity-cli-loop](https://github.com/hatayama/unity-cli-loop)-based skills:
 
 > First run `uloop-launch` to start Unity, then run other `uloop-*` commands after the editor is ready.
+> In a freshly created worktree, resolve VPM packages before launching Unity — see "New worktree setup" below.
 
 | Skill | Purpose |
 |-------|---------|
@@ -21,6 +22,14 @@ Unity editor extension for converting VRChat PC avatars to Android (Quest/PICO) 
 Note: When you need to execute `npm` and `npx`, use `pnpm` and `pnpm dlx` instead.
 
 ### Setup
+
+#### New worktree setup
+
+Packages under `Packages/` (e.g. `com.vrchat.avatars`, `com.vrchat.base`) are VPM dependencies
+resolved into the working copy, not tracked in git — a fresh worktree starts without them. Check
+whether `Packages/com.vrchat.base` exists; if it's missing, run `vrc-get resolve` (see the
+`vrc-get` skill) to install all VPM dependencies **before** launching Unity with `uloop-launch`.
+Launching Unity first can cause it to fail or generate broken package state.
 
 The `astcenc` CLI binaries used for fast ASTC texture compression are not committed to the
 repository; download them once per clone/worktree:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ Note: When you need to execute `npm` and `npx`, use `pnpm` and `pnpm dlx` instea
 
 #### New worktree setup
 
-Packages under `Packages/` (e.g. `com.vrchat.avatars`, `com.vrchat.base`) are VPM dependencies
-resolved into the working copy, not tracked in git — a fresh worktree starts without them. Check
+Some packages under `Packages/` (e.g. `com.vrchat.avatars`, `com.vrchat.base`) are VPM dependencies
+resolved into the working copy and are not tracked in git — a fresh worktree starts without them. Check
 whether `Packages/com.vrchat.base` exists; if it's missing, run `vrc-get resolve` (see the
 `vrc-get` skill) to install all VPM dependencies **before** launching Unity with `uloop-launch`.
 Launching Unity first can cause it to fail or generate broken package state.


### PR DESCRIPTION
AGENTS.md now tells agents to run vrc-get resolve before launching Unity in a fresh worktree, using Packages/com.vrchat.base as the marker. The vrc-get skill's install workflow now searches for a package first and only adds a repository when the search comes up empty.