### PR TITLE
Fix i18n inconsistencies and polish JA/EN wording across the board

### DIFF
--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
@@ -66,8 +66,6 @@ namespace KRT.VRCQuestTools.I18n
 
         internal string Maximum => GetText("Maximum");
 
-        internal string IncompatibleSDK => GetText("IncompatibleSDK");
-
         internal string TextureFormatHighQuality => GetText("TextureFormatHighQuality");
         internal string TextureFormatStandard => GetText("TextureFormatStandard");
         internal string TextureFormatHighCompression => GetText("TextureFormatHighCompression");
@@ -84,9 +82,7 @@ namespace KRT.VRCQuestTools.I18n
         internal string GenerateMobileTexturesTooltip => GetText("GenerateMobileTexturesTooltip");
         internal string SupportedShadersLabel => GetText("SupportedShadersLabel");
         internal string SaveToLabel => GetText("SaveToLabel");
-        internal string SelectButtonLabel => GetText("SelectButtonLabel");
         internal string ConvertButtonLabel => GetText("ConvertButtonLabel");
-        internal string AssignButtonLabel => GetText("AssignButtonLabel");
         internal string UpdateTexturesLabel => GetText("UpdateTexturesLabel");
         internal string AdvancedConverterSettingsLabel => GetText("AdvancedConverterSettingsLabel");
         internal string RemoveVertexColorLabel => GetText("RemoveVertexColorLabel");
@@ -96,7 +92,6 @@ namespace KRT.VRCQuestTools.I18n
         internal string MenuIconSettingsLabel => GetText("MenuIconSettingsLabel");
         internal string ResizeExpressionsMenuIconsLabel => GetText("ResizeExpressionsMenuIconsLabel");
         internal string ResizeExpressionsMenuIconsTooltip => GetText("ResizeExpressionsMenuIconsTooltip");
-        internal string CompressExpressionsMenuIconsLabel => GetText("CompressExpressionsMenuIconsLabel");
         internal string CompressExpressionsMenuIconsTooltip => GetText("CompressExpressionsMenuIconsTooltip");
         internal string AssignNetworkIdsLabel => GetText("AssignNetworkIdsLabel");
         internal string AssignNetworkIdsTooltip => GetText("AssignNetworkIdsTooltip");
@@ -108,14 +103,14 @@ namespace KRT.VRCQuestTools.I18n
         internal string EnableMaterialPreviewTooltip => GetText("EnableMaterialPreviewTooltip");
         internal string ForceMaterialPreviewEnableLabel => GetText("ForceMaterialPreviewEnableLabel");
         internal string ForceMaterialPreviewDisableLabel => GetText("ForceMaterialPreviewDisableLabel");
-        internal string ForceMaterialPreviewTooltip => GetText("ForceMaterialPreviewTooltip");
+        internal string ForceMaterialPreviewEnableTooltip => GetText("ForceMaterialPreviewEnableTooltip");
+        internal string ForceMaterialPreviewDisableTooltip => GetText("ForceMaterialPreviewDisableTooltip");
         internal string GeneratingTexturesDialogMessage => GetText("GeneratingTexturesDialogMessage");
         internal string AvatarConverterFailedDialogMessage => GetText("AvatarConverterFailedDialogMessage");
         internal string MaterialExceptionDialogMessage => GetText("MaterialExceptionDialogMessage");
         internal string AnimationClipExceptionDialogMessage => GetText("AnimationClipExceptionDialogMessage");
         internal string AnimatorControllerExceptionDialogMessage => GetText("AnimatorControllerExceptionDialogMessage");
         internal string InvalidReplacementMaterialExceptionDialogMessage => GetText("InvalidReplacementMaterialExceptionDialogMessage");
-        internal string InfoForNdmfConversion => GetText("InfoForNdmfConversion");
         internal string InfoForNdmfConversion2 => GetText("InfoForNdmfConversion2");
         internal string InfoForNdmfAutoConversion => GetText("InfoForNdmfAutoConversion");
         internal string PhysBoneSyncReminder => GetText("PhysBoneSyncReminder");
@@ -147,7 +142,6 @@ namespace KRT.VRCQuestTools.I18n
         internal string ManualConversionWarning => GetText("ManualConversionWarning");
         internal string ManualConvertButtonLabel => GetText("ManualConvertButtonLabel");
         internal string ManualConversionFoldoutLabel => GetText("ManualConversionFoldoutLabel");
-        internal string ConfirmationForUnityConstraints => GetText("ConfirmationForUnityConstraints");
         internal string ConfirmationForMAConvertConstraints => GetText("ConfirmationForMAConvertConstraints");
 
         // IMaterialConvertSettings
@@ -171,11 +165,8 @@ namespace KRT.VRCQuestTools.I18n
         internal string ToonStandardConvertSettingsFeaturesSpecularLabel => GetText("ToonStandardConvertSettingsFeaturesSpecularLabel");
         internal string ToonStandardConvertSettingsFeaturesMatcapLabel => GetText("ToonStandardConvertSettingsFeaturesMatcapLabel");
         internal string ToonStandardConvertSettingsFeaturesRimLightingLabel => GetText("ToonStandardConvertSettingsFeaturesRimLightingLabel");
-        internal string ToonStandardConvertSettingsFeaturesMode => GetText("ToonStandardConvertSettingsFeaturesMode");
         internal string ToonStandardConvertSettingsFeaturesModeOptIn => GetText("ToonStandardConvertSettingsFeaturesModeOptIn");
         internal string ToonStandardConvertSettingsFeaturesModeOptOut => GetText("ToonStandardConvertSettingsFeaturesModeOptOut");
-        internal string ToonStandardConvertSettingsMaskTextureSizeLimitLabel => GetText("ToonStandardConvertSettingsMaskTextureSizeLimitLabel");
-        internal string ToonStandardConvertSettingsMaskMobileTextureFormatLabel => GetText("ToonStandardConvertSettingsMaskMobileTextureFormatLabel");
         internal string AdditionalMaterialConvertSettingsTargetMaterialLabel => GetText("AdditionalMaterialConvertSettingsTargetMaterialLabel");
         internal string AdditionalMaterialConvertSettingsSelectMaterialLabel => GetText("AdditionalMaterialConvertSettingsSelectMaterialLabel");
         internal string MaterialConvertTypePopupLabelToonLit => GetText("MaterialConvertTypePopupLabelToonLit");
@@ -205,7 +196,6 @@ namespace KRT.VRCQuestTools.I18n
         // Remove PhysBones
         internal string SelectComponentsToKeep => GetText("SelectComponentsToKeep");
         internal string PhysBonesListTooltip => GetText("PhysBonesListTooltip");
-        internal string KeepAll => GetText("KeepAll");
         internal string PhysBonesWillBeRemovedAtRunTime => GetText("PhysBonesWillBeRemovedAtRunTime");
         internal string PhysBoneCollidersWillBeRemovedAtRunTime => GetText("PhysBoneCollidersWillBeRemovedAtRunTime");
         internal string ContactsWillBeRemovedAtRunTime => GetText("ContactsWillBeRemovedAtRunTime");
@@ -239,7 +229,6 @@ namespace KRT.VRCQuestTools.I18n
         internal string TextureCompressionLabel => GetText("TextureCompressionLabel");
         internal string TextureCompressionHelp => GetText("TextureCompressionHelp");
         internal string TextureCompressionButtonLabel => GetText("TextureCompressionButtonLabel");
-        internal string ApplyAllButtonLabel => GetText("ApplyAllButtonLabel");
         internal string ShowOnStartupLabel => GetText("ShowOnStartupLabel");
         internal string AllAppliedHelp => GetText("AllAppliedHelp");
 
@@ -247,7 +236,6 @@ namespace KRT.VRCQuestTools.I18n
         internal string GetUpdate => GetText("GetUpdate");
         internal string SeeChangelog => GetText("SeeChangelog");
         internal string SkipThisVersion => GetText("SkipThisVersion");
-        internal string NewVersionIsAvailable(string latestVersion) => GetText("NewVersionIsAvailable", latestVersion);
         internal string NewVersionHasBreakingChanges => GetText("NewVersionHasBreakingChanges");
 
         // Validations
@@ -299,7 +287,7 @@ namespace KRT.VRCQuestTools.I18n
         internal string MeshFlipperEditorEnabledOnPCLabel => GetText("MeshFlipperEditorEnabledOnPCLabel");
         internal string MeshFlipperEditorEnabledOnMobileLabel => GetText("MeshFlipperEditorEnabledOnMobileLabel");
         internal string MeshFlipperEditorEnabledOnPCWarning => GetText("MeshFlipperEditorEnabledOnPCWarning");
-        internal string MeshFlipperEditorEnabledOnMobileWarning => GetText("MeshFlipperEditorEnabledOnMobileWarning");
+        internal string MeshFlipperEditorBothSidesWarning => GetText("MeshFlipperEditorBothSidesWarning");
         internal string MeshFlipperEditorMaskTextureMissingError => GetText("MeshFlipperEditorMaskTextureMissingError");
         internal string MeshFlipperEditorMaskTextureNotReadableError => GetText("MeshFlipperEditorMaskTextureNotReadableError");
         internal string MeshFlipperMeshDirectionFlip => GetText("MeshFlipperMeshDirectionFlip");
@@ -336,7 +324,5 @@ namespace KRT.VRCQuestTools.I18n
         internal string LegacyPackageExceptionMessage(string packageName, string requiredVersion) => GetText("LegacyPackageExceptionMessage", packageName, requiredVersion);
         internal string BreakingPackageExceptionMessage(string packageName, string breakingVersion) => GetText("BreakingPackageExceptionMessage", packageName, breakingVersion);
 
-        // NDMF
-        internal string FeatureRequiresNdmf => GetText("FeatureRequiresNdmf");
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
@@ -221,7 +221,7 @@ namespace KRT.VRCQuestTools.I18n
         internal string GenerateButtonLabel => GetText("GenerateButtonLabel");
 
         // Unity Settings
-        internal string RecommendedUnitySettingsForAndroid => GetText("RecommendedUnitySettingsForAndroid");
+        internal string RecommendedUnitySettingsForMobile => GetText("RecommendedUnitySettingsForMobile");
         internal string AndroidBuildSupportButtonLabel => GetText("AndroidBuildSupportButtonLabel");
         internal string AndroidBuildSupportHelp => GetText("AndroidBuildSupportHelp");
         internal string IOSBuildSupportButtonLabel => GetText("IOSBuildSupportButtonLabel");

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
@@ -449,7 +449,7 @@ msgstr "Please choose a location to save the texture"
 msgid "GenerateButtonLabel"
 msgstr "Generate Metallic Smoothness"
 
-msgid "RecommendedUnitySettingsForAndroid"
+msgid "RecommendedUnitySettingsForMobile"
 msgstr "Recommended Settings for Mobile"
 
 msgid "AndroidBuildSupportHelp"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
@@ -49,9 +49,6 @@ msgstr "Fix"
 msgid "Maximum"
 msgstr "Maximum"
 
-msgid "IncompatibleSDK"
-msgstr "Incompatible VRChat SDK. Please report."
-
 msgid "TextureFormatHighQuality"
 msgstr "High Quality"
 
@@ -65,16 +62,16 @@ msgid "AvatarConverterSettingsEditorDescription"
 msgstr "Convert this avatar to be uploadable to the Mobile (Android, iOS) platform."
 
 msgid "AvatarConverterSettingsEditorDescriptionNDMF"
-msgstr "Convert this avatar to be uploadable to the Mobile (Android, iOS) platform when the target platform is Mobile (Android, iOS)."
+msgstr "When the build target is Mobile (Android, iOS), convert this avatar so it can be uploaded to the platform."
 
 msgid "ExitPlayModeToEdit"
 msgstr "Exit play mode to edit."
 
 msgid "BeginConvertSettingsButtonLabel"
-msgstr "Begin Converter Settings"
+msgstr "Begin Conversion Setup"
 
 msgid "BeginConvertSettingsButtonDescription"
-msgstr "This will add following components."
+msgstr "This will add the following components."
 
 msgid "AvatarLabel"
 msgstr "Avatar"
@@ -83,22 +80,16 @@ msgid "GenerateMobileTexturesLabel"
 msgstr "Generate Textures for Mobile"
 
 msgid "GenerateMobileTexturesTooltip"
-msgstr "By generating new textures which applying material's parameters not only main textures, get closer to PC version of the avatar"
+msgstr "Generate new textures that apply material parameters beyond just the main texture, to bring the appearance closer to the PC version of the avatar."
 
 msgid "SupportedShadersLabel"
 msgstr "Supported Shaders"
 
 msgid "SaveToLabel"
-msgstr "Folder to Save"
-
-msgid "SelectButtonLabel"
-msgstr "Select"
+msgstr "Save Folder"
 
 msgid "ConvertButtonLabel"
 msgstr "Convert"
-
-msgid "AssignButtonLabel"
-msgstr "Assign"
 
 msgid "UpdateTexturesLabel"
 msgstr "Update Converted Mobile Textures"
@@ -111,7 +102,7 @@ msgstr "Remove Vertex Color from Meshes"
 
 msgid "RemoveVertexColorTooltip"
 msgstr "Usually you don't have to disable this option. You can disable this option to prevent unexpected behavior when you are using special shaders which require vertex colors in PC avatars.\n"
-"Restore from the avatar's \"VertexColorRemover\" component if vertex color is accidentally removed."
+"This process only applies to a duplicated mesh and does not affect the original mesh."
 
 msgid "RemoveExtraMaterialSlotsLabel"
 msgstr "Remove Extra Material Slots"
@@ -128,9 +119,6 @@ msgstr "Resize Menu Icons"
 msgid "ResizeExpressionsMenuIconsTooltip"
 msgstr "Resize expressions menu icons on mobile build target."
 
-msgid "CompressExpressionsMenuIconsLabel"
-msgstr "Compress Menu Icons"
-
 msgid "CompressExpressionsMenuIconsTooltip"
 msgstr "Compress expressions menu icons if they are not compressed."
 
@@ -144,7 +132,7 @@ msgid "AnimationOverrideLabel"
 msgstr "Animation Override"
 
 msgid "AnimationOverrideTooltip"
-msgstr "Convert Animator Controllers with Animator Override Controller's animations."
+msgstr "Convert Animator Controllers using the animations specified in the Animator Override Controller."
 
 msgid "NdmfPhaseLabel"
 msgstr "NDMF Phase to Convert"
@@ -164,8 +152,11 @@ msgstr "Enable temporary preview"
 msgid "ForceMaterialPreviewDisableLabel"
 msgstr "Disable temporary preview"
 
-msgid "ForceMaterialPreviewTooltip"
-msgstr "Temporarily enable material preview using NDMF preview."
+msgid "ForceMaterialPreviewEnableTooltip"
+msgstr "Temporarily enable material conversion preview via NDMF Preview."
+
+msgid "ForceMaterialPreviewDisableTooltip"
+msgstr "Disable the temporarily enabled material conversion preview via NDMF Preview."
 
 msgid "GeneratingTexturesDialogMessage"
 msgstr "Generating textures..."
@@ -185,32 +176,29 @@ msgstr "An error occurred when converting Animator Controllers. Aborted."
 msgid "InvalidReplacementMaterialExceptionDialogMessage"
 msgstr "The replacement material is not allowed for mobile avatars. Aborted."
 
-msgid "InfoForNdmfConversion"
-msgstr "You can non-destructively convert the avatar at build-time when the project has Non-Destructive Modular Framework (NDMF) package. Please use the Avatar Builder to avoid VRChat SDK limitation."
-
 msgid "InfoForNdmfConversion2"
 msgstr "You can non-destructively convert the avatar at build-time when the project has Non-Destructive Modular Framework (NDMF) package. Now you can also upload the avatar directly from VRChat SDK Control Panel."
 
 msgid "InfoForNdmfAutoConversion"
-msgstr "This avatar will be automatically converted for the mobile platform at build time (non-destructive). You can upload it as usual from the VRChat SDK Control Panel."
+msgstr "When the build target is Mobile, this avatar will be automatically converted (non-destructive) at build time. You can upload it as usual from the VRChat SDK Control Panel."
 
 msgid "PhysBoneSyncReminder"
 msgstr "To synchronize PhysBones between PC and Mobile, please upload the non-converted avatar for PC."
 
 msgid "WarningForPerformance"
 msgstr "Estimated performance rating is Very Poor, but you can upload the converted avatar for Mobile platform.\n"
-"Mobile users will see its imposter or fallback avatar by default. However, they can see the avatar by changing \"Avatar Display\" setting (as known as \"Show Avatar\")."
+"Mobile users will see its imposter or fallback avatar by default. However, they can see the avatar by changing the \"Avatar Display\" setting (also known as \"Show Avatar\")."
 
 msgid "WarningForAppearance"
-msgstr "Texture's transparency doesn't make any effects, so this will be an issue for facial expression. In this case, please take steps by yourself (for example, by editing animation clips or deleting problematic meshes).\n"
-"You should check converted avatar's appearance on PC by uploading with another Blueprint ID or using Avatars 3.0 local testing."
+msgstr "Texture transparency has no effect, so this may cause issues with facial expressions. In that case, you'll need to address it yourself (for example, by editing animation clips or removing the problematic meshes).\n"
+"You should check the converted avatar's appearance on PC by uploading with another Blueprint ID or using Avatars 3.0 local testing."
 
 msgid "WarningForUnsupportedShaders"
-msgstr "Following materials are using unsupported shaders. Textures might not properly be generated.\n"
-"Disabling \"Generate Textures for Mobile\" option changes only shader."
+msgstr "The following materials are using unsupported shaders. Textures might not be generated correctly.\n"
+"Disabling the \"Generate Textures for Mobile\" option only changes the shader."
 
 msgid "AlertForComponents"
-msgstr "Following unsupported components will be removed. Check avatar features after conversion."
+msgstr "The following unsupported components will be removed. Check avatar features after conversion."
 
 msgid "AlertForDynamicBoneConversion"
 msgstr "VRCQuestTools doesn't convert Dynamic Bones to PhysBones. Please set up PhysBones before converting the avatar."
@@ -228,10 +216,10 @@ msgid "AlertForAaoTraceAndOptimize"
 msgstr "Adding an AAO Trace and Optimize component automatically optimizes the avatar."
 
 msgid "AlertForAvatarDynamicsPerformance"
-msgstr "Avatar Dynamics (PhysBones and Contacts) performance rating will be \"Very Poor\", so components will be removed even if you upload to Mobile. Please keep \"Poor\" rating in avatar dynamics categories."
+msgstr "Avatar Dynamics (PhysBones and Contacts) performance rating will be \"Very Poor\", so components will be removed even if you upload to Mobile. Please reduce components so the Avatar Dynamics performance rating stays at \"Poor\" or better."
 
 msgid "ErrorForPrefabStage"
-msgstr "Can't convert the avatar in prefab mode. Please go back to a scene from prefab mode."
+msgstr "Cannot convert the avatar in prefab mode. Please go back to a scene from prefab mode."
 
 msgid "ExitPrefabStageButtonLabel"
 msgstr "Back to Scene"
@@ -255,16 +243,16 @@ msgid "AvatarConverterRemoveAvatarDynamicsTooltip"
 msgstr "Keep avatar dynamics components which are selected in \"Avatar Dynamics Settings\". Unselected components will be removed during conversion."
 
 msgid "AvatarConverterPhysBonesTooltip"
-msgstr "Set PhysBones to keep while conversion."
+msgstr "Set PhysBones to keep during conversion."
 
 msgid "AvatarConverterPhysBoneCollidersTooltip"
-msgstr "Set PhysBoneColliders to keep while conversion."
+msgstr "Set PhysBoneColliders to keep during conversion."
 
 msgid "AvatarConverterContactsTooltip"
-msgstr "Set ContactSenders and ContactReceivers to keep while conversion."
+msgstr "Set ContactSenders and ContactReceivers to keep during conversion."
 
 msgid "ManualConversionWarning"
-msgstr "When converting manually, non-destructive components other than MA Merge Animator are not considered. Unexpected issues may arise in the behavior after combining."
+msgstr "When converting manually, non-destructive components other than MA Merge Animator are not considered. Unexpected issues may occur in the resulting behavior after combining."
 
 msgid "ManualConvertButtonLabel"
 msgstr "Convert"
@@ -272,17 +260,14 @@ msgstr "Convert"
 msgid "ManualConversionFoldoutLabel"
 msgstr "Manual Conversion"
 
-msgid "ConfirmationForUnityConstraints"
-msgstr "Manual conversion will remove Unity Constraints. You can non-destructively convert them to VRChat Constraints by adding a MA Convert Constraints component to the avatar and using Avatar Builder to upload. Do you really want to continue conversion?"
-
 msgid "ConfirmationForMAConvertConstraints"
-msgstr "You can non-destructively convert Unity Constraints to VRChat Constraints by adding a MA Convert Constraints. Do you want to add the component before conversion?"
+msgstr "You can non-destructively convert Unity Constraints to VRChat Constraints by adding an MA Convert Constraints component. Do you want to add the component before conversion?"
 
 msgid "IMaterialConvertSettingsTexturesSizeLimitLabel"
 msgstr "Max Size"
 
 msgid "IMaterialConvertSettingsMobileTextureFormatLabel"
-msgstr "Compression"
+msgstr "Compression Format"
 
 msgid "IMaterialConvertSettingsMainTextureSettingsLabel"
 msgstr "Main Texture Settings"
@@ -291,7 +276,7 @@ msgid "IMaterialConvertSettingsMaskTextureSettingsLabel"
 msgstr "Mask Texture Settings"
 
 msgid "IMaterialConvertSettingsMatCapTextureSettingsLabel"
-msgstr "MatCap Texture Settings"
+msgstr "MatCap Settings"
 
 msgid "IMaterialConvertSettingsMainTextureBrightnessLabel"
 msgstr "Brightness"
@@ -306,7 +291,7 @@ msgid "MatCapLitConvertSettingsMatCapTextureLabel"
 msgstr "MatCap Texture"
 
 msgid "MatCapLitConvertSettingsMatCapTextureWarning"
-msgstr "Set MatCap texture."
+msgstr "Set the MatCap texture."
 
 msgid "ToonStandardConvertSettingsFallbackShadowRampLabel"
 msgstr "Fallback Shading"
@@ -318,7 +303,7 @@ msgid "ToonStandardConvertSettingsCustomFallbackShadowRampLabel"
 msgstr "Shadow Ramp"
 
 msgid "ToonStandardConvertSettingsFeaturesLabel"
-msgstr "Features"
+msgstr "Feature Settings"
 
 msgid "ToonStandardConvertSettingsFeaturesNormalMapLabel"
 msgstr "Normal Map"
@@ -333,25 +318,16 @@ msgid "ToonStandardConvertSettingsFeaturesSpecularLabel"
 msgstr "Specular"
 
 msgid "ToonStandardConvertSettingsFeaturesMatcapLabel"
-msgstr "Matcap"
+msgstr "MatCap"
 
 msgid "ToonStandardConvertSettingsFeaturesRimLightingLabel"
 msgstr "Rim Lighting"
-
-msgid "ToonStandardConvertSettingsFeaturesMode"
-msgstr "Mode"
 
 msgid "ToonStandardConvertSettingsFeaturesModeOptIn"
 msgstr "Opt-In"
 
 msgid "ToonStandardConvertSettingsFeaturesModeOptOut"
 msgstr "Opt-Out"
-
-msgid "ToonStandardConvertSettingsMaskTextureSizeLimitLabel"
-msgstr "Mask Textures Size Limit"
-
-msgid "ToonStandardConvertSettingsMaskMobileTextureFormatLabel"
-msgstr "Mask Compression Format"
 
 msgid "AdditionalMaterialConvertSettingsTargetMaterialLabel"
 msgstr "Target Material"
@@ -372,7 +348,7 @@ msgid "MaterialConvertTypePopupLabelMaterialReplace"
 msgstr "Material Replacement"
 
 msgid "MaterialReplaceSettingsMaterialLabel"
-msgstr "Replaced Material"
+msgstr "Replacement Material"
 
 msgid "MaterialReplaceSettingsMaterialTooltip"
 msgstr "Target material will be replaced by this material."
@@ -387,7 +363,7 @@ msgid "MissingRemoverConfirmationMessage"
 msgstr "Remove \"missing\" components from {0}."
 
 msgid "UnpackPrefabMessage"
-msgstr "This also executes \"Unpack Prefab\" operation."
+msgstr "This also executes the \"Unpack Prefab\" operation."
 
 msgid "MissingRemoverOnBuildDialogMessage"
 msgstr "{0} has \"missing\" components. Would you like to continue building the avatar without such components?"
@@ -408,16 +384,13 @@ msgid "NoUnsupportedComponentsMessage"
 msgstr "There are no unsupported components in {0}."
 
 msgid "UnsupportedRemoverConfirmationMessage"
-msgstr "Remove following unsupported components from {0}."
+msgstr "Remove the following unsupported components from {0}."
 
 msgid "SelectComponentsToKeep"
 msgstr "Select components to keep."
 
 msgid "PhysBonesListTooltip"
 msgstr "The list of components and their root transforms."
-
-msgid "KeepAll"
-msgstr "Keep All"
 
 msgid "PhysBonesWillBeRemovedAtRunTime"
 msgstr "You can upload this avatar to Mobile, but all PhysBone components will be removed. Please reduce PhysBone components."
@@ -429,10 +402,10 @@ msgid "ContactsWillBeRemovedAtRunTime"
 msgstr "You can upload this avatar to Mobile, but all ContactReceiver and ContactSender components will be removed. Please reduce ContactReceiver and ContactSender components."
 
 msgid "PhysBonesTransformsShouldBeReduced"
-msgstr "You can upload this avatar to Mobile, but all PhysBone components will be removed. Please reduce VRCPhysBone components or number of transforms in hierarchy under VRCPhysBone components."
+msgstr "You can upload this avatar to Mobile, but all PhysBone components will be removed. Please reduce the number of PhysBone components or the number of transforms in the hierarchy under them."
 
 msgid "PhysBonesCollisionCheckCountShouldBeReduced"
-msgstr "You can upload this avatar to Mobile, but all PhysBoneCollider components will be removed. Please reduce collision check count between VRCPhysBone components and VRCPhysBoneCollider components."
+msgstr "You can upload this avatar to Mobile, but all PhysBoneCollider components will be removed. Please reduce the collision check count between PhysBone components and PhysBoneCollider components."
 
 msgid "PhysBonesShouldHaveNetworkID"
 msgstr "To properly synchronize PhysBones, PhysBones must have same Network ID between PC and Mobile. Please assign Network IDs to both of PC version and Mobile version with Network ID Utility of VRCSDK, then re-upload both."
@@ -471,13 +444,13 @@ msgid "SaveFileDialogTitle"
 msgstr "Save {0}"
 
 msgid "SaveFileDialogMessage"
-msgstr "Please enter a file name to save the texture to"
+msgstr "Please choose a location to save the texture"
 
 msgid "GenerateButtonLabel"
 msgstr "Generate Metallic Smoothness"
 
 msgid "RecommendedUnitySettingsForAndroid"
-msgstr "Recommended Settings for Android"
+msgstr "Recommended Settings for Mobile"
 
 msgid "AndroidBuildSupportHelp"
 msgstr "Android Build Support is required to upload avatars for Android platform."
@@ -495,13 +468,10 @@ msgid "TextureCompressionLabel"
 msgstr "Android Texture Compression"
 
 msgid "TextureCompressionHelp"
-msgstr "ASTC improves Android texture quality in exchange for long compression time"
+msgstr "ASTC improves Android texture quality at the cost of longer compression times."
 
 msgid "TextureCompressionButtonLabel"
 msgstr "Set texture compression to ASTC"
-
-msgid "ApplyAllButtonLabel"
-msgstr "Apply All Settings"
 
 msgid "ShowOnStartupLabel"
 msgstr "Show on startup"
@@ -518,11 +488,8 @@ msgstr "Changelog"
 msgid "SkipThisVersion"
 msgstr "Skip This"
 
-msgid "NewVersionIsAvailable"
-msgstr "New version {0} is available."
-
 msgid "NewVersionHasBreakingChanges"
-msgstr "This version might have breaking changes about compatibility."
+msgstr "This version may include breaking changes that affect compatibility."
 
 msgid "MissingScripts"
 msgstr "The following objects have \"Missing\" components. Please check for assets or packages you forgot to import."
@@ -531,7 +498,7 @@ msgid "ExperimentalComponentWarning"
 msgstr "This component is an experimental feature."
 
 msgid "AvatarRootComponentMustBeOnAvatarRoot"
-msgstr "This component must be attached to VRC_AvatarDescriptor GameObject."
+msgstr "This component must be attached to the GameObject that has a VRC_AvatarDescriptor."
 
 msgid "VertexColorRemoverEditorDescription"
 msgstr "Vertex color is automatically removed from this GameObject's mesh."
@@ -546,16 +513,16 @@ msgid "ConvertedAvatarEditorMessage"
 msgstr "This component indicates the avatar was converted by VRCQuestTools."
 
 msgid "ConvertedAvatarEditorNDMFMessage"
-msgstr "Components which are not supported on Mobile will be removed in NDMF optimization phase."
+msgstr "Components that are not supported on Mobile will be removed during the NDMF optimization phase."
 
 msgid "NetworkIDAssignerEditorDescription"
-msgstr "Assign Network IDs to the avatar's components such as PhysBones in build process. IDs are determined by hash values of hierarchy paths from the avatar root."
+msgstr "Assigns Network IDs to the avatar's components, such as PhysBones, during the build process. IDs are determined by hash values of the hierarchy paths from the avatar root."
 
 msgid "PlatformTargetSettingsEditorDescription"
-msgstr "Components are enforced to use a specific platform settings in NDMF build process."
+msgstr "Components are forced to use settings for a specific platform during the NDMF build process."
 
 msgid "PlatformTargetSettingsIsRequiredToEnforcePlatform"
-msgstr "To override the platform for this component, add a PlatformTargetSettings component to the avatar root object."
+msgstr "To override the platform for this component, add a Platform Target Settings component to the avatar root object."
 
 msgid "ComponentRequiresNdmf"
 msgstr "Non-Destructive Modular Framework (NDMF) is required."
@@ -564,28 +531,28 @@ msgid "BuildTargetLabel"
 msgstr "Build Target"
 
 msgid "BuildTargetTooltip"
-msgstr "Select build target platform. Use Unity's target platform when Auto is selected."
+msgstr "Select the build target platform. Use Unity's target platform when Auto is selected."
 
 msgid "PlatformComponentRemoverEditorDescription"
-msgstr "Components will be removed on build for unselected build targets."
+msgstr "Components will be removed at build time for unselected build targets."
 
 msgid "PlatformComponentRemoverEditorComponentSettingsLabel"
 msgstr "Components to Keep"
 
 msgid "PlatformComponentRemoverEditorComponentSettingsTooltip"
-msgstr "Select platform to keep components."
+msgstr "Select the platforms on which to keep these components."
 
 msgid "PlatformComponentRemoverEditorCheckboxPCTooltip"
-msgstr "Keep selected components on PC build."
+msgstr "Keep the selected components in the PC build."
 
 msgid "PlatformComponentRemoverEditorCheckboxMobileTooltip"
-msgstr "Keep selected components on Mobile build."
+msgstr "Keep the selected components in the Mobile build."
 
 msgid "ComponentLabel"
 msgstr "Component"
 
 msgid "PlatformGameObjectRemoverEditorDescription"
-msgstr "This GameObject will be removed on build for unselected build targets."
+msgstr "This GameObject will be removed at build time for unselected build targets."
 
 msgid "PlatformGameObjectRemoverEditorKeepOnPCLabel"
 msgstr "Keep on PC"
@@ -594,7 +561,7 @@ msgid "PlatformGameObjectRemoverEditorKeepOnMobileLabel"
 msgstr "Keep on Mobile"
 
 msgid "MeshFlipperEditorDescription"
-msgstr "Duplicate the polygons of a mesh to make it double-sided. Or flip the faces."
+msgstr "Duplicate the polygons of a mesh to make it double-sided, or flip the faces to reverse them."
 
 msgid "MeshFlipperEditorDirectionLabel"
 msgstr "Mesh Direction"
@@ -618,9 +585,9 @@ msgid "MeshFlipperEditorProcessingPhaseLabel"
 msgstr "NDMF Phase"
 
 msgid "MeshFlipperEditorEnabledOnPCWarning"
-msgstr "It may be possible to achieve this with shader settings without using this component."
+msgstr "You may be able to achieve the same result using shader settings instead of this component."
 
-msgid "MeshFlipperEditorEnabledOnMobileWarning"
+msgid "MeshFlipperEditorBothSidesWarning"
 msgstr "The polygon count for this mesh will increase."
 
 msgid "MeshFlipperEditorMaskTextureMissingError"
@@ -636,7 +603,7 @@ msgid "MeshFlipperMeshDirectionDoubleSide"
 msgstr "Double Sided"
 
 msgid "MaterialSwapEditorDescription"
-msgstr "Replace materials of this avatar for mobile platform build."
+msgstr "Replace this avatar's materials for the Mobile platform build."
 
 msgid "MaterialSwapEditorMaterialMappingsLabel"
 msgstr "Material Mappings"
@@ -651,19 +618,19 @@ msgid "MaterialSwapEditorSelectMaterialLabel"
 msgstr "Select from children"
 
 msgid "MaterialSwapEditorReplacementMaterialError"
-msgstr "This material's shader is not allowed for mobile avatars."
+msgstr "This material's shader is not allowed for Mobile avatars."
 
 msgid "MaterialConversionSettingsEditorDescription"
-msgstr "Convert materials for mobile platform."
+msgstr "Convert materials for the Mobile platform."
 
 msgid "MaterialConversionSettingsEditorDefaultConversionWarning"
-msgstr "Place this component to the avatar's root object in order to use disabled settings. But VQT Avatar Converter Settings takes priority."
+msgstr "Place this component alone on the avatar's root object, or use VQT Avatar Converter Settings instead (in that case, its settings take priority)."
 
 msgid "MaterialConversionSettingsEditorConversionSettingsLabel"
 msgstr "Material Conversion Settings"
 
 msgid "MenuIconResizerEditorDescription"
-msgstr "Resize menu icons in the avatar's expressions menu."
+msgstr "Resize menu icons in the avatar's Expressions Menu."
 
 msgid "MenuIconResizerEditorResizeModePCLabel"
 msgstr "Resize Mode (PC)"
@@ -684,16 +651,13 @@ msgid "BuildAndTestFailed"
 msgstr "Failed to build avatar: {0}"
 
 msgid "BuildAndTestSucceeded"
-msgstr "Succeeded to build the avatar {0} for local testing."
+msgstr "Successfully built the avatar {0} for local testing."
 
 msgid "LegacyPackageExceptionMessage"
-msgstr "Current version of {0} is not supported. Update {0} to {1} or later."
+msgstr "The current version of {0} is not supported. Update {0} to {1} or later."
 
 msgid "BreakingPackageExceptionMessage"
-msgstr "Current version of {0} is not supported. Update VRCQuestTools or downgrade {0} to earlier than {1}."
-
-msgid "FeatureRequiresNdmf"
-msgstr "Non-Destructive Modular Framework is required."
+msgstr "The current version of {0} is not supported. Update VRCQuestTools or downgrade {0} to a version earlier than {1}."
 
 msgid "NDMF:RemovedUnsupportedComponentTitle"
 msgstr "Removed Unsupported Component"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
@@ -449,7 +449,7 @@ msgstr "テクスチャの保存先を選択してください"
 msgid "GenerateButtonLabel"
 msgstr "Metallic Smoothness を生成"
 
-msgid "RecommendedUnitySettingsForAndroid"
+msgid "RecommendedUnitySettingsForMobile"
 msgstr "Mobile 用の推奨設定"
 
 msgid "AndroidBuildSupportHelp"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
@@ -49,9 +49,6 @@ msgstr "修正"
 msgid "Maximum"
 msgstr "最大"
 
-msgid "IncompatibleSDK"
-msgstr "非対応の VRChat SDK です。報告をお願いします。"
-
 msgid "TextureFormatHighQuality"
 msgstr "高品質"
 
@@ -91,14 +88,8 @@ msgstr "対応シェーダー"
 msgid "SaveToLabel"
 msgstr "保存先フォルダ"
 
-msgid "SelectButtonLabel"
-msgstr "選択"
-
 msgid "ConvertButtonLabel"
 msgstr "変換"
-
-msgid "AssignButtonLabel"
-msgstr "割り当て"
 
 msgid "UpdateTexturesLabel"
 msgstr "変換後のMobile用テクスチャを更新"
@@ -111,7 +102,7 @@ msgstr "メッシュから頂点カラーを削除"
 
 msgid "RemoveVertexColorTooltip"
 msgstr "通常このオプションを無効にする必要はありません。PC用アバターで頂点カラーの必要な特別なシェーダーを使用している場合は、誤動作を防ぐためにこのオプションを無効にできます。\n"
-"誤って頂点カラーを削除した場合は、アバターの\"VertexColorRemover\"コンポーネントで復元できます。"
+"この処理は複製したメッシュに対してのみ行われ、元のメッシュには影響しません。"
 
 msgid "RemoveExtraMaterialSlotsLabel"
 msgstr "余分なマテリアルスロットを削除する"
@@ -127,9 +118,6 @@ msgstr "メニューのアイコンをリサイズする"
 
 msgid "ResizeExpressionsMenuIconsTooltip"
 msgstr "MobileビルドターゲットでExpressions Menuのアイコンをリサイズします。"
-
-msgid "CompressExpressionsMenuIconsLabel"
-msgstr "メニューアイコンを圧縮"
 
 msgid "CompressExpressionsMenuIconsTooltip"
 msgstr "Expressions Menuのアイコンが圧縮されていなければ圧縮します。"
@@ -164,8 +152,11 @@ msgstr "一時的なプレビューを有効化"
 msgid "ForceMaterialPreviewDisableLabel"
 msgstr "一時的なプレビューを無効化"
 
-msgid "ForceMaterialPreviewTooltip"
+msgid "ForceMaterialPreviewEnableTooltip"
 msgstr "NDMF プレビューによるマテリアル変換を一時的に有効化します。"
+
+msgid "ForceMaterialPreviewDisableTooltip"
+msgstr "一時的に有効化した NDMF プレビューによるマテリアル変換を無効化します。"
 
 msgid "GeneratingTexturesDialogMessage"
 msgstr "テクスチャを生成中"
@@ -177,7 +168,7 @@ msgid "MaterialExceptionDialogMessage"
 msgstr "マテリアルの変換中にエラーが発生しました。変換を中止します。"
 
 msgid "AnimationClipExceptionDialogMessage"
-msgstr "アニメーションの変換中にエラーが発生しました。変換を中止します。"
+msgstr "アニメーションクリップの変換中にエラーが発生しました。変換を中止します。"
 
 msgid "AnimatorControllerExceptionDialogMessage"
 msgstr "Animator Controllerの変換中にエラーが発生しました。変換を中止します。"
@@ -185,14 +176,11 @@ msgstr "Animator Controllerの変換中にエラーが発生しました。変�
 msgid "InvalidReplacementMaterialExceptionDialogMessage"
 msgstr "置換先マテリアルが Mobile アバターでは許可されていません。変換を中止します。"
 
-msgid "InfoForNdmfConversion"
-msgstr "プロジェクトに Non-Destructive Modular Framework (NDMF) パッケージがある場合、アバターのビルド時に非破壊的に変換をすることができます。 VRChat SDK による制限を回避するため、専用の Avatar Builder を使用してください。"
-
 msgid "InfoForNdmfConversion2"
 msgstr "プロジェクトに Non-Destructive Modular Framework (NDMF) パッケージがある場合、アバターのビルド時に非破壊的に変換をすることができます。 VRChat SDK コントロールパネルから直接アップロードすることもできます。"
 
 msgid "InfoForNdmfAutoConversion"
-msgstr "このアバターはビルド時に自動的に非破壊変換されます。そのままVRChat SDKコントロールパネルからアップロードしてください。"
+msgstr "ビルドターゲットが Mobile の場合、このアバターはビルド時に自動的に非破壊変換されます。そのまま VRChat SDK コントロールパネルからアップロードできます。"
 
 msgid "PhysBoneSyncReminder"
 msgstr "PCとMobileでPhysBoneを同期させるために、変換前のアバターをPC向けにアップロードしてください。"
@@ -202,7 +190,7 @@ msgstr "変換後のアバターの推定パフォーマンスランクは Very 
 "デフォルトではインポスターまたはフォールバックアバターが表示されますが、見る側が「アバターの表示」設定を個別に変更することで表示できます。 (Show Avatar 操作)"
 
 msgid "WarningForAppearance"
-msgstr "テクスチャの透過が反映されないため、頬染めなどの表現に問題がある場合があります。そのような場合はアニメーション編集やメッシュ削除などの方法で対策する必要があります。\n"
+msgstr "テクスチャの透過が反映されないため、表情の表現に問題が生じます。その場合はアニメーション編集やメッシュ削除などの方法で対策してください。\n"
 "別の Blueprint ID でのアップロードや Avatars 3.0 のローカルテストを使用して、変換後のアバターの見た目をPCで確認することをお勧めします。"
 
 msgid "WarningForUnsupportedShaders"
@@ -264,16 +252,13 @@ msgid "AvatarConverterContactsTooltip"
 msgstr "変換時に残しておく ContactSender と ContactReceiver を選択します。"
 
 msgid "ManualConversionWarning"
-msgstr "手動で変換する場合 MA Merge Animator 以外の非破壊コンポーネントを考慮しません。組み合わせた後の動作に予期せぬ問題があるかもしれません。"
+msgstr "手動で変換する場合、MA Merge Animator 以外の非破壊コンポーネントを考慮しません。組み合わせた後の動作に予期せぬ問題があるかもしれません。"
 
 msgid "ManualConvertButtonLabel"
 msgstr "変換する"
 
 msgid "ManualConversionFoldoutLabel"
 msgstr "手動変換"
-
-msgid "ConfirmationForUnityConstraints"
-msgstr "手動変換では Unity Constraints が削除されます。アバターに MA Convert Constraints コンポーネントを追加し Avatar Builder を使用してアップロードすることで VRChat Constraints に非破壊的に変換することができますが、本当に変換を続行しますか？"
 
 msgid "ConfirmationForMAConvertConstraints"
 msgstr "MA Convert Constraints コンポーネントを追加すると Unity Constraints を VRChat Constraints に非破壊的に変換することができます。変換前にコンポーネントを追加しますか？"
@@ -303,16 +288,16 @@ msgid "ToonLitConvertSettingsGenerateShadowFromNormalMapLabel"
 msgstr "ノーマルマップから影を生成する"
 
 msgid "MatCapLitConvertSettingsMatCapTextureLabel"
-msgstr "MatCap テクスチャ"
+msgstr "マットキャップテクスチャ"
 
 msgid "MatCapLitConvertSettingsMatCapTextureWarning"
-msgstr "MatCap テクスチャを設定してください。"
+msgstr "マットキャップテクスチャを設定してください。"
 
 msgid "ToonStandardConvertSettingsFallbackShadowRampLabel"
 msgstr "影のフォールバック"
 
 msgid "ToonStandardConvertSettingsGenerateShadowRampLabel"
-msgstr "影の設定を生成する"
+msgstr "Shadow Ramp を生成する"
 
 msgid "ToonStandardConvertSettingsCustomFallbackShadowRampLabel"
 msgstr "Shadow Ramp"
@@ -338,20 +323,11 @@ msgstr "マットキャップ"
 msgid "ToonStandardConvertSettingsFeaturesRimLightingLabel"
 msgstr "リムライト"
 
-msgid "ToonStandardConvertSettingsFeaturesMode"
-msgstr "モード"
-
 msgid "ToonStandardConvertSettingsFeaturesModeOptIn"
 msgstr "オプトイン"
 
 msgid "ToonStandardConvertSettingsFeaturesModeOptOut"
 msgstr "オプトアウト"
-
-msgid "ToonStandardConvertSettingsMaskTextureSizeLimitLabel"
-msgstr "マスクの最大サイズ"
-
-msgid "ToonStandardConvertSettingsMaskMobileTextureFormatLabel"
-msgstr "マスクの圧縮形式"
 
 msgid "AdditionalMaterialConvertSettingsTargetMaterialLabel"
 msgstr "対象マテリアル"
@@ -416,9 +392,6 @@ msgstr "削除せずに残すコンポーネントを選択してください。
 msgid "PhysBonesListTooltip"
 msgstr "コンポーネントと Root Transform の一覧"
 
-msgid "KeepAll"
-msgstr "すべて残す"
-
 msgid "PhysBonesWillBeRemovedAtRunTime"
 msgstr "Mobile用にアップロードできますが、すべての PhysBone が削除されます。 PhysBone の数を減らしてください。"
 
@@ -426,7 +399,7 @@ msgid "PhysBoneCollidersWillBeRemovedAtRunTime"
 msgstr "Mobile用にアップロードできますが、すべての PhysBoneCollider が削除されます。 PhysBoneCollider の数を減らしてください。"
 
 msgid "ContactsWillBeRemovedAtRunTime"
-msgstr "Mobile用にアップロードできますが、すべての ContactReceiver と ContactSender が削除されます。数を減らしてください。"
+msgstr "Mobile用にアップロードできますが、すべての ContactReceiver と ContactSender が削除されます。 ContactReceiver と ContactSender の数を減らしてください。"
 
 msgid "PhysBonesTransformsShouldBeReduced"
 msgstr "Mobile用にアップロードできますが、すべての PhysBone が削除されます。 PhysBone の数を減らすか、PhysBone の子オブジェクトの数を減らしてください。"
@@ -441,7 +414,7 @@ msgid "AlertForMultiplePhysBones"
 msgstr "1つの GameObject に複数の PhysBone があります。Mobile 用に PhysBone を削除した場合、PC と Mobile で正しく同期しない可能性があります。"
 
 msgid "EstimatedPerformanceStats"
-msgstr "推定パフォーマンスランク"
+msgstr "推定パフォーマンス統計"
 
 msgid "DeleteUnselectedComponents"
 msgstr "選択していないコンポーネントを削除"
@@ -477,7 +450,7 @@ msgid "GenerateButtonLabel"
 msgstr "Metallic Smoothness を生成"
 
 msgid "RecommendedUnitySettingsForAndroid"
-msgstr "Android 用の推奨設定"
+msgstr "Mobile 用の推奨設定"
 
 msgid "AndroidBuildSupportHelp"
 msgstr "Android 向けにアバターをアップロードするには Android Build Support が必要です。"
@@ -498,10 +471,7 @@ msgid "TextureCompressionHelp"
 msgstr "ASTCを使用するとAndroid用のテクスチャ圧縮に時間がかかる代わりに画質が向上します。"
 
 msgid "TextureCompressionButtonLabel"
-msgstr "ASTCでテクスチャを圧縮"
-
-msgid "ApplyAllButtonLabel"
-msgstr "すべての設定を適用"
+msgstr "テクスチャ圧縮をASTCに設定"
 
 msgid "ShowOnStartupLabel"
 msgstr "起動時に表示"
@@ -518,11 +488,8 @@ msgstr "変更履歴"
 msgid "SkipThisVersion"
 msgstr "スキップ"
 
-msgid "NewVersionIsAvailable"
-msgstr "新しいバージョン {0} があります。"
-
 msgid "NewVersionHasBreakingChanges"
-msgstr "このバージョンには互換性に関する重要な変更がある可能性があります。"
+msgstr "このバージョンには互換性を損なう破壊的な変更が含まれている可能性があります。"
 
 msgid "MissingScripts"
 msgstr "以下のオブジェクトには \"Missing\" 状態のコンポーネントがあります。インポートし忘れたアセットやパッケージがないか確認してください。"
@@ -585,7 +552,7 @@ msgid "ComponentLabel"
 msgstr "コンポーネント"
 
 msgid "PlatformGameObjectRemoverEditorDescription"
-msgstr "チェックマークを入れていないビルドターゲットでは、このGameObjectをビルド時に削除します。"
+msgstr "チェックを入れていないビルドターゲットでは、このGameObjectをビルド時に削除します。"
 
 msgid "PlatformGameObjectRemoverEditorKeepOnPCLabel"
 msgstr "PCで維持"
@@ -620,7 +587,7 @@ msgstr "NDMFフェーズ"
 msgid "MeshFlipperEditorEnabledOnPCWarning"
 msgstr "このコンポーネントを使用しなくてもシェーダーの設定で実現できる可能性があります。"
 
-msgid "MeshFlipperEditorEnabledOnMobileWarning"
+msgid "MeshFlipperEditorBothSidesWarning"
 msgstr "このメッシュのポリゴン数は増加します。"
 
 msgid "MeshFlipperEditorMaskTextureMissingError"
@@ -651,13 +618,13 @@ msgid "MaterialSwapEditorSelectMaterialLabel"
 msgstr "子オブジェクトから選択"
 
 msgid "MaterialSwapEditorReplacementMaterialError"
-msgstr "このマテリアルのシェーダーはモバイルアバターでは許可されていません。"
+msgstr "このマテリアルのシェーダーは Mobile アバターでは許可されていません。"
 
 msgid "MaterialConversionSettingsEditorDescription"
 msgstr "Mobile プラットフォーム向けにマテリアルを変換します。"
 
 msgid "MaterialConversionSettingsEditorDefaultConversionWarning"
-msgstr "無効になっている設定を使用するにはこのコンポーネントをアバターのルートオブジェクトに配置してください。ただし VQT Avatar Converter Settings の設定が優先されます。"
+msgstr "このコンポーネントをアバターのルートオブジェクトに単独で配置するか、VQT Avatar Converter Settings の設定を使用してください(その場合はそちらの設定が優先されます)。"
 
 msgid "MaterialConversionSettingsEditorConversionSettingsLabel"
 msgstr "マテリアル変換設定"
@@ -691,9 +658,6 @@ msgstr "現在のバージョンの{0}には非対応です。{0}を{1}以降に
 
 msgid "BreakingPackageExceptionMessage"
 msgstr "現在のバージョンの{0}には非対応です。VRCQuestToolsを更新するか{0}を{1}未満にダウングレードしてください。"
-
-msgid "FeatureRequiresNdmf"
-msgstr "Non-Destructive Modular Framework (NDMF) が必要です。"
 
 msgid "NDMF:RemovedUnsupportedComponentTitle"
 msgstr "非対応コンポーネントの削除"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
@@ -390,7 +390,7 @@ msgstr "Пожалуйста, выберите место для сохране�
 msgid "GenerateButtonLabel"
 msgstr "Создать металлическую гладкость"
 
-msgid "RecommendedUnitySettingsForAndroid"
+msgid "RecommendedUnitySettingsForMobile"
 msgstr "Рекомендуемые настройки для Mobile"
 
 msgid "AndroidBuildSupportHelp"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ru-RU.po
@@ -49,9 +49,6 @@ msgstr ""
 msgid "Maximum"
 msgstr "Максимум"
 
-msgid "IncompatibleSDK"
-msgstr "Несовместимый VRChat SDK. Пожалуйста, сообщите об этом."
-
 msgid "TextureFormatHighQuality"
 msgstr ""
 
@@ -91,14 +88,8 @@ msgstr "Поддерживаемые шейдеры"
 msgid "SaveToLabel"
 msgstr "Папка для сохранения"
 
-msgid "SelectButtonLabel"
-msgstr "Выбрать"
-
 msgid "ConvertButtonLabel"
 msgstr "Конвертировать"
-
-msgid "AssignButtonLabel"
-msgstr "Назначить"
 
 msgid "UpdateTexturesLabel"
 msgstr "Обновить конвертированные текстуры для Mobile"
@@ -116,9 +107,6 @@ msgid "RemoveExtraMaterialSlotsLabel"
 msgstr ""
 
 msgid "RemoveExtraMaterialSlotsTooltip"
-msgstr ""
-
-msgid "CompressExpressionsMenuIconsLabel"
 msgstr ""
 
 msgid "CompressExpressionsMenuIconsTooltip"
@@ -160,9 +148,6 @@ msgstr "Произошла ошибка при конвертации контр
 msgid "InvalidReplacementMaterialExceptionDialogMessage"
 msgstr ""
 
-msgid "InfoForNdmfConversion"
-msgstr "Вы можете неразрушающе конвертировать аватар во время сборки, когда проект имеет пакет Неразрушаемая Модульная Структура (NDMF). Пожалуйста, используйте Конструктор Аватаров, чтобы избежать ограничений VRChat SDK."
-
 msgid "InfoForNdmfConversion2"
 msgstr ""
 
@@ -172,7 +157,7 @@ msgstr "Оценочная оценка производительности —
 "Мобильные пользователи по умолчанию увидят его импостер или резервный аватар. Однако они могут увидеть аватар, изменив настройку «Отображение аватара» (также известную как «Показать аватар»)."
 
 msgid "WarningForAppearance"
-msgstr "Прозрачность текстуры не оказывает никакого эффекта, поэтому это будет проблемой для выражения лица."
+msgstr "Прозрачность текстуры не оказывает никакого эффекта, поэтому могут возникнуть проблемы с мимикой."
 
 msgid "WarningForUnsupportedShaders"
 msgstr "Следующие материалы используют неподдерживаемые шейдеры. Текстуры могут быть сгенерированы неправильно."
@@ -190,7 +175,7 @@ msgid "AlertForUnityConstraintsConversion"
 msgstr "Не конвертируйте ограничения Unity в ограничения VRChat. Пожалуйста, настройте ограничения VRChat перед конвертацией аватара."
 
 msgid "AlertForAvatarDynamicsPerformance"
-msgstr "Оценка производительности динамики аватара (физические кости и контакты) будет \"Очень Плохо\", поэтому компоненты будут удалены даже при загрузке для Mobile. Пожалуйста, поддерживайте оценку \"Плохо\" в категориях динамики аватара."
+msgstr "Оценка производительности динамики аватара (физические кости и контакты) будет \"Очень Плохо\", поэтому компоненты будут удалены даже при загрузке для Mobile. Пожалуйста, уменьшите количество компонентов, чтобы оценка производительности динамики аватара оставалась на уровне \"Плохо\" или выше."
 
 msgid "ErrorForPrefabStage"
 msgstr "Невозможно конвертировать аватар в режиме префаба. Пожалуйста, вернитесь к сцене из режима префаба."
@@ -230,9 +215,6 @@ msgstr "При ручном преобразовании не учитывают
 
 msgid "ManualConvertButtonLabel"
 msgstr "Преобразовать"
-
-msgid "ConfirmationForUnityConstraints"
-msgstr "Ручное преобразование удалит Unity Constraints. Вы можете без разрушения преобразовать их в VRChat Constraints, добавив компонент MA Convert Constraints к аватару и используя Avatar Builder для загрузки. Вы действительно хотите продолжить преобразование?"
 
 msgid "ConfirmationForMAConvertConstraints"
 msgstr ""
@@ -307,7 +289,7 @@ msgid "MaterialConvertTypePopupLabelMaterialReplace"
 msgstr "Замена материала"
 
 msgid "MaterialReplaceSettingsMaterialLabel"
-msgstr "Заменяемый материал"
+msgstr "Заменяющий материал"
 
 msgid "MaterialReplaceSettingsMaterialTooltip"
 msgstr "Целевой материал будет заменен этим материалом."
@@ -350,9 +332,6 @@ msgstr "Выберите компоненты для сохранения."
 
 msgid "PhysBonesListTooltip"
 msgstr "Список компонентов и их корневых трансформаций."
-
-msgid "KeepAll"
-msgstr "Сохранить все"
 
 msgid "PhysBonesWillBeRemovedAtRunTime"
 msgstr "Вы можете загрузить этот аватар для Mobile, но все компоненты PhysBone будут удалены. Пожалуйста, уменьшите количество компонентов PhysBone."
@@ -406,13 +385,13 @@ msgid "SaveFileDialogTitle"
 msgstr "Сохранить {0}"
 
 msgid "SaveFileDialogMessage"
-msgstr "Пожалуйста, введите имя файла для сохранения текстуры"
+msgstr "Пожалуйста, выберите место для сохранения текстуры"
 
 msgid "GenerateButtonLabel"
 msgstr "Создать металлическую гладкость"
 
 msgid "RecommendedUnitySettingsForAndroid"
-msgstr "Рекомендуемые настройки для Android"
+msgstr "Рекомендуемые настройки для Mobile"
 
 msgid "AndroidBuildSupportHelp"
 msgstr ""
@@ -429,9 +408,6 @@ msgstr "ASTC улучшает качество текстур для Android в 
 msgid "TextureCompressionButtonLabel"
 msgstr "Установить сжатие текстур на ASTC"
 
-msgid "ApplyAllButtonLabel"
-msgstr "Применить все настройки"
-
 msgid "ShowOnStartupLabel"
 msgstr "Показывать при запуске"
 
@@ -446,9 +422,6 @@ msgstr "Журнал изменений"
 
 msgid "SkipThisVersion"
 msgstr "Пропустить эту версию"
-
-msgid "NewVersionIsAvailable"
-msgstr "Доступна новая версия {0}."
 
 msgid "NewVersionHasBreakingChanges"
 msgstr "Эта версия может иметь критические изменения в совместимости."
@@ -484,7 +457,7 @@ msgid "PlatformTargetSettingsEditorDescription"
 msgstr "Компоненты принудительно используют определенные настройки платформы в процессе сборки NDMF."
 
 msgid "PlatformTargetSettingsIsRequiredToEnforcePlatform"
-msgstr "Чтобы переопределить платформу для этого компонента, добавьте компонент PlatformTargetSettings в корневой объект аватара."
+msgstr "Чтобы переопределить платформу для этого компонента, добавьте компонент Platform Target Settings в корневой объект аватара."
 
 msgid "ComponentRequiresNdmf"
 msgstr "Требуется Неразрушаемая Модульная Структура (NDMF)."
@@ -549,7 +522,7 @@ msgstr ""
 msgid "MeshFlipperEditorEnabledOnPCWarning"
 msgstr "Возможно, это можно сделать с помощью настроек шейдера без использования этого компонента."
 
-msgid "MeshFlipperEditorEnabledOnMobileWarning"
+msgid "MeshFlipperEditorBothSidesWarning"
 msgstr "Количество полигонов для этой сетки увеличится."
 
 msgid "MeshFlipperEditorMaskTextureMissingError"
@@ -620,9 +593,6 @@ msgstr ""
 
 msgid "BreakingPackageExceptionMessage"
 msgstr ""
-
-msgid "FeatureRequiresNdmf"
-msgstr "Требуется Неразрушаемая Модульная Структура (NDMF)."
 
 msgid "NDMF:RemovedUnsupportedComponentTitle"
 msgstr "Удалён неподдерживаемый компонент"

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/AvatarConverterSettingsEditor.cs
@@ -353,12 +353,13 @@ namespace KRT.VRCQuestTools.Inspector
                     using (var disabledPreview = new EditorGUI.DisabledGroupScope(Utils.ComponentUtility.IsMobileBuildTarget(descriptor.gameObject)))
                     {
                         var forceLabel = converterSettings.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableLabel : i18n.ForceMaterialPreviewEnableLabel;
+                        var forceTooltip = converterSettings.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableTooltip : i18n.ForceMaterialPreviewEnableTooltip;
                         var oldBg = GUI.backgroundColor;
                         if (converterSettings.ForceMaterialPreview)
                         {
                             GUI.backgroundColor = Color.green;
                         }
-                        if (GUILayout.Button(new GUIContent("[NDMF] " + forceLabel, i18n.ForceMaterialPreviewTooltip)))
+                        if (GUILayout.Button(new GUIContent("[NDMF] " + forceLabel, forceTooltip)))
                         {
                             converterSettings.forceMaterialPreview = !converterSettings.forceMaterialPreview;
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/ConvertedAvatarEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/ConvertedAvatarEditor.cs
@@ -16,8 +16,10 @@ namespace KRT.VRCQuestTools.Inspector
         /// <inheritdoc />
         public override void OnInspectorGUIInternal()
         {
+#if VQT_HAS_NDMF
             var i18n = VRCQuestToolsSettings.I18nResource;
             EditorGUILayout.LabelField(i18n.ConvertedAvatarEditorNDMFMessage, EditorStyles.wordWrappedLabel);
+#endif
         }
     }
 }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MaterialConversionSettingsEditor.cs
@@ -58,12 +58,13 @@ namespace KRT.VRCQuestTools.Inspector
             {
                 var component = TargetComponent;
                 var forceLabel = component.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableLabel : i18n.ForceMaterialPreviewEnableLabel;
+                var forceTooltip = component.ForceMaterialPreview ? i18n.ForceMaterialPreviewDisableTooltip : i18n.ForceMaterialPreviewEnableTooltip;
                 var oldBg = GUI.backgroundColor;
                 if (component.ForceMaterialPreview)
                 {
                     GUI.backgroundColor = Color.green;
                 }
-                if (GUILayout.Button(new GUIContent("[NDMF] " + forceLabel, i18n.ForceMaterialPreviewTooltip)))
+                if (GUILayout.Button(new GUIContent("[NDMF] " + forceLabel, forceTooltip)))
                 {
                     component.forceMaterialPreview = !component.forceMaterialPreview;
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MeshFlipperEditor.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Inspector/MeshFlipperEditor.cs
@@ -27,7 +27,7 @@ namespace KRT.VRCQuestTools.Inspector
 
             if (direction.enumValueIndex == (int)MeshFlipperMeshDirection.BothSides)
             {
-                EditorGUILayout.HelpBox(i18n.MeshFlipperEditorEnabledOnMobileWarning, MessageType.Warning);
+                EditorGUILayout.HelpBox(i18n.MeshFlipperEditorBothSidesWarning, MessageType.Warning);
             }
 
             var useMask = so.FindProperty("useMask");

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/ViewModels/UnityQuestSettingsViewModel.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/ViewModels/UnityQuestSettingsViewModel.cs
@@ -42,7 +42,6 @@ namespace KRT.VRCQuestTools.ViewModels
         {
             get
             {
-                // Do not check cache server on Unity 2019 (Asset Pipeline v2)
                 return HasValidAndroidTextureCompression && HasAndroidBuildSupport && HasIOSBuildSupport;
             }
         }

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/ViewModels/UnityQuestSettingsViewModel.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/ViewModels/UnityQuestSettingsViewModel.cs
@@ -43,7 +43,7 @@ namespace KRT.VRCQuestTools.ViewModels
             get
             {
                 // Do not check cache server on Unity 2019 (Asset Pipeline v2)
-                return HasValidAndroidTextureCompression && HasAndroidBuildSupport;
+                return HasValidAndroidTextureCompression && HasAndroidBuildSupport && HasIOSBuildSupport;
             }
         }
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/UnityQuestSettingsWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/UnityQuestSettingsWindow.cs
@@ -36,7 +36,7 @@ namespace KRT.VRCQuestTools.Views
         {
             var i18n = VRCQuestToolsSettings.I18nResource;
 
-            EditorGUILayout.LabelField(i18n.RecommendedUnitySettingsForAndroid, EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(i18n.RecommendedUnitySettingsForMobile, EditorStyles.boldLabel);
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Build Settings", EditorStyles.boldLabel);

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/UnityQuestSettingsWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/UnityQuestSettingsWindow.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using KRT.VRCQuestTools.Models;
 using KRT.VRCQuestTools.ViewModels;
 using UnityEditor;
@@ -37,7 +35,6 @@ namespace KRT.VRCQuestTools.Views
         private void OnGUI()
         {
             var i18n = VRCQuestToolsSettings.I18nResource;
-            var allActions = new List<Action>();
 
             EditorGUILayout.LabelField(i18n.RecommendedUnitySettingsForAndroid, EditorStyles.boldLabel);
             EditorGUILayout.Space();
@@ -72,7 +69,6 @@ namespace KRT.VRCQuestTools.Views
             if (!model.HasValidAndroidTextureCompression)
             {
                 EditorGUILayout.HelpBox(i18n.TextureCompressionHelp, MessageType.Info);
-                allActions.Add(OnClickTextureCompressionButton);
                 if (GUILayout.Button(i18n.TextureCompressionButtonLabel))
                 {
                     OnClickTextureCompressionButton();
@@ -81,17 +77,7 @@ namespace KRT.VRCQuestTools.Views
 
             EditorGUILayout.Space();
 
-            if (allActions.Count >= 2)
-            {
-                if (GUILayout.Button(i18n.ApplyAllButtonLabel))
-                {
-                    foreach (var action in allActions)
-                    {
-                        action();
-                    }
-                }
-            }
-            else if (model.AllSettingsValid)
+            if (model.AllSettingsValid)
             {
                 EditorGUILayout.HelpBox(i18n.AllAppliedHelp, MessageType.Info);
             }


### PR DESCRIPTION
Audits ja-JP.po/en-US.po against the code that displays each string and fixes real bugs uncovered along the way: dead code paths whose UI text could never show (Apply All button, unused NDMF info banner), a tooltip whose English meaning was backwards (Replacement vs Replaced Material), a NDMF marker message shown even when NDMF isn't installed, and several messages describing behavior that no longer matches the implementation. Also removes 20 unused localization keys, proofreads the Japanese text, reconciles JA/EN meaning mismatches, and native-checks the English source strings. Propagates the same structural and meaning changes to ru-RU.po, leaving untranslated entries untouched.