### PR TITLE
Update commit message format to disable [ci skip] in crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,4 +2,5 @@ files:
   - source: /Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
     translation: /%original_path%/%locale%.po
 
-commit_message: ""
+commit_message: "New translations {fileName} ({languageName})"
+append_commit_message: false


### PR DESCRIPTION
https://support.crowdin.com/developer/configuration-file/#commit-message

> When you replace the default message (append_commit_message: false), the [ci skip] tag is no longer added automatically. Include it in your custom message if you still want to skip intermediate CI builds.