### PR TITLE
Fix observations and node reuse in NDMF preview filters

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/ForceMaterialPreviewTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/ForceMaterialPreviewTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using KRT.VRCQuestTools.Components;
 using KRT.VRCQuestTools.Models;
+using nadena.dev.ndmf.preview;
 
 namespace KRT.VRCQuestTools.Ndmf
 {
@@ -36,6 +37,37 @@ namespace KRT.VRCQuestTools.Ndmf
 
             // ForceMaterialPreview is a temporary flag and must not be included in the cache key
             Assert.IsFalse(key.Contains($"_{comp.ForceMaterialPreview}"), $"Cache key included force preview flag: {key}");
+        }
+
+        /// <summary>
+        /// forceMaterialPreview is a non-serialized field which the inspector button writes directly, so Unity's
+        /// object change stream reports nothing and an observation of it is never invalidated on its own. The
+        /// inspectors therefore call NdmfUtility.NotifyObjectUpdate; this locks in that the call is what makes
+        /// the preview filters observing the flag rebuild.
+        /// </summary>
+        [Test]
+        public void NotifyObjectUpdate_InvalidatesForceMaterialPreviewObservation()
+        {
+            var gameObject = new UnityEngine.GameObject("ForceMaterialPreviewProbe");
+            try
+            {
+                var settings = gameObject.AddComponent<AvatarConverterSettings>();
+                settings.forceMaterialPreview = false;
+
+                var context = new ComputeContext("test force material preview");
+                context.Observe((UnityEngine.Object)settings, o => ((AvatarConverterSettings)o).ForceMaterialPreview);
+
+                // Flip the flag exactly like the inspector button does.
+                settings.forceMaterialPreview = true;
+                Utils.NdmfUtility.NotifyObjectUpdate(settings);
+                ComputeContext.FlushInvalidates();
+
+                Assert.IsTrue(context.IsInvalidated, "NotifyObjectUpdate must invalidate an observation of ForceMaterialPreview.");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(gameObject);
+            }
         }
     }
 }

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterGroupTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterGroupTests.cs
@@ -1,0 +1,124 @@
+// <copyright file="MaterialConversionFilterGroupTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+#if VQT_NDMF_HAS_PROP_CACHE_DEBUG
+using System.Linq;
+using KRT.VRCQuestTools.Models;
+#endif
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf.preview;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for the render groups built by <see cref="MaterialConversionFilter.GetTargetGroups"/>,
+    /// which attach the primary conversion component as typed group data so that a change of the
+    /// primary component's identity makes the groups compare unequal.
+    /// </summary>
+    public class MaterialConversionFilterGroupTests
+    {
+        private NdmfTestAvatarBuilder builder;
+        private GameObject rendererObject;
+        private Mesh mesh;
+        private Material material;
+
+        /// <summary>
+        /// Cleans up objects created during the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            builder?.Destroy();
+            builder = null;
+
+            if (rendererObject != null)
+            {
+                Object.DestroyImmediate(rendererObject);
+                rendererObject = null;
+            }
+
+            if (mesh != null)
+            {
+                Object.DestroyImmediate(mesh);
+                mesh = null;
+            }
+
+            if (material != null)
+            {
+                Object.DestroyImmediate(material);
+                material = null;
+            }
+        }
+
+        /// <summary>
+        /// Canary for the NDMF equality semantics MaterialConversionFilter relies on: groups over the
+        /// same renderers must compare equal when the attached data is the same component and unequal
+        /// when it is a different component. If NDMF ever changed this, stale nodes would be reused
+        /// with the wrong settings component.
+        /// </summary>
+        [Test]
+        public void RenderGroup_WithData_ChangesEquality_WhenPrimaryComponentDiffers()
+        {
+            rendererObject = new GameObject("Renderer");
+            var renderer = rendererObject.AddComponent<SkinnedMeshRenderer>();
+            var a = rendererObject.AddComponent<MaterialConversionSettings>();
+            var b = rendererObject.AddComponent<MaterialConversionSettings>();
+
+            var groupA1 = RenderGroup.For(renderer).WithData<Component>(a);
+            var groupA2 = RenderGroup.For(renderer).WithData<Component>(a);
+            var groupB = RenderGroup.For(renderer).WithData<Component>(b);
+
+            Assert.AreEqual(groupA1, groupA2, "Groups over the same renderers with the same data component must be equal.");
+            Assert.AreNotEqual(groupA1, groupB, "Groups over the same renderers with different data components must not be equal.");
+        }
+
+#if VQT_NDMF_HAS_PROP_CACHE_DEBUG
+        /// <summary>
+        /// GetTargetGroups must attach the primary conversion component as group data, and switching the
+        /// primary component (adding AvatarConverterSettings next to MaterialConversionSettings) must
+        /// produce an unequal group even though the renderer set is unchanged, so NDMF discards the prior
+        /// node instead of silently reusing it with the stale settings.
+        /// </summary>
+        [Test]
+        public void GetTargetGroups_AttachesPrimaryComponentAsGroupData()
+        {
+            builder = new NdmfTestAvatarBuilder();
+            var conversionSettings = builder.Root.AddComponent<MaterialConversionSettings>();
+            conversionSettings.ndmfPhase = AvatarConverterNdmfPhase.Optimizing;
+
+            mesh = new Mesh();
+            mesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            mesh.triangles = new[] { 0, 1, 2 };
+            material = new Material(Shader.Find("Standard"));
+            var renderer = builder.AddSkinnedMeshRenderer("Body", mesh, material);
+
+            var firstGroup = GetGroupFor(renderer);
+            Assert.AreSame(conversionSettings, firstGroup.GetData<Component>(), "The primary conversion component must be attached as group data.");
+
+            // AvatarConverterSettings on the root takes over as the primary component
+            // (MaterialConversionSettings.IsPrimaryRoot turns false next to it).
+            var converterSettings = builder.Root.AddComponent<AvatarConverterSettings>();
+            converterSettings.ndmfPhase = AvatarConverterNdmfPhase.Optimizing;
+
+            var secondGroup = GetGroupFor(renderer);
+            Assert.AreSame(converterSettings, secondGroup.GetData<Component>(), "The added AvatarConverterSettings must take over as the primary component.");
+            Assert.IsTrue(firstGroup.Renderers.SequenceEqual(secondGroup.Renderers), "The renderer set must be unchanged by the primary component switch.");
+            Assert.AreNotEqual(firstGroup, secondGroup, "Groups must compare unequal when the primary component's identity changed, so NDMF rebuilds the node.");
+        }
+
+        private static RenderGroup GetGroupFor(Renderer renderer)
+        {
+            // Global queries are cached and don't observe objects created inside a synchronous test body.
+            // PropCacheDebug.InvalidateAllCaches() itself requires NDMF 1.10.0+ (see VQT_NDMF_HAS_PROP_CACHE_DEBUG),
+            // so GetTargetGroups() is only exercised here.
+            PropCacheDebug.InvalidateAllCaches();
+            var groups = new MaterialConversionFilter(AvatarConverterNdmfPhase.Optimizing).GetTargetGroups(new ComputeContext("test"));
+            return groups.Single(g => g.Renderers.Contains(renderer));
+        }
+#endif
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterGroupTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MaterialConversionFilterGroupTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fec2f442ba87899429d6752129c7ec7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperFilterTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperFilterTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="MeshFlipperFilterTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf.preview;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="MeshFlipperFilter"/> nodes driven directly through
+    /// <see cref="IRenderFilter.Instantiate"/> with a manually constructed proxy renderer.
+    /// </summary>
+    public class MeshFlipperFilterTests
+    {
+        private NdmfTestAvatarBuilder builder;
+        private GameObject proxyObject;
+        private Mesh originalMesh;
+        private Mesh proxyMesh;
+        private IRenderFilterNode node;
+
+        /// <summary>
+        /// Cleans up objects created during the test. Disposing the node first destroys any
+        /// flipped mesh it owns, so only the source meshes need explicit destruction here.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            node?.Dispose();
+            node = null;
+
+            builder?.Destroy();
+            builder = null;
+
+            if (proxyObject != null)
+            {
+                Object.DestroyImmediate(proxyObject);
+                proxyObject = null;
+            }
+
+            if (originalMesh != null)
+            {
+                Object.DestroyImmediate(originalMesh);
+                originalMesh = null;
+            }
+
+            if (proxyMesh != null)
+            {
+                Object.DestroyImmediate(proxyMesh);
+                proxyMesh = null;
+            }
+        }
+
+        /// <summary>
+        /// Instantiate must return a usable no-op node instead of null when the renderer has no mesh.
+        /// NDMF's NodeController does not null-check Instantiate's result, so a null node would throw
+        /// and take down the whole preview pipeline build.
+        /// </summary>
+        [Test]
+        public void Instantiate_ReturnsNoOpNode_WhenMeshIsNull()
+        {
+            var original = CreateAvatarRenderer(mesh: null, addMeshFlipper: true, enabledOnPC: true);
+            var proxy = CreateProxyRenderer(mesh: null);
+
+            node = Instantiate(original, proxy);
+
+            Assert.IsNotNull(node, "Instantiate must return a no-op node, not null, when the mesh is missing.");
+            node.OnFrame(original, proxy);
+            Assert.IsNull(proxy.sharedMesh, "A no-op node must leave the proxy mesh unchanged.");
+        }
+
+        /// <summary>
+        /// Instantiate must return a usable no-op node instead of null when the MeshFlipper component
+        /// is missing (e.g. removed between GetTargetGroups and Instantiate).
+        /// </summary>
+        [Test]
+        public void Instantiate_ReturnsNoOpNode_WhenComponentMissing()
+        {
+            var original = CreateAvatarRenderer(CreateTriangleMesh(), addMeshFlipper: false, enabledOnPC: false);
+            var proxy = CreateProxyRenderer(CreateProxyMesh());
+
+            node = Instantiate(original, proxy);
+
+            Assert.IsNotNull(node, "Instantiate must return a no-op node, not null, when the component is missing.");
+            node.OnFrame(original, proxy);
+            Assert.AreSame(proxyMesh, proxy.sharedMesh, "A no-op node must leave the proxy mesh unchanged.");
+        }
+
+        /// <summary>
+        /// The flipped mesh only depends on the proxy's mesh, so blendshape, material and texture changes
+        /// upstream must reuse the node while a mesh change or an invalidation of the node's own
+        /// observations (updatedAspects == 0) must force a rebuild.
+        /// </summary>
+        [Test]
+        public void FilterNode_Refresh_ReusesForShapesMaterialTexture_RebuildsForMeshAndZero()
+        {
+            var original = CreateAvatarRenderer(CreateTriangleMesh(), addMeshFlipper: true, enabledOnPC: true);
+            var proxy = CreateProxyRenderer(CreateProxyMesh());
+            node = Instantiate(original, proxy);
+            var proxyPairs = new (Renderer, Renderer)[0];
+
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes), "Blendshape/bone updates cannot change the flipped geometry, so the node must be reusable.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Material), "Material changes cannot change the flipped geometry, so the node must be reusable.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Texture), "Texture changes cannot change the flipped geometry, so the node must be reusable.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes | RenderAspects.Material | RenderAspects.Texture), "RenderAspects is a flag set; a combination of reusable aspects must still be reusable.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Mesh), "A mesh change upstream invalidates the flipped mesh and must force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Mesh | RenderAspects.Shapes), "A reusable aspect combined with a non-reusable one must still force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, 0), "Zero means this node's own context was invalidated, which must force a rebuild.");
+        }
+
+        /// <summary>
+        /// When the flipper does not process (disabled for the resolved PC target), the node passes the
+        /// source mesh through and Dispose must not destroy it: it may be an in-memory mesh owned by an
+        /// upstream preview node.
+        /// </summary>
+        [Test]
+        public void Dispose_DoesNotDestroySourceMesh_WhenNotProcessing()
+        {
+            var original = CreateAvatarRenderer(CreateTriangleMesh(), addMeshFlipper: true, enabledOnPC: false);
+            var proxy = CreateProxyRenderer(CreateProxyMesh());
+            node = Instantiate(original, proxy);
+
+            node.OnFrame(original, proxy);
+            Assert.AreSame(proxyMesh, proxy.sharedMesh, "A pass-through node must reuse the source mesh as-is.");
+
+            node.Dispose();
+
+            Assert.IsTrue(proxyMesh != null, "Dispose must not destroy a source mesh the node does not own.");
+        }
+
+        /// <summary>
+        /// When the flipper processes, the node owns the flipped mesh and Dispose must destroy it while
+        /// leaving the source mesh alive.
+        /// </summary>
+        [Test]
+        public void Dispose_DestroysFlippedMesh_WhenProcessing()
+        {
+            var original = CreateAvatarRenderer(CreateTriangleMesh(), addMeshFlipper: true, enabledOnPC: true);
+            var proxy = CreateProxyRenderer(CreateProxyMesh());
+            node = Instantiate(original, proxy);
+
+            node.OnFrame(original, proxy);
+            var flippedMesh = proxy.sharedMesh;
+            Assert.AreNotSame(proxyMesh, flippedMesh, "A processing node must assign a newly created flipped mesh to the proxy.");
+
+            node.Dispose();
+
+            Assert.IsTrue(flippedMesh == null, "Dispose must destroy the flipped mesh the node owns.");
+            Assert.IsTrue(proxyMesh != null, "Dispose must leave the source mesh alive.");
+        }
+
+        private static IRenderFilterNode Refresh(IRenderFilterNode node, (Renderer Original, Renderer Proxy)[] proxyPairs, RenderAspects updatedAspects)
+        {
+            var task = node.Refresh(proxyPairs, new ComputeContext($"test {updatedAspects}"), updatedAspects);
+            Assert.IsTrue(task.IsCompleted, "MeshFlipperFilterNode.Refresh is synchronous and must complete immediately.");
+            return task.Result;
+        }
+
+        private static Mesh CreateTriangleMesh()
+        {
+            var mesh = new Mesh();
+            mesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            mesh.normals = new[] { Vector3.back, Vector3.back, Vector3.back };
+            mesh.uv = new[] { Vector2.zero, Vector2.right, Vector2.up };
+            mesh.triangles = new[] { 0, 1, 2 };
+            return mesh;
+        }
+
+        private static IRenderFilterNode Instantiate(Renderer original, Renderer proxy)
+        {
+            var group = RenderGroup.For(original);
+            var pairs = new[] { (original, proxy) };
+            var task = new MeshFlipperFilter(MeshFlipperProcessingPhase.AfterPolygonReduction).Instantiate(group, pairs, new ComputeContext("test"));
+            Assert.IsTrue(task.IsCompleted, "MeshFlipperFilter.Instantiate is synchronous and must complete immediately.");
+            return task.Result;
+        }
+
+        private SkinnedMeshRenderer CreateAvatarRenderer(Mesh mesh, bool addMeshFlipper, bool enabledOnPC)
+        {
+            originalMesh = mesh;
+            builder = new NdmfTestAvatarBuilder();
+
+            // Pin the resolved build target so the test does not depend on the editor's active build target.
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = Models.BuildTarget.PC;
+            var smr = builder.AddSkinnedMeshRenderer("Body", mesh);
+            if (addMeshFlipper)
+            {
+                var meshFlipper = smr.gameObject.AddComponent<MeshFlipper>();
+                meshFlipper.processingPhase = MeshFlipperProcessingPhase.AfterPolygonReduction;
+                meshFlipper.enabledOnPC = enabledOnPC;
+            }
+            return smr;
+        }
+
+        private Mesh CreateProxyMesh()
+        {
+            proxyMesh = Object.Instantiate(originalMesh);
+            return proxyMesh;
+        }
+
+        private SkinnedMeshRenderer CreateProxyRenderer(Mesh mesh)
+        {
+            proxyObject = new GameObject("Proxy");
+            var smr = proxyObject.AddComponent<SkinnedMeshRenderer>();
+            smr.sharedMesh = mesh;
+            return smr;
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperFilterTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/MeshFlipperFilterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fa67bea5b081074b8edae54fb059e81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/VertexColorRemoverFilterTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/VertexColorRemoverFilterTests.cs
@@ -1,0 +1,195 @@
+// <copyright file="VertexColorRemoverFilterTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Components;
+using nadena.dev.ndmf.preview;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Ndmf
+{
+    /// <summary>
+    /// Tests for <see cref="VertexColorRemoverFilter"/> nodes driven directly through
+    /// <see cref="IRenderFilter.Instantiate"/> with a manually constructed proxy renderer.
+    /// </summary>
+    public class VertexColorRemoverFilterTests
+    {
+        private NdmfTestAvatarBuilder builder;
+        private GameObject proxyObject;
+        private Mesh originalMesh;
+        private Mesh proxyMesh;
+        private IRenderFilterNode node;
+
+        /// <summary>
+        /// Cleans up objects created during the test. Disposing the node first destroys any
+        /// colorless mesh it owns, so only the source meshes need explicit destruction here.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            node?.Dispose();
+            node = null;
+
+            builder?.Destroy();
+            builder = null;
+
+            if (proxyObject != null)
+            {
+                Object.DestroyImmediate(proxyObject);
+                proxyObject = null;
+            }
+
+            if (originalMesh != null)
+            {
+                Object.DestroyImmediate(originalMesh);
+                originalMesh = null;
+            }
+
+            if (proxyMesh != null)
+            {
+                Object.DestroyImmediate(proxyMesh);
+                proxyMesh = null;
+            }
+        }
+
+        /// <summary>
+        /// Instantiate must return a usable no-op node instead of null when the avatar has no
+        /// AvatarConverterSettings (e.g. removed between GetTargetGroups and Instantiate).
+        /// NDMF's NodeController does not null-check Instantiate's result, so a null node would
+        /// throw and take down the whole preview pipeline build.
+        /// </summary>
+        [Test]
+        public void Instantiate_ReturnsNoOpNode_WhenSettingsMissing()
+        {
+            var original = CreateAvatarRenderer(addConverterSettings: false, removeVertexColor: false, target: Models.BuildTarget.Android);
+            var proxy = CreateProxyRenderer();
+
+            node = Instantiate(original, proxy);
+
+            Assert.IsNotNull(node, "Instantiate must return a no-op node, not null, when the settings component is missing.");
+            node.OnFrame(original, proxy);
+            Assert.AreSame(proxyMesh, proxy.sharedMesh, "A no-op node must leave the proxy mesh unchanged.");
+        }
+
+        /// <summary>
+        /// When vertex colors are not removed (removeVertexColor disabled and PC target), the node passes
+        /// the source mesh through and Dispose must not destroy it: it may be an in-memory mesh owned by an
+        /// upstream preview node.
+        /// </summary>
+        [Test]
+        public void Dispose_DoesNotDestroySourceMesh_WhenNotRemoving()
+        {
+            var original = CreateAvatarRenderer(addConverterSettings: true, removeVertexColor: false, target: Models.BuildTarget.PC);
+            var proxy = CreateProxyRenderer();
+            node = Instantiate(original, proxy);
+
+            node.OnFrame(original, proxy);
+            Assert.AreSame(proxyMesh, proxy.sharedMesh, "A pass-through node must reuse the source mesh as-is.");
+
+            node.Dispose();
+
+            Assert.IsTrue(proxyMesh != null, "Dispose must not destroy a source mesh the node does not own.");
+        }
+
+        /// <summary>
+        /// When vertex colors are removed, the node owns the cloned colorless mesh and Dispose must
+        /// destroy it while leaving the source mesh alive.
+        /// </summary>
+        [Test]
+        public void Dispose_DestroysColorlessMesh_WhenRemoving()
+        {
+            var original = CreateAvatarRenderer(addConverterSettings: true, removeVertexColor: true, target: Models.BuildTarget.Android);
+            var proxy = CreateProxyRenderer();
+            node = Instantiate(original, proxy);
+
+            node.OnFrame(original, proxy);
+            var colorlessMesh = proxy.sharedMesh;
+            Assert.AreNotSame(proxyMesh, colorlessMesh, "A removing node must assign a newly cloned colorless mesh to the proxy.");
+            Assert.IsTrue(colorlessMesh.colors32 == null || colorlessMesh.colors32.Length == 0, "The cloned mesh must have its vertex colors removed.");
+            Assert.IsTrue(proxyMesh.colors32 != null && proxyMesh.colors32.Length > 0, "The source mesh must keep its vertex colors.");
+
+            node.Dispose();
+
+            Assert.IsTrue(colorlessMesh == null, "Dispose must destroy the colorless mesh the node owns.");
+            Assert.IsTrue(proxyMesh != null, "Dispose must leave the source mesh alive.");
+        }
+
+        /// <summary>
+        /// The colorless mesh only depends on the proxy's mesh, so blendshape, material and texture changes
+        /// upstream must reuse the node while a mesh change or an invalidation of the node's own
+        /// observations (updatedAspects == 0) must force a rebuild.
+        /// </summary>
+        [Test]
+        public void FilterNode_Refresh_ReusesForShapesMaterialTexture_RebuildsForMeshAndZero()
+        {
+            var original = CreateAvatarRenderer(addConverterSettings: true, removeVertexColor: true, target: Models.BuildTarget.Android);
+            var proxy = CreateProxyRenderer();
+            node = Instantiate(original, proxy);
+            var proxyPairs = new (Renderer, Renderer)[0];
+
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes), "Blendshape/bone updates cannot affect vertex colors, so the node must be reusable.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Material), "Material changes cannot affect vertex colors, so the node must be reusable.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Texture), "Texture changes cannot affect vertex colors, so the node must be reusable.");
+            Assert.AreSame(node, Refresh(node, proxyPairs, RenderAspects.Shapes | RenderAspects.Material | RenderAspects.Texture), "RenderAspects is a flag set; a combination of reusable aspects must still be reusable.");
+            Assert.IsNull(Refresh(node, proxyPairs, RenderAspects.Mesh), "A mesh change upstream invalidates the colorless mesh and must force a rebuild.");
+            Assert.IsNull(Refresh(node, proxyPairs, 0), "Zero means this node's own context was invalidated, which must force a rebuild.");
+        }
+
+        private static IRenderFilterNode Refresh(IRenderFilterNode node, (Renderer Original, Renderer Proxy)[] proxyPairs, RenderAspects updatedAspects)
+        {
+            var task = node.Refresh(proxyPairs, new ComputeContext($"test {updatedAspects}"), updatedAspects);
+            Assert.IsTrue(task.IsCompleted, "VertexColorRemoverFilterNode.Refresh is synchronous and must complete immediately.");
+            return task.Result;
+        }
+
+        private static Mesh CreateColoredTriangleMesh()
+        {
+            var mesh = new Mesh();
+            mesh.vertices = new[] { Vector3.zero, Vector3.right, Vector3.up };
+            mesh.normals = new[] { Vector3.back, Vector3.back, Vector3.back };
+            mesh.triangles = new[] { 0, 1, 2 };
+            mesh.colors32 = new[]
+            {
+                new Color32(255, 0, 0, 255),
+                new Color32(255, 0, 0, 255),
+                new Color32(255, 0, 0, 255),
+            };
+            return mesh;
+        }
+
+        private static IRenderFilterNode Instantiate(Renderer original, Renderer proxy)
+        {
+            var group = RenderGroup.For(original);
+            var pairs = new[] { (original, proxy) };
+            var task = new VertexColorRemoverFilter().Instantiate(group, pairs, new ComputeContext("test"));
+            Assert.IsTrue(task.IsCompleted, "VertexColorRemoverFilter.Instantiate is synchronous and must complete immediately.");
+            return task.Result;
+        }
+
+        private SkinnedMeshRenderer CreateAvatarRenderer(bool addConverterSettings, bool removeVertexColor, Models.BuildTarget target)
+        {
+            originalMesh = CreateColoredTriangleMesh();
+            builder = new NdmfTestAvatarBuilder();
+
+            // Pin the resolved build target so the test does not depend on the editor's active build target.
+            builder.Root.AddComponent<PlatformTargetSettings>().buildTarget = target;
+            if (addConverterSettings)
+            {
+                var settings = builder.Root.AddComponent<AvatarConverterSettings>();
+                settings.removeVertexColor = removeVertexColor;
+            }
+            return builder.AddSkinnedMeshRenderer("Body", originalMesh);
+        }
+
+        private SkinnedMeshRenderer CreateProxyRenderer()
+        {
+            proxyMesh = Object.Instantiate(originalMesh);
+            proxyObject = new GameObject("Proxy");
+            var smr = proxyObject.AddComponent<SkinnedMeshRenderer>();
+            smr.sharedMesh = proxyMesh;
+            return smr;
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/NDMF/VertexColorRemoverFilterTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/NDMF/VertexColorRemoverFilterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23afe96a79e065743a55b926bb873e0e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
@@ -361,6 +361,11 @@ namespace KRT.VRCQuestTools.Inspector
                         if (GUILayout.Button(new GUIContent("[NDMF] " + forceLabel, i18n.ForceMaterialPreviewTooltip)))
                         {
                             converterSettings.forceMaterialPreview = !converterSettings.forceMaterialPreview;
+
+                            // forceMaterialPreview is not serialized and is written directly here, so Unity's
+                            // object change stream reports nothing. Tell NDMF explicitly, or the preview filters
+                            // observing this flag are never invalidated and the preview does not update.
+                            Utils.NdmfUtility.NotifyObjectUpdate(converterSettings);
                         }
                         GUI.backgroundColor = oldBg;
                     }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
@@ -66,6 +66,11 @@ namespace KRT.VRCQuestTools.Inspector
                 if (GUILayout.Button(new GUIContent("[NDMF] " + forceLabel, i18n.ForceMaterialPreviewTooltip)))
                 {
                     component.forceMaterialPreview = !component.forceMaterialPreview;
+
+                    // forceMaterialPreview is not serialized and is written directly here, so Unity's object
+                    // change stream reports nothing. Tell NDMF explicitly, or the preview filters observing
+                    // this flag are never invalidated and the preview does not update.
+                    Utils.NdmfUtility.NotifyObjectUpdate(component);
                 }
                 GUI.backgroundColor = oldBg;
             }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MaterialConversionFilter.cs
@@ -1,3 +1,8 @@
+// <copyright file="MaterialConversionFilter.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -54,8 +59,13 @@ namespace KRT.VRCQuestTools.Ndmf
         public ImmutableList<RenderGroup> GetTargetGroups(ComputeContext context)
         {
             Logger.LogDebug("Getting target groups");
+
+            // Observed lookup: GetAvatarRoots() is backed by a PropCache whose SequenceEqual comparer stops
+            // propagation when the root list is unchanged, so a plain GetComponents here would never see a
+            // conversion component added to (or removed from) an existing root. context.GetComponents registers
+            // a component-list monitor on each root instead.
             var rootConversions = context.GetAvatarRoots()
-                .Select(root => ComponentUtility.GetPrimaryMaterialConversionComponent(root))
+                .Select(root => context.GetComponents<IMaterialConversionComponent>(root).FirstOrDefault(c => c.IsPrimaryRoot))
                 .Cast<Component>()
                 .Where(component =>
                 {
@@ -84,9 +94,15 @@ namespace KRT.VRCQuestTools.Ndmf
                 context.Observe(rootConversion, c => AvatarConverterPassUtility.ResolveAvatarConverterNdmfPhase(c.gameObject));
             }
 
-            return rootConversions.Select(root => context.GetComponentsInChildren<Renderer>(root.gameObject, true).Where(r => r is SkinnedMeshRenderer || r is MeshRenderer))
-                .Where(r => r.Any())
-                .Select(r => RenderGroup.For(r))
+            // Attach the primary component as group data (explicit type argument: RenderGroup data equality is
+            // typed, and GetData<Component>() in Instantiate throws unless the same T was used). When the primary
+            // component's identity changes while the renderer set stays equal (e.g. an AvatarConverterSettings is
+            // added next to an existing MaterialConversionSettings), the groups compare unequal and NDMF discards
+            // the prior node instead of silently reusing it with the stale settings.
+            return rootConversions
+                .Select(component => (component, renderers: context.GetComponentsInChildren<Renderer>(component.gameObject, true).Where(r => r is SkinnedMeshRenderer || r is MeshRenderer)))
+                .Where(pair => pair.renderers.Any())
+                .Select(pair => RenderGroup.For(pair.renderers).WithData<Component>(pair.component))
                 .ToImmutableList();
         }
 
@@ -96,18 +112,28 @@ namespace KRT.VRCQuestTools.Ndmf
             var avatarRoot = context.GetAvatarRoot(group.Renderers[0].gameObject);
             Logger.LogDebug($"Instantiating material conversion filter for {avatarRoot}", avatarRoot);
 
-            IMaterialConversionComponent settings = avatarRoot.GetComponent<AvatarConverterSettings>();
-            if (settings == null)
+            // The primary conversion component was resolved by GetTargetGroups and attached as group data.
+            // Guard against it being destroyed between GetTargetGroups and Instantiate: NDMF's NodeController
+            // does not null-check Instantiate's result, so return a no-op node instead.
+            var settings = group.GetData<Component>() as IMaterialConversionComponent;
+            if (settings == null || (settings as Component) == null)
             {
-                settings = avatarRoot.GetComponent<MaterialConversionSettings>();
+                return Task.FromResult<IRenderFilterNode>(new MaterialConversionFilterNode(new Dictionary<Material, Material>(), false, null));
             }
+
+            var settingsGameObject = (settings as Component).gameObject;
             context.Observe(settings as Object, s => (s as IMaterialConversionComponent).GetCacheKey());
 
-            // Hoisted out of the `if` below (rather than declared by its `out var`) so it stays in scope, and
-            // definitely assigned, for the MaterialConversionFilterNode built at the end of this method: the node
-            // has to re-observe it in Refresh. TryGetComponent leaves it null when there is no such component.
-            PlatformTargetSettings targetSettings = null;
-            if (settings is Component c && c.TryGetComponent<PlatformTargetSettings>(out targetSettings))
+            // GetCacheKey deliberately excludes ForceMaterialPreview, so observe it separately: it feeds the
+            // conversion decision below. Extractor-based observations are re-evaluated every frame by NDMF's
+            // PropertyMonitor, which is what makes the non-serialized inspector toggle take effect here.
+            context.Observe(settings as Object, s => (s as IMaterialConversionComponent).ForceMaterialPreview);
+
+            // NdmfHelper.ResolveBuildTarget reads PlatformTargetSettings without ComputeContext, so observe it
+            // here. context.GetComponent registers a component-list monitor, so a PlatformTargetSettings added
+            // later is caught as well. Kept in a local so the node can re-observe it in Refresh.
+            var targetSettings = context.GetComponent<PlatformTargetSettings>(settingsGameObject);
+            if (targetSettings != null)
             {
                 context.Observe(targetSettings);
             }
@@ -119,7 +145,7 @@ namespace KRT.VRCQuestTools.Ndmf
             }
 
             var isTargetMobile = NdmfHelper.ResolveBuildTarget(avatarRoot) == Models.BuildTarget.Android;
-            var forcePreview = settings != null && settings.ForceMaterialPreview;
+            var forcePreview = settings.ForceMaterialPreview;
             if (!isTargetMobile && !forcePreview)
             {
                 // If the target is not mobile and preview is not forced, we do not process this filter.
@@ -130,8 +156,10 @@ namespace KRT.VRCQuestTools.Ndmf
             HashSet<Material> avatarMaterials = new();
             foreach (var (original, proxy) in proxyPairs)
             {
-                context.Observe(original);
-                context.Observe(proxy);
+                // The renderers themselves are intentionally not observed: NDMF's ProxyObjectController already
+                // monitors each original renderer, its materials and its mesh, and any change it reports arrives
+                // as non-zero updatedAspects in Refresh (a sharedMaterials array change arrives as Material,
+                // which is never reusable, so the node rebuilds and re-reads the arrays).
                 var slots = removeExtraMaterialSlots
                     ? RendererUtility.GetSharedMeshSubMeshCount(original)
                     : original.sharedMaterials.Length;
@@ -199,7 +227,7 @@ namespace KRT.VRCQuestTools.Ndmf
                     removeExtraMaterialSlots,
                     materialLease,
                     settings as Object,
-                    targetSettings,
+                    settingsGameObject,
                     avatarMaterials.ToArray()));
             }
             catch (System.Exception e)
@@ -217,7 +245,7 @@ namespace KRT.VRCQuestTools.Ndmf
             private readonly bool removeExtraMaterialSlots;
             private readonly SharedMaterialMapLease materialLease;
             private readonly Object settingsComponent;
-            private readonly PlatformTargetSettings platformTargetSettings;
+            private readonly GameObject settingsGameObject;
             private readonly Material[] observedMaterials;
             private bool disposedValue;
 
@@ -226,14 +254,14 @@ namespace KRT.VRCQuestTools.Ndmf
                 bool removeExtraMaterialSlots,
                 SharedMaterialMapLease materialLease,
                 Object settingsComponent = null,
-                PlatformTargetSettings platformTargetSettings = null,
+                GameObject settingsGameObject = null,
                 Material[] observedMaterials = null)
             {
                 this.materialMap = materialMap;
                 this.removeExtraMaterialSlots = removeExtraMaterialSlots;
                 this.materialLease = materialLease;
                 this.settingsComponent = settingsComponent;
-                this.platformTargetSettings = platformTargetSettings;
+                this.settingsGameObject = settingsGameObject;
                 this.observedMaterials = observedMaterials;
             }
 
@@ -272,7 +300,10 @@ namespace KRT.VRCQuestTools.Ndmf
             /// needs. The observations, however, are not carried over: the NodeController built around a reused
             /// node takes the *new* ComputeContext passed in here, so everything <see cref="Instantiate"/>
             /// observed has to be observed again on it. Miss one and this node is never invalidated again --
-            /// editing the avatar's convert settings would silently stop updating the preview.
+            /// editing the avatar's convert settings would silently stop updating the preview. The renderers are
+            /// intentionally not observed (neither here nor in <see cref="Instantiate"/>): NDMF's
+            /// ProxyObjectController already monitors each original renderer, its materials and its mesh, and any
+            /// change it reports arrives as non-zero <paramref name="updatedAspects"/>.
             /// </remarks>
             public Task<IRenderFilterNode> Refresh(IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context, RenderAspects updatedAspects)
             {
@@ -290,15 +321,15 @@ namespace KRT.VRCQuestTools.Ndmf
                 if (settingsComponent != null)
                 {
                     context.Observe(settingsComponent, s => (s as IMaterialConversionComponent).GetCacheKey());
+                    context.Observe(settingsComponent, s => (s as IMaterialConversionComponent).ForceMaterialPreview);
                 }
-                if (platformTargetSettings != null)
+                if (settingsGameObject != null)
                 {
-                    context.Observe(platformTargetSettings);
-                }
-                foreach (var (original, proxy) in proxyPairs)
-                {
-                    context.Observe(original);
-                    context.Observe(proxy);
+                    var platformSettings = context.GetComponent<PlatformTargetSettings>(settingsGameObject);
+                    if (platformSettings != null)
+                    {
+                        context.Observe(platformSettings);
+                    }
                 }
                 if (observedMaterials != null)
                 {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MeshFlipperFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/MeshFlipperFilter.cs
@@ -1,3 +1,8 @@
+// <copyright file="MeshFlipperFilter.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -68,20 +73,35 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public Task<IRenderFilterNode> Instantiate(RenderGroup group, IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context)
         {
-            var meshFlipper = group.Renderers[0].GetComponent<MeshFlipper>();
+            // Observed lookup: registers a component-list monitor so removing the component invalidates this node,
+            // and returns null instead of racing with component removal.
+            var meshFlipper = context.GetComponent<MeshFlipper>(group.Renderers[0].gameObject);
             var targetRenderer = proxyPairs.First().Item2;
 
-            var mesh = RendererUtility.GetSharedMesh(targetRenderer);
-            if (mesh == null)
+            var mesh = targetRenderer != null ? RendererUtility.GetSharedMesh(targetRenderer) : null;
+            if (meshFlipper == null || mesh == null)
             {
-                return Task.FromResult<IRenderFilterNode>(null);
+                // NDMF's NodeController does not null-check Instantiate's result; a null node would throw and
+                // take down the whole preview pipeline build. Return a no-op node instead.
+                return Task.FromResult<IRenderFilterNode>(new MeshFlipperFilterNode(null, false, null, null, null));
             }
 
             context.Observe(meshFlipper);
             context.Observe(mesh);
 
+            var avatarRoot = context.GetAvatarRoot(meshFlipper.gameObject);
+
+            // NdmfHelper.ResolveBuildTarget reads PlatformTargetSettings without ComputeContext, so observe it
+            // here to rebuild the preview when the target platform changes. context.GetComponent registers a
+            // component-list monitor, so a PlatformTargetSettings added later is caught as well.
+            var platformSettings = avatarRoot != null ? context.GetComponent<PlatformTargetSettings>(avatarRoot) : null;
+            if (platformSettings != null)
+            {
+                context.Observe(platformSettings);
+            }
+
             var shouldProcess = meshFlipper.processingPhase == phase;
-            var isMobileTarget = NdmfHelper.ResolveBuildTarget(context.GetAvatarRoot(meshFlipper.gameObject)) == Models.BuildTarget.Android;
+            var isMobileTarget = NdmfHelper.ResolveBuildTarget(avatarRoot) == Models.BuildTarget.Android;
             if (isMobileTarget)
             {
                 shouldProcess &= meshFlipper.enabledOnAndroid;
@@ -92,11 +112,13 @@ namespace KRT.VRCQuestTools.Ndmf
             }
 
             Mesh result = mesh;
+            var ownsMesh = false;
             if (shouldProcess)
             {
                 try
                 {
                     result = MeshFlipper.CreateFlippedMesh(meshFlipper, mesh);
+                    ownsMesh = true;
 
                     // Register the replaced mesh so the ObjectRegistry can trace it back to the original,
                     // matching build-pass behavior. Runs inside Instantiate where an ObjectRegistryScope is active.
@@ -107,23 +129,74 @@ namespace KRT.VRCQuestTools.Ndmf
                     // do not report missing mask.
                 }
             }
-            return Task.FromResult<IRenderFilterNode>(new MeshFlipperFilterNode(result));
+            return Task.FromResult<IRenderFilterNode>(new MeshFlipperFilterNode(result, ownsMesh, meshFlipper, mesh, avatarRoot));
         }
 
         private class MeshFlipperFilterNode : IRenderFilterNode
         {
+            /// <summary>
+            /// Upstream changes this node's flipped mesh survives. The mesh was flipped from the proxy's mesh,
+            /// so only an upstream Mesh change (or an invalidation of this node's own observations, which
+            /// arrives as updatedAspects == 0) requires re-flipping; blendshape, bone, material and texture
+            /// changes cannot affect the flipped geometry.
+            /// </summary>
+            private const RenderAspects ReusableAspects = RenderAspects.Shapes | RenderAspects.Material | RenderAspects.Texture;
+
+            private readonly bool ownsMesh;
+            private readonly MeshFlipper meshFlipper;
+            private readonly Mesh sourceMesh;
+            private readonly GameObject avatarRoot;
             private Mesh flippedMesh;
             private bool disposedValue;
 
-            public MeshFlipperFilterNode(Mesh flippedMesh)
+            public MeshFlipperFilterNode(Mesh flippedMesh, bool ownsMesh, MeshFlipper meshFlipper, Mesh sourceMesh, GameObject avatarRoot)
             {
                 this.flippedMesh = flippedMesh;
+                this.ownsMesh = ownsMesh;
+                this.meshFlipper = meshFlipper;
+                this.sourceMesh = sourceMesh;
+                this.avatarRoot = avatarRoot;
             }
 
             public RenderAspects WhatChanged => RenderAspects.Mesh;
 
+            public Task<IRenderFilterNode> Refresh(IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context, RenderAspects updatedAspects)
+            {
+                // No-op nodes (flippedMesh == null) and destroyed components always rebuild; rebuilding them is
+                // cheap and re-evaluates the condition that made them no-ops in the first place.
+                if (disposedValue || flippedMesh == null || meshFlipper == null
+                    || updatedAspects == 0 || (updatedAspects & ~ReusableAspects) != 0)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                // Re-register every observation Instantiate made, onto the new context. The NodeController built
+                // around a reused node takes the new ComputeContext passed in here; missing one observation would
+                // mean this node is never invalidated again.
+                context.Observe(meshFlipper);
+                if (sourceMesh != null)
+                {
+                    context.Observe(sourceMesh);
+                }
+                if (avatarRoot != null)
+                {
+                    var platformSettings = context.GetComponent<PlatformTargetSettings>(avatarRoot);
+                    if (platformSettings != null)
+                    {
+                        context.Observe(platformSettings);
+                    }
+                }
+
+                return Task.FromResult<IRenderFilterNode>(this);
+            }
+
             public void OnFrame(Renderer original, Renderer proxy)
             {
+                if (flippedMesh == null)
+                {
+                    return;
+                }
+
                 switch (proxy)
                 {
                     case SkinnedMeshRenderer smr:
@@ -154,7 +227,9 @@ namespace KRT.VRCQuestTools.Ndmf
                 {
                     if (flippedMesh != null)
                     {
-                        if (string.IsNullOrEmpty(AssetDatabase.GetAssetPath(flippedMesh)))
+                        // Only destroy meshes this node created. When shouldProcess was false, flippedMesh is the
+                        // source mesh itself, which may be an in-memory mesh owned by an upstream preview node.
+                        if (ownsMesh && string.IsNullOrEmpty(AssetDatabase.GetAssetPath(flippedMesh)))
                         {
                             UnityEngine.Object.DestroyImmediate(flippedMesh);
                         }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/VertexColorRemoverFilter.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/NDMF/Preview/VertexColorRemoverFilter.cs
@@ -1,3 +1,8 @@
+// <copyright file="VertexColorRemoverFilter.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -11,7 +16,7 @@ using UnityEngine;
 namespace KRT.VRCQuestTools.Ndmf
 {
     /// <summary>
-    /// NDMF Preview filter for <see cref="IVertexColorRemoverComponent"/> such as <see cref="AvatarConverterSettings"/> and <see cref="VertexColorRemoverSettings"/>.
+    /// NDMF Preview filter which previews vertex color removal of <see cref="RemoveVertexColorPass"/> for avatars with <see cref="AvatarConverterSettings"/>.
     /// </summary>
     internal class VertexColorRemoverFilter : IRenderFilter
     {
@@ -32,8 +37,12 @@ namespace KRT.VRCQuestTools.Ndmf
         /// <inheritdoc/>
         public ImmutableList<RenderGroup> GetTargetGroups(ComputeContext context)
         {
+            // Observed lookup: GetAvatarRoots() is backed by a PropCache whose SequenceEqual comparer stops
+            // propagation when the root list is unchanged, so a plain GetComponent here would never see an
+            // AvatarConverterSettings added to an existing root. context.GetComponent registers a
+            // component-list monitor on each root instead.
             var rootConversions = context.GetAvatarRoots()
-                .Select(root => root.GetComponent<AvatarConverterSettings>())
+                .Select(root => context.GetComponent<AvatarConverterSettings>(root))
                 .Where(component => component != null)
                 .ToArray();
 
@@ -49,8 +58,19 @@ namespace KRT.VRCQuestTools.Ndmf
         public Task<IRenderFilterNode> Instantiate(RenderGroup group, IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context)
         {
             var root = context.GetAvatarRoot(group.Renderers[0].gameObject);
-            var settings = root.GetComponent<AvatarConverterSettings>();
-            if (settings.TryGetComponent<PlatformTargetSettings>(out var platformSettings))
+
+            // Observed lookup so removing the component invalidates this node. NDMF's NodeController does not
+            // null-check Instantiate's result, so return a no-op node instead of racing with component removal.
+            var settings = root != null ? context.GetComponent<AvatarConverterSettings>(root) : null;
+            if (settings == null)
+            {
+                return Task.FromResult<IRenderFilterNode>(new VertexColorRemoverFilterNode(null, false, null, null));
+            }
+
+            // NdmfHelper.ResolveBuildTarget reads PlatformTargetSettings without ComputeContext, so observe it
+            // here. context.GetComponent also catches a PlatformTargetSettings added later.
+            var platformSettings = context.GetComponent<PlatformTargetSettings>(root);
+            if (platformSettings != null)
             {
                 context.Observe(platformSettings);
             }
@@ -60,36 +80,84 @@ namespace KRT.VRCQuestTools.Ndmf
             var isTargetMobile = NdmfHelper.ResolveBuildTarget(root) == Models.BuildTarget.Android;
 
             var proxy = proxyPairs.First().Item2;
-            var mesh = RendererUtility.GetSharedMesh(proxy);
+            var mesh = proxy != null ? RendererUtility.GetSharedMesh(proxy) : null;
             Mesh newMesh = mesh;
 
+            var ownsMesh = false;
             var shouldRemove = (removeVertexColor || forcePreview) && (isTargetMobile || forcePreview) && mesh != null && mesh.colors32 != null && mesh.colors32.Length > 0;
             if (shouldRemove)
             {
                 newMesh = Mesh.Instantiate(newMesh);
                 newMesh.colors32 = null;
+                ownsMesh = true;
 
                 // Register the replaced mesh so the ObjectRegistry can trace it back to the original,
                 // matching build-pass behavior. Runs inside Instantiate where an ObjectRegistryScope is active.
                 NdmfObjectRegistry.TryRegisterReplacedObjectToActiveRegistry(mesh, newMesh);
             }
-            return Task.FromResult<IRenderFilterNode>(new VertexColorRemoverFilterNode(newMesh));
+            return Task.FromResult<IRenderFilterNode>(new VertexColorRemoverFilterNode(newMesh, ownsMesh, settings, root));
         }
 
         private class VertexColorRemoverFilterNode : IRenderFilterNode
         {
+            /// <summary>
+            /// Upstream changes this node's colorless mesh survives. The mesh was cloned from the proxy's mesh,
+            /// so only an upstream Mesh change (or an invalidation of this node's own observations, which
+            /// arrives as updatedAspects == 0) requires re-cloning; blendshape, bone, material and texture
+            /// changes cannot affect the vertex colors.
+            /// </summary>
+            private const RenderAspects ReusableAspects = RenderAspects.Shapes | RenderAspects.Material | RenderAspects.Texture;
+
+            private readonly bool ownsMesh;
+            private readonly AvatarConverterSettings settings;
+            private readonly GameObject avatarRoot;
             private Mesh colorlessMesh;
             private bool disposedValue;
 
-            public VertexColorRemoverFilterNode(Mesh mesh)
+            public VertexColorRemoverFilterNode(Mesh mesh, bool ownsMesh, AvatarConverterSettings settings, GameObject avatarRoot)
             {
                 this.colorlessMesh = mesh;
+                this.ownsMesh = ownsMesh;
+                this.settings = settings;
+                this.avatarRoot = avatarRoot;
             }
 
             public RenderAspects WhatChanged => RenderAspects.Mesh;
 
+            public Task<IRenderFilterNode> Refresh(IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context, RenderAspects updatedAspects)
+            {
+                // No-op nodes (colorlessMesh == null) and destroyed components always rebuild; rebuilding them
+                // is cheap and re-evaluates the condition that made them no-ops in the first place.
+                if (disposedValue || colorlessMesh == null || settings == null
+                    || updatedAspects == 0 || (updatedAspects & ~ReusableAspects) != 0)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                // Re-register every observation Instantiate made, onto the new context. The NodeController built
+                // around a reused node takes the new ComputeContext passed in here; missing one observation would
+                // mean this node is never invalidated again.
+                context.Observe(settings, s => s.removeVertexColor);
+                context.Observe(settings, s => s.ForceMaterialPreview);
+                if (avatarRoot != null)
+                {
+                    var platformSettings = context.GetComponent<PlatformTargetSettings>(avatarRoot);
+                    if (platformSettings != null)
+                    {
+                        context.Observe(platformSettings);
+                    }
+                }
+
+                return Task.FromResult<IRenderFilterNode>(this);
+            }
+
             public void OnFrame(Renderer original, Renderer proxy)
             {
+                if (colorlessMesh == null)
+                {
+                    return;
+                }
+
                 if (RendererUtility.GetSharedMesh(proxy) != null)
                 {
                     RendererUtility.SetSharedMesh(proxy, colorlessMesh);
@@ -112,7 +180,9 @@ namespace KRT.VRCQuestTools.Ndmf
                     }
                     if (colorlessMesh != null)
                     {
-                        if (string.IsNullOrEmpty(AssetDatabase.GetAssetPath(colorlessMesh)))
+                        // Only destroy meshes this node created. When shouldRemove was false, colorlessMesh is
+                        // the source mesh itself, which may be an in-memory mesh owned by an upstream preview node.
+                        if (ownsMesh && string.IsNullOrEmpty(AssetDatabase.GetAssetPath(colorlessMesh)))
                         {
                             Object.DestroyImmediate(colorlessMesh);
                         }


### PR DESCRIPTION
MaterialConversionFilter:
- Drop the redundant Observe(original)/Observe(proxy) calls. NDMF's ProxyObjectController already monitors every original renderer, its materials and its mesh, and reports those changes as non-zero updatedAspects; a sharedMaterials change arrives as Material, which is never reusable, so the node rebuilds and re-reads the arrays anyway.
- Observe ForceMaterialPreview, which GetCacheKey deliberately excludes, so that toggling it rebuilds the node. Because the flag is [NonSerialized] and both inspectors write it with a plain assignment, Unity's object change stream reports nothing, so the inspectors also have to call NdmfUtility.NotifyObjectUpdate; the observation and the notification only work together.
- Resolve the primary conversion component through context.GetComponents and attach it as typed group data. GetAvatarRoots() is backed by a PropCache whose SequenceEqual comparer stops propagation when the root list is unchanged, so a plain GetComponents never saw a component added to an existing root; and a switch of the primary component's identity used to leave the groups equal, silently reusing a node with the stale settings.

MeshFlipperFilter, VertexColorRemoverFilter:
- Return a no-op node instead of null when the component or mesh is missing. NDMF's NodeController does not null-check Instantiate's result, so a null node took down the whole preview pipeline build.
- Implement Refresh so blendshape, material and texture changes reuse the node instead of re-running the flip/clone on every pipeline generation.
- Only destroy meshes the node created. When the filter passes the mesh through, it may be an in-memory mesh owned by an upstream preview node.
- Observe PlatformTargetSettings, which NdmfHelper.ResolveBuildTarget reads without a ComputeContext.