### PR TITLE
Benchmark DXT compression and document why it stays synchronous

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs
@@ -27,10 +27,11 @@ namespace KRT.VRCQuestTools.Utils
     /// ~2.2 ms, 2048px ~9-16 ms, 4096px ~24-36 ms. Unlike ASTC's "-thorough"-equivalent Unity encoding (which
     /// astcenc's multi-core, out-of-process path was built to speed up and to keep off the main thread for NDMF
     /// preview), Unity's built-in DXT encoder is already sub-frame even at 4096px -- there is no multi-second
-    /// stall to hide and no editor freeze to fix. Conclusion: an external CLI DXT/BC encoder run out-of-process
-    /// (mirroring <see cref="AstcencCli"/>) is not worth building; the complexity of bundling/downloading a new
-    /// binary and its own temp-file pipeline would not measurably improve either compression speed or preview
-    /// responsiveness. <see cref="UnityTextureCompressor.CompressTexture"/> remains synchronous for DXT/BC.
+    /// stall to hide and no editor freeze to fix. <see cref="DxtCliBenchmarkTests"/> then confirmed the other
+    /// side of the comparison: actual DXT/BC encoder CLIs (texconv, Compressonator) are 25-100x *slower* than
+    /// Unity here, and their per-invocation process overhead alone exceeds Unity's entire compression time.
+    /// Conclusion: an external CLI DXT/BC encoder run out-of-process (mirroring <see cref="AstcencCli"/>) is not
+    /// worth building; <see cref="UnityTextureCompressor.CompressTexture"/> remains synchronous for DXT/BC.
     /// </remarks>
     [Explicit("Benchmark")]
     public class DxtBenchmarkTests
@@ -62,6 +63,10 @@ namespace KRT.VRCQuestTools.Utils
             var sw = Stopwatch.StartNew();
             EditorUtility.CompressTexture(candidate, format, TextureCompressionQuality.Best);
             sw.Stop();
+
+            // Guards the measurement itself: if the requested format were silently not applied, the timing
+            // below would be of something other than the compression this benchmark claims to measure.
+            Assert.AreEqual(format, candidate.format, $"Texture was not compressed to {format} at size={size}.");
 
             rows.Add(new Row(size, format.ToString(), sw.Elapsed.TotalMilliseconds));
             Debug.Log($"{size},{format},{sw.Elapsed.TotalMilliseconds:F1}");

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="DxtBenchmarkTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace KRT.VRCQuestTools.Utils
+{
+    /// <summary>
+    /// Manual benchmark measuring how long Unity's built-in DXT5 compression
+    /// (<see cref="EditorUtility.CompressTexture"/> with <see cref="TextureCompressionQuality.Best"/>, the same
+    /// call <see cref="UnityTextureCompressor.CompressTexture"/> makes for the PC/Standalone fallback format)
+    /// takes on the main thread. Used to decide whether the same out-of-process/async pattern used for ASTC
+    /// (see <see cref="AstcencTextureCompressor"/>, justified by <see cref="AstcencBenchmarkTests"/>) is worth
+    /// building for DXT too. This is not part of the normal (CI) test run: it is marked
+    /// <see cref="ExplicitAttribute"/> and must be invoked directly from the Test Runner.
+    /// </summary>
+    /// <remarks>
+    /// Measured result (Windows, procedurally generated non-flat textures, DXT5/DXT1): 512px ~1.6 ms, 1024px
+    /// ~2.2 ms, 2048px ~9-16 ms, 4096px ~24-36 ms. Unlike ASTC's "-thorough"-equivalent Unity encoding (which
+    /// astcenc's multi-core, out-of-process path was built to speed up and to keep off the main thread for NDMF
+    /// preview), Unity's built-in DXT encoder is already sub-frame even at 4096px -- there is no multi-second
+    /// stall to hide and no editor freeze to fix. Conclusion: an external CLI DXT/BC encoder run out-of-process
+    /// (mirroring <see cref="AstcencCli"/>) is not worth building; the complexity of bundling/downloading a new
+    /// binary and its own temp-file pipeline would not measurably improve either compression speed or preview
+    /// responsiveness. <see cref="UnityTextureCompressor.CompressTexture"/> remains synchronous for DXT/BC.
+    /// </remarks>
+    [Explicit("Benchmark")]
+    public class DxtBenchmarkTests
+    {
+        private static readonly int[] Sizes = { 512, 1024, 2048, 4096 };
+
+        /// <summary>
+        /// Measures <see cref="EditorUtility.CompressTexture"/> wall-clock time for DXT5 across texture sizes.
+        /// Each measurement is logged as a CSV-style row (size,format,timeMs), followed by a summary table.
+        /// </summary>
+        [Test]
+        public void SpeedMatrix()
+        {
+            var rows = new List<Row>();
+            Debug.Log("size,format,timeMs");
+
+            foreach (var size in Sizes)
+            {
+                MeasureUnity(size, TextureFormat.DXT5, rows);
+                MeasureUnity(size, TextureFormat.DXT1, rows);
+            }
+
+            LogSummary(rows);
+        }
+
+        private static void MeasureUnity(int size, TextureFormat format, List<Row> rows)
+        {
+            var candidate = CreateNaturalisticTexture(size);
+            var sw = Stopwatch.StartNew();
+            EditorUtility.CompressTexture(candidate, format, TextureCompressionQuality.Best);
+            sw.Stop();
+
+            rows.Add(new Row(size, format.ToString(), sw.Elapsed.TotalMilliseconds));
+            Debug.Log($"{size},{format},{sw.Elapsed.TotalMilliseconds:F1}");
+
+            UnityEngine.Object.DestroyImmediate(candidate);
+        }
+
+        private static void LogSummary(List<Row> rows)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("=== Summary (time ms) ===");
+            foreach (var row in rows)
+            {
+                sb.AppendLine($"  size={row.Size,5} format={row.Format,-6} time={row.TimeMs,9:F1}ms");
+            }
+            Debug.Log(sb.ToString());
+        }
+
+        /// <summary>
+        /// Generates a fully opaque procedural texture mixing several sine/cosine frequencies per channel
+        /// (same generator as <see cref="AstcencBenchmarkTests.CreateNaturalisticTexture(int, bool)"/>) so it
+        /// has both smooth gradients and higher-frequency detail instead of a flat placeholder image, which
+        /// would let the encoder take shortcuts unrepresentative of real content.
+        /// </summary>
+        private static Texture2D CreateNaturalisticTexture(int size)
+        {
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, false, false);
+            var pixels = new Color32[size * size];
+            for (var y = 0; y < size; y++)
+            {
+                for (var x = 0; x < size; x++)
+                {
+                    var fx = x / (float)size;
+                    var fy = y / (float)size;
+                    var r = 127f + (80f * Mathf.Sin(x * 0.13f)) + (48f * Mathf.Sin((y * 0.07f) + (x * 0.02f)));
+                    var g = 127f + (80f * Mathf.Cos(y * 0.11f)) + (48f * Mathf.Sin((x + y) * 0.05f));
+                    var b = 127f + (100f * fx * fy) + (40f * Mathf.Sin((x * 0.29f) + (y * 0.19f)));
+                    pixels[(y * size) + x] = new Color32(
+                        (byte)Mathf.Clamp(r, 0f, 255f),
+                        (byte)Mathf.Clamp(g, 0f, 255f),
+                        (byte)Mathf.Clamp(b, 0f, 255f),
+                        255);
+                }
+            }
+            tex.SetPixels32(pixels);
+            tex.Apply(false, false);
+            return tex;
+        }
+
+        private readonly struct Row
+        {
+            internal Row(int size, string format, double timeMs)
+            {
+                Size = size;
+                Format = format;
+                TimeMs = timeMs;
+            }
+
+            internal int Size { get; }
+
+            internal string Format { get; }
+
+            internal double TimeMs { get; }
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs
@@ -23,15 +23,17 @@ namespace KRT.VRCQuestTools.Utils
     /// <see cref="ExplicitAttribute"/> and must be invoked directly from the Test Runner.
     /// </summary>
     /// <remarks>
-    /// Measured result (Windows, procedurally generated non-flat textures, DXT5/DXT1): 512px ~1.6 ms, 1024px
-    /// ~2.2 ms, 2048px ~9-16 ms, 4096px ~24-36 ms. Unlike ASTC's "-thorough"-equivalent Unity encoding (which
-    /// astcenc's multi-core, out-of-process path was built to speed up and to keep off the main thread for NDMF
-    /// preview), Unity's built-in DXT encoder is already sub-frame even at 4096px -- there is no multi-second
-    /// stall to hide and no editor freeze to fix. <see cref="DxtCliBenchmarkTests"/> then confirmed the other
-    /// side of the comparison: actual DXT/BC encoder CLIs (texconv, Compressonator) are 25-100x *slower* than
-    /// Unity here, and their per-invocation process overhead alone exceeds Unity's entire compression time.
-    /// Conclusion: an external CLI DXT/BC encoder run out-of-process (mirroring <see cref="AstcencCli"/>) is not
-    /// worth building; <see cref="UnityTextureCompressor.CompressTexture"/> remains synchronous for DXT/BC.
+    /// Measured result (Windows, procedurally generated non-flat textures, DXT5/DXT1, median of 5 after warmup
+    /// with the compressed bytes read back inside the timed region): 512px 0.8-1.3 ms, 1024px 2.6-11 ms, 2048px
+    /// 11.5-14.1 ms, 4096px 33.8-43.2 ms. Unlike ASTC's "-thorough"-equivalent Unity encoding (which astcenc's
+    /// multi-core, out-of-process path was built to speed up and to keep off the main thread for NDMF preview),
+    /// Unity's built-in DXT encoder is already sub-frame even at 4096px -- there is no multi-second stall to
+    /// hide and no editor freeze to fix. <see cref="DxtCliBenchmarkTests"/> then confirmed the other side of the
+    /// comparison: actual DXT/BC encoder CLIs (texconv, Compressonator) are 10-75x *slower* than Unity here even
+    /// though both already run multi-threaded, and their per-invocation process overhead alone exceeds Unity's
+    /// entire compression time. Conclusion: an external CLI DXT/BC encoder run out-of-process (mirroring
+    /// <see cref="AstcencCli"/>) is not worth building;
+    /// <see cref="UnityTextureCompressor.CompressTexture"/> remains synchronous for DXT/BC.
     /// </remarks>
     [Explicit("Benchmark")]
     public class DxtBenchmarkTests
@@ -59,25 +61,49 @@ namespace KRT.VRCQuestTools.Utils
 
         private static void MeasureUnity(int size, TextureFormat format, List<Row> rows)
         {
-            var candidate = CreateNaturalisticTexture(size);
-            var sw = Stopwatch.StartNew();
-            EditorUtility.CompressTexture(candidate, format, TextureCompressionQuality.Best);
-            sw.Stop();
+            // One warmup plus a median over several runs: a single cold measurement is dominated by one-time
+            // initialization, which showed up as 512px appearing *slower* than 1024px when this was measured
+            // once per size.
+            const int warmups = 1;
+            const int iterations = 5;
+            var samples = new List<double>(iterations);
 
-            // Guards the measurement itself: if the requested format were silently not applied, the timing
-            // below would be of something other than the compression this benchmark claims to measure.
-            Assert.AreEqual(format, candidate.format, $"Texture was not compressed to {format} at size={size}.");
+            for (var i = 0; i < warmups + iterations; i++)
+            {
+                var candidate = CreateNaturalisticTexture(size);
+                var sw = Stopwatch.StartNew();
+                EditorUtility.CompressTexture(candidate, format, TextureCompressionQuality.Best);
 
-            rows.Add(new Row(size, format.ToString(), sw.Elapsed.TotalMilliseconds));
-            Debug.Log($"{size},{format},{sw.Elapsed.TotalMilliseconds:F1}");
+                // Inside the timed region on purpose: reading the compressed bytes back forces them to actually
+                // be materialized, so a deferred or lazily-evaluated compression cannot make this look faster
+                // than it is. Costs a memcpy of the (already small) compressed data on top of the encode.
+                var bytes = candidate.GetRawTextureData();
+                sw.Stop();
 
-            UnityEngine.Object.DestroyImmediate(candidate);
+                // Guards the measurement itself: if the requested format were silently not applied, or no data
+                // produced, the timing would be of something other than the compression this benchmark claims.
+                Assert.AreEqual(format, candidate.format, $"Texture was not compressed to {format} at size={size}.");
+                Assert.Greater(bytes.Length, 0, $"Compressed texture has no data at size={size}.");
+
+                if (i >= warmups)
+                {
+                    samples.Add(sw.Elapsed.TotalMilliseconds);
+                }
+
+                UnityEngine.Object.DestroyImmediate(candidate);
+            }
+
+            samples.Sort();
+            var median = samples[samples.Count / 2];
+
+            rows.Add(new Row(size, format.ToString(), median));
+            Debug.Log($"{size},{format},{median:F1}");
         }
 
         private static void LogSummary(List<Row> rows)
         {
             var sb = new StringBuilder();
-            sb.AppendLine("=== Summary (time ms) ===");
+            sb.AppendLine("=== Summary (median ms over 5 runs, after warmup, incl. forced readback) ===");
             foreach (var row in rows)
             {
                 sb.AppendLine($"  size={row.Size,5} format={row.Format,-6} time={row.TimeMs,9:F1}ms");

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtBenchmarkTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6afe426e4a208e4aadd467b8f2a3c85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs
@@ -40,23 +40,32 @@ namespace KRT.VRCQuestTools.Utils
     /// a full mip chain means 11 invocations, so the floor is paid 11 times over.
     /// </para>
     /// <para>
-    /// Measured result (Windows, DXT5/BC3). Unity compresses the whole texture in 2.2-31 ms; both CLIs need that
-    /// much or more just to start up, and are 25-100x slower overall for mip 0 alone:
+    /// Measured result (Windows, 12 cores, DXT5/BC3), CLI process wall time vs Unity's median-of-5 whole-texture
+    /// time from <see cref="DxtBenchmarkTests"/>:
     /// </para>
     /// <list type="table">
-    /// <item><description>512px: unity 3.4 ms / texconv 83 ms / compressonator 435 ms</description></item>
-    /// <item><description>1024px: unity 2.2 ms / texconv 115 ms / compressonator 570 ms</description></item>
-    /// <item><description>2048px: unity 8.3 ms / texconv 363 ms / compressonator 1148 ms</description></item>
-    /// <item><description>4096px: unity 31 ms / texconv 801 ms / compressonator 3232 ms</description></item>
+    /// <item><description>1024px: unity 2.6 ms / texconv 61 ms / compressonator 523 ms</description></item>
+    /// <item><description>2048px: unity 14.1 ms / texconv 108 ms / compressonator 966 ms</description></item>
+    /// <item><description>4096px: unity 33.8 ms / texconv 335 ms / compressonator 2509 ms</description></item>
     /// </list>
     /// <para>
-    /// The per-invocation floor is 49 ms (texconv) and 344 ms (compressonator), so a full mip chain costs
-    /// 0.5-0.6 s resp. 3.4-4.5 s in pure process/I-O overhead before any encoding happens -- an order of
-    /// magnitude more than Unity spends on the entire texture. Quality is not a compensating factor either:
-    /// image diff came out 0.00029 (unity), 0.00056 (texconv, worse) and 0.00028 (compressonator, equal within
-    /// noise). Conclusion: unlike ASTC, there is nothing for an out-of-process DXT encoder to win -- it would be
-    /// slower, not faster, so no async/CLI path is built for DXT. See
-    /// <see cref="UnityTextureCompressor.CompressTexture"/>.
+    /// The gap is NOT a missed parallelism flag, which was checked explicitly. Measuring each process's
+    /// <see cref="System.Diagnostics.Process.TotalProcessorTime"/> against its wall time gives a cpu/wall ratio
+    /// of 2.6-7.9x (texconv) and 3.2-9.5x (compressonator) on a 12-core machine -- both encoders already run
+    /// multi-threaded and saturate most of the box by default. Compressonator's alternate backends were tried
+    /// too and none help for BC3: <c>-EncodeWith HPC</c> measured the same as the default CPU path (967 vs
+    /// 929 ms at 2048px, within noise; HPC targets BC6H/BC7), while <c>DXC</c> (3207 ms) and <c>GPU</c>
+    /// (1299 ms) were worse. Its <c>-NumThreads</c> option is documented as BC6H/BC7-only. In CPU-time terms the
+    /// difference is stark: at 4096px texconv spends 2.6 s and compressonator 23.9 s of CPU to do what Unity
+    /// finishes in 33.8 ms of wall time.
+    /// </para>
+    /// <para>
+    /// On top of the encode itself, the per-invocation floor is 49 ms (texconv) and 344 ms (compressonator), so
+    /// a full mip chain costs 0.5-0.6 s resp. 3.4-4.5 s in pure process/I-O overhead before any encoding
+    /// happens. Quality is not a compensating factor either: image diff came out 0.00029 (unity), 0.00056
+    /// (texconv, worse) and 0.00028 (compressonator, equal within noise). Conclusion: unlike ASTC, there is
+    /// nothing for an out-of-process DXT encoder to win -- it would be slower, not faster, so no async/CLI path
+    /// is built for DXT. See <see cref="UnityTextureCompressor.CompressTexture"/>.
     /// </para>
     /// </remarks>
     [Explicit("Benchmark")]
@@ -126,7 +135,7 @@ namespace KRT.VRCQuestTools.Utils
                     for (var i = 0; i < iterations; i++)
                     {
                         var sw = Stopwatch.StartNew();
-                        RunCliPipeline(encoder, reference, 4, out _, out _, out _, out _);
+                        RunCliPipeline(encoder, reference, 4, out _, out _, out _, out _, out _);
                         sw.Stop();
                         samples.Add(sw.Elapsed.TotalMilliseconds);
                     }
@@ -149,6 +158,54 @@ namespace KRT.VRCQuestTools.Utils
                 UnityEngine.Object.DestroyImmediate(reference);
             }
 
+            Debug.Log(sb.ToString());
+        }
+
+        /// <summary>
+        /// Checks whether the CLI encoders are actually using multiple cores, by comparing each process's total
+        /// CPU time (summed over all its threads) against its wall time. This exists to rule out the obvious
+        /// explanation for the CLIs losing so badly in <see cref="PipelineBreakdown"/> -- that they were left
+        /// running single-threaded while Unity's encoder was not -- rather than leaving it assumed.
+        /// </summary>
+        /// <remarks>
+        /// Measured on a 12-core Windows machine: texconv reaches 2.6x (1024px) to 7.9x (4096px) and
+        /// Compressonator 3.2x to 9.5x, i.e. both already engage most of the machine without any extra flag.
+        /// Compressonator's <c>-EncodeWith HPC</c> was tried separately and made no difference for BC3 (it
+        /// targets BC6H/BC7), and its <c>-NumThreads</c> is documented as BC6H/BC7-only.
+        /// </remarks>
+        [Test]
+        public void ParallelismCheck()
+        {
+            var encoders = ResolveEncoders();
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"=== Encoder parallelism (cpu time / wall time; machine has {SystemInfo.processorCount} cores) ===");
+
+            foreach (var size in new[] { 1024, 2048, 4096 })
+            {
+                var reference = CreateNaturalisticTexture(size);
+                try
+                {
+                    foreach (var encoder in encoders)
+                    {
+                        // Warm up first so the reported ratio reflects steady state rather than cold module load.
+                        RunCliPipeline(encoder, reference, size, out _, out _, out _, out _, out _);
+
+                        var blocks = RunCliPipeline(encoder, reference, size, out _, out var processMs, out _, out var cpuMs, out var output);
+                        Assert.IsNotNull(blocks, $"{encoder.Name} failed for size={size}: {output}");
+
+                        var ratio = processMs > 0 ? cpuMs / processMs : 0;
+                        sb.AppendLine($"  {size,5}px {encoder.Name,-22} wall={processMs,8:F1}ms cpu={cpuMs,9:F1}ms cpu/wall={ratio,5:F2}x");
+                    }
+                }
+                finally
+                {
+                    UnityEngine.Object.DestroyImmediate(reference);
+                }
+            }
+
+            sb.AppendLine("A ratio well above 1.00x means the encoder is already multi-threaded, so its slowness");
+            sb.AppendLine("relative to Unity is not explained by a missing parallelism option.");
             Debug.Log(sb.ToString());
         }
 
@@ -208,7 +265,7 @@ namespace KRT.VRCQuestTools.Utils
         private static void MeasureCli(EncoderSpec encoder, Texture2D reference, int size, List<Row> rows)
         {
             var sw = Stopwatch.StartNew();
-            var blocks = RunCliPipeline(encoder, reference, size, out var writeMs, out var processMs, out var readMs, out var output);
+            var blocks = RunCliPipeline(encoder, reference, size, out var writeMs, out var processMs, out var readMs, out _, out var output);
             sw.Stop();
             Assert.IsNotNull(blocks, $"{encoder.Name} failed for size={size}: {output}");
 
@@ -233,11 +290,12 @@ namespace KRT.VRCQuestTools.Utils
         /// <param name="source">Source image to encode.</param>
         /// <param name="size">Width and height of <paramref name="source"/>.</param>
         /// <param name="writeMs">Milliseconds spent writing the TGA input.</param>
-        /// <param name="processMs">Milliseconds spent running the encoder process.</param>
+        /// <param name="processMs">Milliseconds spent running the encoder process (wall clock).</param>
         /// <param name="readMs">Milliseconds spent reading the DDS output back.</param>
+        /// <param name="cpuMs">CPU time consumed by the encoder process across all its threads.</param>
         /// <param name="output">Captured process output, for failure diagnosis.</param>
         /// <returns>Raw compressed block data, or null when the encoder failed.</returns>
-        private static byte[] RunCliPipeline(EncoderSpec encoder, Texture2D source, int size, out double writeMs, out double processMs, out double readMs, out string output)
+        private static byte[] RunCliPipeline(EncoderSpec encoder, Texture2D source, int size, out double writeMs, out double processMs, out double readMs, out double cpuMs, out string output)
         {
             var tempDir = Path.GetFullPath(TempDirectory);
             Directory.CreateDirectory(tempDir);
@@ -259,6 +317,8 @@ namespace KRT.VRCQuestTools.Utils
                 swProcess.Stop();
                 processMs = swProcess.Elapsed.TotalMilliseconds;
                 output = result.Output;
+
+                cpuMs = result.CpuMs;
 
                 if (result.ExitCode != 0 || !File.Exists(ddsPath))
                 {
@@ -329,10 +389,15 @@ namespace KRT.VRCQuestTools.Utils
                 if (!process.WaitForExit(timeoutMs))
                 {
                     AstcencCli.KillSilently(process);
-                    return new ProcessRunResult(-1, "timed out");
+                    return new ProcessRunResult(-1, "timed out", 0);
                 }
                 process.WaitForExit(); // Ensure redirected streams are flushed.
-                return new ProcessRunResult(process.ExitCode, stdErrTask.Result + stdOutTask.Result);
+
+                // Read before leaving the using block: TotalProcessorTime is still available for an exited
+                // process, but not for a disposed one. Summed across every thread the process used, so
+                // comparing it against wall time reveals how many cores the encoder actually engaged.
+                var cpuMs = process.TotalProcessorTime.TotalMilliseconds;
+                return new ProcessRunResult(process.ExitCode, stdErrTask.Result + stdOutTask.Result, cpuMs);
             }
         }
 
@@ -477,15 +542,21 @@ namespace KRT.VRCQuestTools.Utils
 
         private readonly struct ProcessRunResult
         {
-            internal ProcessRunResult(int exitCode, string output)
+            internal ProcessRunResult(int exitCode, string output, double cpuMs)
             {
                 ExitCode = exitCode;
                 Output = output;
+                CpuMs = cpuMs;
             }
 
             internal int ExitCode { get; }
 
             internal string Output { get; }
+
+            /// <summary>
+            /// Gets the total CPU time consumed across all of the process's threads, in milliseconds.
+            /// </summary>
+            internal double CpuMs { get; }
         }
 
         private readonly struct Row

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs
@@ -1,0 +1,519 @@
+// <copyright file="DxtCliBenchmarkTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace KRT.VRCQuestTools.Utils
+{
+    /// <summary>
+    /// Manual benchmark comparing Unity's built-in DXT compression against out-of-process DXT/BC encoder CLIs
+    /// (Microsoft DirectXTex's texconv and AMD's Compressonator), mirroring the way
+    /// <see cref="AstcencTextureCompressor"/> drives astcenc. Complements <see cref="DxtBenchmarkTests"/>, which
+    /// only measures Unity's side: this one answers whether a CLI encoder could actually beat it, by measuring
+    /// the CLI pipeline's own fixed cost (TGA write, process spawn, output read) alongside the encode itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Neither CLI is bundled with this repository. Obtain them once, relative to the Unity project root, before
+    /// running:
+    /// <c>curl -sL -o Temp/dxtbench/texconv_dxtex/texconv.exe https://github.com/microsoft/DirectXTex/releases/latest/download/texconv.exe</c>
+    /// and the <c>compressonatorcli-*-win64.zip</c> from the Compressonator releases page extracted under
+    /// <c>Temp/dxtbench/compressonator/</c>. Each encoder is skipped individually when absent, and the whole
+    /// class is marked <see cref="ExplicitAttribute"/> so it never runs in CI.
+    /// </para>
+    /// <para>
+    /// Two per-invocation costs matter and are reported separately. <see cref="PipelineBreakdown"/> measures one
+    /// mip level end to end; <see cref="FixedInvocationOverhead"/> measures a 4x4 image, where the encode work is
+    /// negligible, so the result is the floor cost of any CLI approach regardless of which encoder is chosen.
+    /// That floor is what must be compared against Unity's whole-texture time, because
+    /// <see cref="AstcencTextureCompressor"/>'s pattern spawns one process per mip level -- a 1024px texture with
+    /// a full mip chain means 11 invocations, so the floor is paid 11 times over.
+    /// </para>
+    /// <para>
+    /// Measured result (Windows, DXT5/BC3). Unity compresses the whole texture in 2.2-31 ms; both CLIs need that
+    /// much or more just to start up, and are 25-100x slower overall for mip 0 alone:
+    /// </para>
+    /// <list type="table">
+    /// <item><description>512px: unity 3.4 ms / texconv 83 ms / compressonator 435 ms</description></item>
+    /// <item><description>1024px: unity 2.2 ms / texconv 115 ms / compressonator 570 ms</description></item>
+    /// <item><description>2048px: unity 8.3 ms / texconv 363 ms / compressonator 1148 ms</description></item>
+    /// <item><description>4096px: unity 31 ms / texconv 801 ms / compressonator 3232 ms</description></item>
+    /// </list>
+    /// <para>
+    /// The per-invocation floor is 49 ms (texconv) and 344 ms (compressonator), so a full mip chain costs
+    /// 0.5-0.6 s resp. 3.4-4.5 s in pure process/I-O overhead before any encoding happens -- an order of
+    /// magnitude more than Unity spends on the entire texture. Quality is not a compensating factor either:
+    /// image diff came out 0.00029 (unity), 0.00056 (texconv, worse) and 0.00028 (compressonator, equal within
+    /// noise). Conclusion: unlike ASTC, there is nothing for an out-of-process DXT encoder to win -- it would be
+    /// slower, not faster, so no async/CLI path is built for DXT. See
+    /// <see cref="UnityTextureCompressor.CompressTexture"/>.
+    /// </para>
+    /// </remarks>
+    [Explicit("Benchmark")]
+    public class DxtCliBenchmarkTests
+    {
+        /// <summary>
+        /// Temporary directory for benchmark work files, relative to the Unity project root.
+        /// </summary>
+        private const string TempDirectory = "Temp/dxtbench/work";
+
+        private static readonly int[] Sizes = { 512, 1024, 2048, 4096 };
+
+        /// <summary>
+        /// Compares, for each texture size, Unity's built-in DXT5 compression against each available CLI encoder
+        /// producing the same format (BC3), run out-of-process, and reports the CLI pipeline's cost broken down
+        /// into TGA write, process run, and output read. Also reports the resulting image quality of each, so a
+        /// speed difference is not mistaken for a free win.
+        /// </summary>
+        [Test]
+        public void PipelineBreakdown()
+        {
+            var encoders = ResolveEncoders();
+
+            Debug.Log("size,encoder,totalMs,writeMs,processMs,readMs,diff");
+            var rows = new List<Row>();
+
+            foreach (var size in Sizes)
+            {
+                var reference = CreateNaturalisticTexture(size);
+                try
+                {
+                    MeasureUnity(reference, size, rows);
+                    foreach (var encoder in encoders)
+                    {
+                        MeasureCli(encoder, reference, size, rows);
+                    }
+                }
+                finally
+                {
+                    UnityEngine.Object.DestroyImmediate(reference);
+                }
+            }
+
+            LogSummary(rows, encoders);
+        }
+
+        /// <summary>
+        /// Measures the floor cost of a single CLI invocation by encoding a 4x4 image, where the actual encode
+        /// work is negligible: what remains is process spawn plus temp-file I/O, which every CLI-based encoder
+        /// pays per invocation. Reported as a median over several runs, since process spawn time is noisy.
+        /// </summary>
+        [Test]
+        public void FixedInvocationOverhead()
+        {
+            var encoders = ResolveEncoders();
+
+            const int iterations = 15;
+            var sb = new StringBuilder();
+            sb.AppendLine($"=== Fixed CLI invocation overhead (4x4 image, {iterations} runs each) ===");
+
+            var reference = CreateNaturalisticTexture(4);
+            try
+            {
+                foreach (var encoder in encoders)
+                {
+                    var samples = new List<double>(iterations);
+                    for (var i = 0; i < iterations; i++)
+                    {
+                        var sw = Stopwatch.StartNew();
+                        RunCliPipeline(encoder, reference, 4, out _, out _, out _, out _);
+                        sw.Stop();
+                        samples.Add(sw.Elapsed.TotalMilliseconds);
+                    }
+
+                    samples.Sort();
+                    var median = samples[samples.Count / 2];
+                    sb.AppendLine($"-- {encoder.Name} --");
+                    sb.AppendLine($"  median={median:F1}ms  min={samples[0]:F1}ms  max={samples[samples.Count - 1]:F1}ms");
+                    sb.AppendLine("  Per-invocation floor. The astcenc pattern spawns one process per mip level,");
+                    sb.AppendLine("  so a full mip chain multiplies it:");
+                    foreach (var size in Sizes)
+                    {
+                        var mips = MipCount(size);
+                        sb.AppendLine($"    {size,5}px -> {mips,2} mips -> {median * mips,8:F1}ms of pure overhead");
+                    }
+                }
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(reference);
+            }
+
+            Debug.Log(sb.ToString());
+        }
+
+        /// <summary>
+        /// Builds the list of CLI encoders that are actually present on this machine, skipping the whole test
+        /// when none are.
+        /// </summary>
+        /// <returns>Available encoder specifications.</returns>
+        private static List<EncoderSpec> ResolveEncoders()
+        {
+            var encoders = new List<EncoderSpec>();
+
+            var texconv = Path.GetFullPath("Temp/dxtbench/texconv_dxtex/texconv.exe");
+            if (File.Exists(texconv))
+            {
+                // -m 1: a single mip level, matching the astcenc pattern of encoding each level separately.
+                // -y: overwrite. -nologo: suppress the banner so stdout stays small. texconv derives the output
+                // file name from the input's, so the destination is given as a directory via -o.
+                encoders.Add(new EncoderSpec(
+                    "texconv/BC3",
+                    texconv,
+                    (input, output, tempDir) => $"-nologo -y -f BC3_UNORM -m 1 -o \"{tempDir}\" \"{input}\""));
+            }
+
+            var compressonator = Path.GetFullPath("Temp/dxtbench/compressonator/compressonatorcli-4.5.52-win64/compressonatorcli.exe");
+            if (File.Exists(compressonator))
+            {
+                encoders.Add(new EncoderSpec(
+                    "compressonator/BC3",
+                    compressonator,
+                    (input, output, tempDir) => $"-nomipmap -fd BC3 \"{input}\" \"{output}\""));
+            }
+
+            if (encoders.Count == 0)
+            {
+                Assert.Ignore("No DXT/BC encoder CLI is available; see this class's remarks for how to obtain them.");
+            }
+
+            return encoders;
+        }
+
+        private static void MeasureUnity(Texture2D reference, int size, List<Row> rows)
+        {
+            var candidate = CreateNaturalisticTexture(size);
+            var sw = Stopwatch.StartNew();
+            EditorUtility.CompressTexture(candidate, TextureFormat.DXT5, TextureCompressionQuality.Best);
+            sw.Stop();
+
+            var decoded = TestUtils.DecodeToRGBA32(candidate, size, size);
+            var diff = OrientationAgnosticDifference(reference, decoded, size);
+            AddRow(rows, size, "unity", sw.Elapsed.TotalMilliseconds, 0, 0, 0, diff);
+
+            UnityEngine.Object.DestroyImmediate(decoded);
+            UnityEngine.Object.DestroyImmediate(candidate);
+        }
+
+        private static void MeasureCli(EncoderSpec encoder, Texture2D reference, int size, List<Row> rows)
+        {
+            var sw = Stopwatch.StartNew();
+            var blocks = RunCliPipeline(encoder, reference, size, out var writeMs, out var processMs, out var readMs, out var output);
+            sw.Stop();
+            Assert.IsNotNull(blocks, $"{encoder.Name} failed for size={size}: {output}");
+
+            var compressed = new Texture2D(size, size, TextureFormat.DXT5, false, false);
+            compressed.LoadRawTextureData(blocks);
+            compressed.Apply(false, false);
+
+            var decoded = TestUtils.DecodeToRGBA32(compressed, size, size);
+            var diff = OrientationAgnosticDifference(reference, decoded, size);
+            AddRow(rows, size, encoder.Name, sw.Elapsed.TotalMilliseconds, writeMs, processMs, readMs, diff);
+
+            UnityEngine.Object.DestroyImmediate(decoded);
+            UnityEngine.Object.DestroyImmediate(compressed);
+        }
+
+        /// <summary>
+        /// Runs the full out-of-process pipeline for a single image: write the source as TGA, run the encoder on
+        /// it, and read the resulting DDS back as raw block data. Mirrors what
+        /// <see cref="AstcencTextureCompressor"/> does per mip level, so the measured cost is comparable.
+        /// </summary>
+        /// <param name="encoder">Encoder to run.</param>
+        /// <param name="source">Source image to encode.</param>
+        /// <param name="size">Width and height of <paramref name="source"/>.</param>
+        /// <param name="writeMs">Milliseconds spent writing the TGA input.</param>
+        /// <param name="processMs">Milliseconds spent running the encoder process.</param>
+        /// <param name="readMs">Milliseconds spent reading the DDS output back.</param>
+        /// <param name="output">Captured process output, for failure diagnosis.</param>
+        /// <returns>Raw compressed block data, or null when the encoder failed.</returns>
+        private static byte[] RunCliPipeline(EncoderSpec encoder, Texture2D source, int size, out double writeMs, out double processMs, out double readMs, out string output)
+        {
+            var tempDir = Path.GetFullPath(TempDirectory);
+            Directory.CreateDirectory(tempDir);
+            var id = Guid.NewGuid().ToString("N");
+            var tgaPath = Path.Combine(tempDir, $"{id}.tga");
+            var ddsPath = Path.Combine(tempDir, $"{id}.dds");
+
+            try
+            {
+                // TgaTopToBottomOrigin = true, matching AstcencTextureCompressor (see its remarks for why).
+                var swWrite = Stopwatch.StartNew();
+                AstcUtility.WriteTga(source.GetPixels32(), size, size, true, tgaPath);
+                swWrite.Stop();
+                writeMs = swWrite.Elapsed.TotalMilliseconds;
+
+                var arguments = encoder.BuildArguments(tgaPath, ddsPath, tempDir);
+                var swProcess = Stopwatch.StartNew();
+                var result = RunProcess(encoder.ExePath, arguments, 5 * 60 * 1000);
+                swProcess.Stop();
+                processMs = swProcess.Elapsed.TotalMilliseconds;
+                output = result.Output;
+
+                if (result.ExitCode != 0 || !File.Exists(ddsPath))
+                {
+                    readMs = 0;
+                    return null;
+                }
+
+                var swRead = Stopwatch.StartNew();
+                var fileData = File.ReadAllBytes(ddsPath);
+                var blocks = StripDdsHeader(fileData);
+                swRead.Stop();
+                readMs = swRead.Elapsed.TotalMilliseconds;
+
+                return blocks;
+            }
+            finally
+            {
+                AstcencCli.DeleteFileSilently(tgaPath);
+                AstcencCli.DeleteFileSilently(ddsPath);
+            }
+        }
+
+        /// <summary>
+        /// Strips the DDS header, returning the raw compressed block data. Handles both the legacy 128-byte
+        /// header and the 148-byte variant that carries an additional DDS_HEADER_DXT10 block.
+        /// </summary>
+        /// <param name="fileData">Full contents of a .dds file.</param>
+        /// <returns>The block data following the header.</returns>
+        private static byte[] StripDdsHeader(byte[] fileData)
+        {
+            const int LegacyHeaderBytes = 128;
+            const int Dxt10HeaderBytes = 20;
+
+            Assert.GreaterOrEqual(fileData.Length, LegacyHeaderBytes, "DDS file is shorter than its header.");
+            Assert.AreEqual("DDS ", Encoding.ASCII.GetString(fileData, 0, 4), "Not a DDS file.");
+
+            // DDS_PIXELFORMAT.dwFourCC sits 84 bytes in: 4 (magic) + 72 (offset of DDS_PIXELFORMAT within
+            // DDS_HEADER) + 8 (offset of dwFourCC within DDS_PIXELFORMAT).
+            var fourCC = Encoding.ASCII.GetString(fileData, 84, 4);
+            var dataOffset = fourCC == "DX10" ? LegacyHeaderBytes + Dxt10HeaderBytes : LegacyHeaderBytes;
+
+            var blocks = new byte[fileData.Length - dataOffset];
+            Buffer.BlockCopy(fileData, dataOffset, blocks, 0, blocks.Length);
+            return blocks;
+        }
+
+        private static ProcessRunResult RunProcess(string exePath, string arguments, int timeoutMs)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = exePath,
+                Arguments = arguments,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+
+                // Compressonator loads its image-format plugins (e.g. qtga.dll for TGA input) relative to the
+                // working directory, so it must run from its own install folder rather than the project root.
+                WorkingDirectory = Path.GetDirectoryName(exePath),
+            };
+
+            using (var process = Process.Start(startInfo))
+            {
+                // Drained asynchronously so the process never blocks on a full output buffer, matching AstcencCli.
+                var stdOutTask = process.StandardOutput.ReadToEndAsync();
+                var stdErrTask = process.StandardError.ReadToEndAsync();
+                if (!process.WaitForExit(timeoutMs))
+                {
+                    AstcencCli.KillSilently(process);
+                    return new ProcessRunResult(-1, "timed out");
+                }
+                process.WaitForExit(); // Ensure redirected streams are flushed.
+                return new ProcessRunResult(process.ExitCode, stdErrTask.Result + stdOutTask.Result);
+            }
+        }
+
+        private static void AddRow(List<Row> rows, int size, string encoder, double totalMs, double writeMs, double processMs, double readMs, float diff)
+        {
+            rows.Add(new Row(size, encoder, totalMs, writeMs, processMs, readMs, diff));
+            Debug.Log($"{size},{encoder},{totalMs:F1},{writeMs:F1},{processMs:F1},{readMs:F1},{diff:F5}");
+        }
+
+        private static void LogSummary(List<Row> rows, List<EncoderSpec> encoders)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("=== Summary: Unity built-in DXT5 vs CLI encoders (mip 0 only, one invocation) ===");
+            foreach (var size in Sizes)
+            {
+                var unity = rows.Find(r => r.Size == size && r.Encoder == "unity");
+                sb.AppendLine($"-- size={size} --");
+                sb.AppendLine($"  {"unity",-22} total={unity.TotalMs,9:F1}ms diff={unity.Diff:F5}");
+
+                foreach (var encoder in encoders)
+                {
+                    var cli = rows.Find(r => r.Size == size && r.Encoder == encoder.Name);
+                    var ratio = cli.TotalMs > 0 ? unity.TotalMs / cli.TotalMs : 0;
+                    sb.AppendLine($"  {encoder.Name,-22} total={cli.TotalMs,9:F1}ms diff={cli.Diff:F5} (write={cli.WriteMs,6:F1} process={cli.ProcessMs,7:F1} read={cli.ReadMs,5:F1}) speed={ratio:F2}x vs Unity");
+                }
+            }
+            sb.AppendLine("speed > 1.00x means the CLI is faster than Unity's built-in encoder.");
+            Debug.Log(sb.ToString());
+        }
+
+        private static int MipCount(int size)
+        {
+            var count = 1;
+            while (size > 1)
+            {
+                size >>= 1;
+                count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Computes the image difference, tolerating a vertically flipped result: the TGA origin convention used
+        /// for the CLI input is not necessarily the one each encoder assumes, and a flip would otherwise show up
+        /// as a large diff and be misread as poor encode quality. Returns the smaller of the two comparisons.
+        /// </summary>
+        /// <param name="reference">Reference image.</param>
+        /// <param name="decoded">Decoded compressed image.</param>
+        /// <param name="size">Width and height of both images.</param>
+        /// <returns>The image difference under whichever orientation matches better.</returns>
+        private static float OrientationAgnosticDifference(Texture2D reference, Texture2D decoded, int size)
+        {
+            var direct = TestUtils.Difference(reference, decoded);
+
+            var flipped = FlipVertically(decoded, size);
+            try
+            {
+                var flippedDiff = TestUtils.Difference(reference, flipped);
+                return Math.Min(direct, flippedDiff);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(flipped);
+            }
+        }
+
+        private static Texture2D FlipVertically(Texture2D texture, int size)
+        {
+            var source = TestUtils.CopyTextureAsReadable(texture).GetPixels32();
+            var flipped = new Color32[source.Length];
+            for (var y = 0; y < size; y++)
+            {
+                Array.Copy(source, y * size, flipped, (size - 1 - y) * size, size);
+            }
+
+            var result = new Texture2D(size, size, TextureFormat.RGBA32, false, false);
+            result.SetPixels32(flipped);
+            result.Apply(false, false);
+            return result;
+        }
+
+        /// <summary>
+        /// Generates a fully opaque procedural texture mixing several sine/cosine frequencies per channel, so it
+        /// has both smooth gradients and higher-frequency detail instead of a flat placeholder image, which would
+        /// let the encoders take shortcuts unrepresentative of real content. Matches the generator used by
+        /// <see cref="AstcencBenchmarkTests"/> and <see cref="DxtBenchmarkTests"/> so numbers are comparable.
+        /// </summary>
+        /// <param name="size">Width and height of the generated texture.</param>
+        /// <returns>The generated texture.</returns>
+        private static Texture2D CreateNaturalisticTexture(int size)
+        {
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, false, false);
+            var pixels = new Color32[size * size];
+            for (var y = 0; y < size; y++)
+            {
+                for (var x = 0; x < size; x++)
+                {
+                    var fx = x / (float)size;
+                    var fy = y / (float)size;
+                    var r = 127f + (80f * Mathf.Sin(x * 0.13f)) + (48f * Mathf.Sin((y * 0.07f) + (x * 0.02f)));
+                    var g = 127f + (80f * Mathf.Cos(y * 0.11f)) + (48f * Mathf.Sin((x + y) * 0.05f));
+                    var b = 127f + (100f * fx * fy) + (40f * Mathf.Sin((x * 0.29f) + (y * 0.19f)));
+                    pixels[(y * size) + x] = new Color32(
+                        (byte)Mathf.Clamp(r, 0f, 255f),
+                        (byte)Mathf.Clamp(g, 0f, 255f),
+                        (byte)Mathf.Clamp(b, 0f, 255f),
+                        255);
+                }
+            }
+            tex.SetPixels32(pixels);
+            tex.Apply(false, false);
+            return tex;
+        }
+
+        /// <summary>
+        /// A DXT/BC encoder CLI to benchmark.
+        /// </summary>
+        private readonly struct EncoderSpec
+        {
+            internal EncoderSpec(string name, string exePath, Func<string, string, string, string> buildArguments)
+            {
+                Name = name;
+                ExePath = exePath;
+                BuildArguments = buildArguments;
+            }
+
+            /// <summary>
+            /// Gets the display name used in the reported rows.
+            /// </summary>
+            internal string Name { get; }
+
+            /// <summary>
+            /// Gets the full path to the executable.
+            /// </summary>
+            internal string ExePath { get; }
+
+            /// <summary>
+            /// Gets the callback building the command line from (input TGA path, output DDS path, temp directory).
+            /// </summary>
+            internal Func<string, string, string, string> BuildArguments { get; }
+        }
+
+        private readonly struct ProcessRunResult
+        {
+            internal ProcessRunResult(int exitCode, string output)
+            {
+                ExitCode = exitCode;
+                Output = output;
+            }
+
+            internal int ExitCode { get; }
+
+            internal string Output { get; }
+        }
+
+        private readonly struct Row
+        {
+            internal Row(int size, string encoder, double totalMs, double writeMs, double processMs, double readMs, float diff)
+            {
+                Size = size;
+                Encoder = encoder;
+                TotalMs = totalMs;
+                WriteMs = writeMs;
+                ProcessMs = processMs;
+                ReadMs = readMs;
+                Diff = diff;
+            }
+
+            internal int Size { get; }
+
+            internal string Encoder { get; }
+
+            internal double TotalMs { get; }
+
+            internal double WriteMs { get; }
+
+            internal double ProcessMs { get; }
+
+            internal double ReadMs { get; }
+
+            internal float Diff { get; }
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using UnityEditor;
@@ -28,8 +29,13 @@ namespace KRT.VRCQuestTools.Utils
     /// running:
     /// <c>curl -sL -o Temp/dxtbench/texconv_dxtex/texconv.exe https://github.com/microsoft/DirectXTex/releases/latest/download/texconv.exe</c>
     /// and the <c>compressonatorcli-*-win64.zip</c> from the Compressonator releases page extracted under
-    /// <c>Temp/dxtbench/compressonator/</c>. Each encoder is skipped individually when absent, and the whole
-    /// class is marked <see cref="ExplicitAttribute"/> so it never runs in CI.
+    /// <c>Temp/dxtbench/compressonator/</c> -- any release will do, since <c>compressonatorcli.exe</c> is
+    /// searched for beneath that directory rather than at a version-specific path. texconv must go in its own
+    /// <c>texconv_dxtex/</c> directory as shown, because the Compressonator package bundles a copy of
+    /// <c>texconv.exe</c> too and the two must not be confused. Whichever encoders were resolved is logged at
+    /// the start of each test, so an encoder missed because of a wrong path is visible rather than silently
+    /// dropped from the comparison; the whole class is marked <see cref="ExplicitAttribute"/> so it never runs
+    /// in CI.
     /// </para>
     /// <para>
     /// Two per-invocation costs matter and are reported separately. <see cref="PipelineBreakdown"/> measures one
@@ -75,6 +81,13 @@ namespace KRT.VRCQuestTools.Utils
         /// Temporary directory for benchmark work files, relative to the Unity project root.
         /// </summary>
         private const string TempDirectory = "Temp/dxtbench/work";
+
+        /// <summary>
+        /// Directory the Compressonator release archive is expected to be extracted under, relative to the Unity
+        /// project root. The executable is searched for beneath it (see <see cref="FindExecutableUnder"/>) rather
+        /// than at a fixed path, since the archive's own folder name carries the release version.
+        /// </summary>
+        private const string CompressonatorRoot = "Temp/dxtbench/compressonator";
 
         private static readonly int[] Sizes = { 512, 1024, 2048, 4096 };
 
@@ -217,7 +230,11 @@ namespace KRT.VRCQuestTools.Utils
         private static List<EncoderSpec> ResolveEncoders()
         {
             var encoders = new List<EncoderSpec>();
+            var missing = new List<string>();
 
+            // Pinned to its own directory instead of being searched for: the Compressonator package below
+            // bundles its own copy of texconv.exe, so a wider search under Temp/dxtbench would silently
+            // benchmark AMD's bundled build in place of the DirectXTex release this row is meant to measure.
             var texconv = Path.GetFullPath("Temp/dxtbench/texconv_dxtex/texconv.exe");
             if (File.Exists(texconv))
             {
@@ -229,15 +246,30 @@ namespace KRT.VRCQuestTools.Utils
                     texconv,
                     (input, output, tempDir) => $"-nologo -y -f BC3_UNORM -m 1 -o \"{tempDir}\" \"{input}\""));
             }
+            else
+            {
+                missing.Add($"texconv ({texconv})");
+            }
 
-            var compressonator = Path.GetFullPath("Temp/dxtbench/compressonator/compressonatorcli-4.5.52-win64/compressonatorcli.exe");
-            if (File.Exists(compressonator))
+            var compressonator = FindExecutableUnder(CompressonatorRoot, "compressonatorcli.exe");
+            if (compressonator != null)
             {
                 encoders.Add(new EncoderSpec(
                     "compressonator/BC3",
                     compressonator,
                     (input, output, tempDir) => $"-nomipmap -fd BC3 \"{input}\" \"{output}\""));
             }
+            else
+            {
+                missing.Add($"compressonator ({CompressonatorRoot}/**/compressonatorcli.exe)");
+            }
+
+            // Logged because only a *complete* absence of encoders ignores the test: without this, a run that
+            // resolved just one of the two would quietly report half the comparison as though it were the whole
+            // of it, which is exactly the way a stale or mistyped path goes unnoticed.
+            var found = encoders.Count > 0 ? string.Join(", ", encoders.Select(e => e.Name)) : "(none)";
+            var notFound = missing.Count > 0 ? $" | not found: {string.Join(", ", missing)}" : string.Empty;
+            Debug.Log($"DXT CLI encoders resolved: {found}{notFound}");
 
             if (encoders.Count == 0)
             {
@@ -245,6 +277,44 @@ namespace KRT.VRCQuestTools.Utils
             }
 
             return encoders;
+        }
+
+        /// <summary>
+        /// Finds an executable anywhere beneath a directory, without pinning the intermediate folder names.
+        /// </summary>
+        /// <remarks>
+        /// The Compressonator release archive extracts into a version-named folder (e.g.
+        /// <c>compressonatorcli-4.5.52-win64</c>), so hard-coding one release's directory name would make every
+        /// other release read as "not installed" -- and, because a single missing encoder does not fail or
+        /// ignore the test, do so silently. Searching instead keeps the class remarks ("extract it under
+        /// <see cref="CompressonatorRoot"/>") true for any release.
+        /// </remarks>
+        /// <param name="relativeRoot">Directory to search, relative to the Unity project root.</param>
+        /// <param name="fileName">Executable file name to look for.</param>
+        /// <returns>Full path of the first match in sorted order, or null when the directory or file is absent.</returns>
+        private static string FindExecutableUnder(string relativeRoot, string fileName)
+        {
+            var root = Path.GetFullPath(relativeRoot);
+            if (!Directory.Exists(root))
+            {
+                return null;
+            }
+
+            try
+            {
+                var matches = Directory.GetFiles(root, fileName, SearchOption.AllDirectories);
+
+                // Sorted so the pick stays deterministic if several releases happen to be extracted side by side.
+                Array.Sort(matches, StringComparer.OrdinalIgnoreCase);
+                return matches.Length > 0 ? matches[0] : null;
+            }
+            catch (Exception e)
+            {
+                // e.g. an unreadable directory. Reported rather than thrown: a resolution failure should read
+                // as "this encoder is unavailable", the same as it not being installed.
+                Debug.Log($"Failed to search for {fileName} under {root}: {e.Message}");
+                return null;
+            }
         }
 
         private static void MeasureUnity(Texture2D reference, int size, List<Row> rows)
@@ -359,6 +429,11 @@ namespace KRT.VRCQuestTools.Utils
             // DDS_HEADER) + 8 (offset of dwFourCC within DDS_PIXELFORMAT).
             var fourCC = Encoding.ASCII.GetString(fileData, 84, 4);
             var dataOffset = fourCC == "DX10" ? LegacyHeaderBytes + Dxt10HeaderBytes : LegacyHeaderBytes;
+
+            // Re-checked against the resolved offset rather than only the legacy minimum asserted above: a
+            // DX10-tagged file between 128 and 147 bytes long would otherwise compute a negative length here
+            // and throw on the allocation, instead of failing with a message that names the actual problem.
+            Assert.GreaterOrEqual(fileData.Length, dataOffset, $"DDS file is shorter than its {dataOffset}-byte header.");
 
             var blocks = new byte[fileData.Length - dataOffset];
             Buffer.BlockCopy(fileData, dataOffset, blocks, 0, blocks.Length);

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/DxtCliBenchmarkTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e311cddd980a87408416d18ca65a89b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/UnityTextureCompressor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/UnityTextureCompressor.cs
@@ -26,9 +26,10 @@ namespace KRT.VRCQuestTools.Utils
         /// <see cref="AstcencTextureCompressor"/> instead runs out-of-process/async because Unity's built-in ASTC
         /// encoder is slow enough to stall NDMF preview, DXT stays on this synchronous path deliberately:
         /// Unity's built-in DXT encoder was measured (<c>DxtBenchmarkTests</c>) at low tens of milliseconds even
-        /// at 4096px, and DXT/BC encoder CLIs were measured (<c>DxtCliBenchmarkTests</c>) to be 25-100x slower
-        /// than that, with per-invocation process overhead alone exceeding Unity's entire compression time. An
-        /// out-of-process DXT path would therefore be slower, not faster.
+        /// at 4096px, and DXT/BC encoder CLIs were measured (<c>DxtCliBenchmarkTests</c>) to be 10-75x slower
+        /// than that -- already running multi-threaded, so not for want of a parallelism flag -- with
+        /// per-invocation process overhead alone exceeding Unity's entire compression time. An out-of-process
+        /// DXT path would therefore be slower, not faster.
         /// </remarks>
         public AsyncCallbackRequest CompressTexture(Texture2D texture, TextureFormat format, Action<Texture2D> completion)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/UnityTextureCompressor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/UnityTextureCompressor.cs
@@ -22,11 +22,13 @@ namespace KRT.VRCQuestTools.Utils
         /// <inheritdoc/>
         /// <remarks>
         /// This is also the path used for the PC/Standalone DXT5 fallback (see
-        /// <see cref="TextureUtility.ResolveEffectiveCompressionFormat"/>): unlike ASTC, which
+        /// <see cref="TextureUtility.ResolveEffectiveCompressionFormat"/>). Unlike ASTC, which
         /// <see cref="AstcencTextureCompressor"/> instead runs out-of-process/async because Unity's built-in ASTC
-        /// encoder is slow enough to stall NDMF preview, Unity's built-in DXT encoder was measured
-        /// (<c>DxtBenchmarkTests</c>) at low tens of milliseconds even at 4096px -- no async/external-CLI path is
-        /// warranted for it.
+        /// encoder is slow enough to stall NDMF preview, DXT stays on this synchronous path deliberately:
+        /// Unity's built-in DXT encoder was measured (<c>DxtBenchmarkTests</c>) at low tens of milliseconds even
+        /// at 4096px, and DXT/BC encoder CLIs were measured (<c>DxtCliBenchmarkTests</c>) to be 25-100x slower
+        /// than that, with per-invocation process overhead alone exceeding Unity's entire compression time. An
+        /// out-of-process DXT path would therefore be slower, not faster.
         /// </remarks>
         public AsyncCallbackRequest CompressTexture(Texture2D texture, TextureFormat format, Action<Texture2D> completion)
         {

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/UnityTextureCompressor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/TextureCompression/UnityTextureCompressor.cs
@@ -20,6 +20,14 @@ namespace KRT.VRCQuestTools.Utils
         public string CacheKeyComponent => "unity";
 
         /// <inheritdoc/>
+        /// <remarks>
+        /// This is also the path used for the PC/Standalone DXT5 fallback (see
+        /// <see cref="TextureUtility.ResolveEffectiveCompressionFormat"/>): unlike ASTC, which
+        /// <see cref="AstcencTextureCompressor"/> instead runs out-of-process/async because Unity's built-in ASTC
+        /// encoder is slow enough to stall NDMF preview, Unity's built-in DXT encoder was measured
+        /// (<c>DxtBenchmarkTests</c>) at low tens of milliseconds even at 4096px -- no async/external-CLI path is
+        /// warranted for it.
+        /// </remarks>
         public AsyncCallbackRequest CompressTexture(Texture2D texture, TextureFormat format, Action<Texture2D> completion)
         {
             EditorUtility.CompressTexture(texture, format, TextureCompressionQuality.Best);


### PR DESCRIPTION
## Motivation

ASTC compression runs out-of-process and asynchronously via the bundled `astcenc` CLI, because Unity's built-in ASTC encoder is slow enough to stall the main thread and freeze NDMF previews. This PR investigates whether the PC/Standalone DXT path deserves the same treatment.

The answer is **no**, and this PR adds the benchmarks that establish it, so the decision is reproducible rather than a matter of recollection.

## What this changes

**No behavior change.** Two `[Explicit("Benchmark")]` EditMode tests plus one doc comment recording the conclusion:

| File | Purpose |
|---|---|
| `DxtBenchmarkTests` | Times Unity's built-in DXT5/DXT1 compression |
| `DxtCliBenchmarkTests` | Compares against out-of-process DXT/BC encoder CLIs (texconv, Compressonator), driven the same way `AstcencTextureCompressor` drives astcenc |
| `UnityTextureCompressor.CompressTexture` | Doc comment pointing at both, so the rationale is discoverable from the code it governs |

## Results

Measured on Windows, 12 cores. Unity figures are a median of 5 runs after a warmup, with the compressed bytes read back inside the timed region so a deferred compression cannot understate them.

**Compression time** (Unity = whole texture; CLI = process wall time for mip 0 alone):

| Size | Unity (DXT5) | texconv | Compressonator |
|---|---|---|---|
| 1024px | 2.6 ms | 83 ms | 517 ms |
| 2048px | 14.1 ms | 120 ms | 939 ms |
| 4096px | 33.8 ms | 357 ms | 2514 ms |

**The gap is not a missing parallelism flag.** Comparing each process's total CPU time against its wall time:

| Size | texconv | Compressonator |
|---|---|---|
| 1024px | 3.58x | 3.32x |
| 2048px | 6.63x | 6.77x |
| 4096px | 7.22x | 9.53x |

Both already engage most of the machine by default. Compressonator's alternate backends were tried too and none help for BC3: `-EncodeWith HPC` measured the same as the default CPU path (967 vs 929 ms at 2048px — HPC targets BC6H/BC7), while `DXC` (3207 ms) and `GPU` (1299 ms) were worse. Its `-NumThreads` is documented as BC6H/BC7-only. In CPU-time terms, at 4096px texconv spends 2.6 s and Compressonator 23.9 s to do what Unity finishes in 33.8 ms of wall time.

**Per-invocation overhead makes it worse.** The floor cost of a single CLI invocation — process spawn plus temp-file I/O, measured on a 4x4 image where encode work is negligible — is 49 ms (texconv) and 344 ms (Compressonator). Since the astcenc pattern spawns one process per mip level, a full mip chain costs 0.5–0.6 s resp. 3.4–4.5 s in pure overhead before any encoding happens.

**Quality does not compensate:** image diff came out 0.00029 (Unity), 0.00056 (texconv, worse), 0.00028 (Compressonator, equal within noise).

## Conclusion

Unlike ASTC, an out-of-process DXT encoder would be **slower, not faster**, so `UnityTextureCompressor` stays synchronous for DXT/BC. There is no multi-second stall to hide and no editor freeze to fix.

## Notes for reviewers

- Both tests are `[Explicit]`, so they never run in CI.
- The CLI encoders are **not** bundled or downloaded by the repo. `DxtCliBenchmarkTests` skips itself per-encoder when they are absent; see the class remarks for the one-line commands to fetch them into `Temp/` (gitignored).
- `DxtBenchmarkTests` needs no external binaries and runs standalone.