### PR TITLE
Add v2 to v3.0.0 migration guide to documentation site

### DIFF
--- a/Website/docs/migration-to-v3.md
+++ b/Website/docs/migration-to-v3.md
@@ -29,7 +29,7 @@ What it used to do is replaced by one of the following.
 
 - For a regular upload, build and upload directly from the VRChat SDK's Control Panel.
 - To test locally only, right-click the avatar and select "VRCQuestTools" → "[NDMF] Build and Test for PC with Mobile Settings".
-    It builds for PC with Mobile settings applied, so you can test it right away.
+  It builds for PC with Mobile settings applied, so you can test it right away.
 
 ## Behavior Changes
 

--- a/Website/docs/migration-to-v3.md
+++ b/Website/docs/migration-to-v3.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 6
+slug: /migration-to-v3
+---
+
+# Migration Guide from v2.x to v3.0.0
+
+VRCQuestTools v3.0.0 is a major update.
+Updating can affect scenes and prefabs you created under v2.x, and part of the conversion procedure.
+
+Non-Destructive Modular Framework (NDMF) conversion doesn't rewrite avatars in the scene, so your existing settings are applied the same way at build time after the update.
+If you don't meet the required versions below or use a removed feature, you need to take action when migrating.
+
+## Requirement Changes
+
+v3.0.0 requires the following versions.
+
+- Unity 2022.3 or later
+- VRChat SDK - Avatars 3.9.0 or later
+- lilToon 1.10.0 or later (if used)
+- NDMF 1.5.0 or later (if used)
+
+For lilToon and NDMF, an outdated version aborts the build or conversion with an error, so check these versions in VCC or ALCOM before updating.
+
+## Removal of the VQT Avatar Builder Window
+
+The **VQT Avatar Builder** window has been removed.
+What it used to do is replaced by one of the following.
+
+- For a regular upload, build and upload directly from the VRChat SDK's Control Panel.
+- To test locally only, right-click the avatar and select "VRCQuestTools" → "[NDMF] Build and Test for PC with Mobile Settings".
+    It builds for PC with Mobile settings applied, so you can test it right away.
+
+## Behavior Changes
+
+### Where Avatar Dynamics Settings Are Stored
+
+The PhysBone/PhysBone Collider/Contacts settings chosen in the **Avatar Dynamics Selector** are now stored in a **Platform Component Remover** component instead of inside the **Avatar Converter Settings** component.
+
+This migration doesn't happen automatically.
+An avatar already set up under v2.x keeps working from the settings stored in Avatar Converter Settings, unless you press the "Apply" button in the Avatar Dynamics Selector.
+So updating the package alone never loses your existing settings.
+Press the "Apply" button only when you want to move your settings to the new location.
+
+### How Vertex Color Removal Works
+
+Vertex color removal during conversion changed from using the **Vertex Color Remover** component to generating a dedicated mesh (a `.vqtmesh` asset) for the converted avatar.
+In v2.x, vertex colors were removed directly from the original mesh, so for avatars that use vertex colors to control their outlines, the pre-conversion avatar's appearance could also change.
+Conversion in v3.0.0 no longer causes this problem.
+The Vertex Color Remover component itself is still available, and attached components keep working as before.
+
+### Avatar Active State After Manual Conversion
+
+When you manually convert from Avatar Converter Settings, the original avatar is no longer deactivated.
+Note that both avatars remain active in the scene.
+
+### Platform GameObject Remover and Platform Component Remover in Manual Conversion
+
+Manual conversion now also applies **Platform GameObject Remover** and Platform Component Remover settings for Mobile.
+These settings weren't reflected in v2.x manual conversion, so if your avatar specifies removal targets for Mobile, the conversion result differs from v2.x.
+For avatars whose Avatar Dynamics settings haven't been migrated to Platform Component Remover, components are still removed based on the settings in Avatar Converter Settings, as before.
+
+## Migration Checklist
+
+1. Check that your project's Unity, VRChat SDK, lilToon, and NDMF versions meet the required versions above.
+2. Update VRCQuestTools to v3.0.0 with VCC or ALCOM.
+3. If needed, press "Apply" in the Avatar Dynamics Selector to finish migrating to Platform Component Remover.
+
+The [Changelog](./changelog.md) covers every change in v3.0.0.

--- a/Website/i18n/ja/docusaurus-plugin-content-docs/current/migration-to-v3.md
+++ b/Website/i18n/ja/docusaurus-plugin-content-docs/current/migration-to-v3.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 6
+slug: /migration-to-v3
+---
+
+# v2 系から v3.0.0 への移行ガイド
+
+VRCQuestTools v3.0.0 はメジャーアップデートです。
+アップデートによって、v2 系で作成したシーンやプレハブ、変換の手順の一部に影響が生じます。
+
+Non-Destructive Modular Framework (NDMF) を使った変換はシーン上のアバターを書き換えないため、既存の設定はアップデート後もビルド時に同じように適用されます。
+後述する必要バージョンを満たしていない場合や、削除された機能を使っている場合は、移行にあたり対応が必要になります。
+
+## 動作要件の変更
+
+v3.0.0 の動作に必要なバージョンは以下のとおりです。
+
+- Unity 2022.3 以降
+- VRChat SDK - Avatars 3.9.0 以降
+- lilToon 1.10.0 以降 (使用している場合)
+- NDMF 1.5.0 以降 (使用している場合)
+
+lilToon と NDMF は、古いバージョンのままだとビルドや変換がエラーにより中断するため、アップデート前に VCC または ALCOM でバージョンを確認してください。
+
+## VQT Avatar Builder ウィンドウの削除
+
+**VQT Avatar Builder** ウィンドウを削除しました。
+このウィンドウから行っていた操作は、次のいずれかに置き換わります。
+
+- 通常のアップロードは、VRChat SDK の Control Panel からそのままビルドしてアップロードしてください。
+- ローカルでの動作確認だけを行いたい場合は、アバターを右クリックして「VRCQuestTools」→「[NDMF] Build and Test for PC with Mobile Settings」を選んでください。
+    Mobile 向け設定を適用した状態で PC 向けにビルドし、その場でテストできます。
+
+## 動作が変わった機能
+
+### Avatar Dynamics の保存先
+
+**Avatar Dynamics Selector** で選んだ PhysBone/PhysBone Collider/Contacts の設定は、**Avatar Converter Settings** コンポーネント内ではなく、**Platform Component Remover** コンポーネントに保存されるようになりました。
+
+この移行は自動では行われません。
+v2 系で設定済みのアバターは、Avatar Dynamics Selector の「適用」ボタンを押さない限り、従来どおり Avatar Converter Settings 側の設定で動作し続けます。
+そのため、アップデートしただけで設定が失われることはありません。
+新しい保存先へ移行する場合だけ、「適用」ボタンを押してください。
+
+### 頂点カラー除去のしくみ
+
+変換時の頂点カラー除去は、**Vertex Color Remover** コンポーネントを使う方式から、変換後のアバター専用のメッシュ (`.vqtmesh` アセット) を生成する方式に変わりました。
+v2 系では元のメッシュから直接頂点カラーを削除していたため、輪郭線の制御に頂点カラーを使うアバターでは、変換前のアバターの表示も変わってしまうことがありました。
+v3.0.0 の変換では、この影響はありません。
+Vertex Color Remover コンポーネント自体は引き続き使用でき、アタッチ済みのコンポーネントもそのまま動作します。
+
+### 手動変換後のアバターのアクティブ状態
+
+Avatar Converter Settings から手動変換したとき、変換前のアバターは非アクティブにならなくなりました。
+両方のアバターがアクティブな状態でシーンに残る点に注意してください。
+
+### 手動変換での Platform GameObject Remover と Platform Component Remover の適用
+
+手動変換でも、**Platform GameObject Remover** と Platform Component Remover の設定が Mobile 向けに適用されるようになりました。
+v2 系の手動変換ではこれらの設定は反映されなかったため、Mobile 向けの削除対象を指定しているアバターは変換結果が変わります。
+なお、Avatar Dynamics の設定を Platform Component Remover に移行していないアバターでは、従来どおり Avatar Converter Settings 側の設定に基づく削除が行われます。
+
+## 移行手順チェックリスト
+
+1. プロジェクトの Unity、VRChat SDK、lilToon、NDMF のバージョンが、上記の必要バージョンを満たしているか確認する。
+2. VCC または ALCOM で VRCQuestTools を v3.0.0 に更新する。
+3. 必要であれば、Avatar Dynamics Selector で「適用」を押して Platform Component Remover への移行を済ませる。
+
+v3.0.0 におけるすべての変更点は [変更履歴](./changelog.md) にまとめています。

--- a/Website/i18n/ja/docusaurus-plugin-content-docs/current/migration-to-v3.md
+++ b/Website/i18n/ja/docusaurus-plugin-content-docs/current/migration-to-v3.md
@@ -29,7 +29,7 @@ lilToon と NDMF は、古いバージョンのままだとビルドや変換が
 
 - 通常のアップロードは、VRChat SDK の Control Panel からそのままビルドしてアップロードしてください。
 - ローカルでの動作確認だけを行いたい場合は、アバターを右クリックして「VRCQuestTools」→「[NDMF] Build and Test for PC with Mobile Settings」を選んでください。
-    Mobile 向け設定を適用した状態で PC 向けにビルドし、その場でテストできます。
+  Mobile 向け設定を適用した状態で PC 向けにビルドし、その場でテストできます。
 
 ## 動作が変わった機能
 


### PR DESCRIPTION
Adds a migration guide page (en/ja) covering the v3.0.0 changes that affect scenes, prefabs, and procedures created with v2.x:

- Required versions (Unity 2022.3, VRChat SDK 3.9.0, lilToon 1.10.0, NDMF 1.5.0)
- Removal of the VQT Avatar Builder window and its replacements
- Avatar Dynamics settings now stored in Platform Component Remover, with opt-in migration via the Avatar Dynamics Selector
- Vertex color removal via dedicated .vqtmesh assets, which no longer affects the pre-conversion avatar
- Manual conversion keeping the original avatar active and applying Platform GameObject Remover / Platform Component Remover settings