### PR TITLE
Use mise for tool version management in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,8 @@ jobs:
     container: unityci/editor:ubuntu-2022.3.22f1-windows-mono-3
     steps:
       - uses: actions/checkout@v4
+      - name: Set up mise
+        uses: jdx/mise-action@v4
       - uses: actions/cache@v4
         with:
           path: Library
@@ -179,11 +181,6 @@ jobs:
       - run: vrc-get info project
       - run: vrc-get repo add https://vpm.nadena.dev/vpm-prerelease.json
       - run: scripts/vrc-get-install.sh nadena.dev.modular-avatar latest
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
 
       # See https://github.com/game-ci/documentation/issues/408#issuecomment-3211109962 for UNITY_SERIAL
       - name: Generate Solution
@@ -240,13 +237,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          version: 10
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'pnpm'
-          cache-dependency-path: Website/pnpm-lock.yaml
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('Website/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - run: cd Website && pnpm install --frozen-lockfile
       - run: cd Website && pnpm run build
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+
       - name: Cache Library folder
         uses: actions/cache@v4
         with:
@@ -54,11 +57,6 @@ jobs:
           retry_wait_seconds: 60
           command: vrc-get resolve
       - run: vrc-get info project
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.0.x
 
       - name: Setup Unity Hub
         run: |
@@ -89,17 +87,18 @@ jobs:
             echo "Unity Editor already installed, skipping installation"
           fi
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          node-version: 22
-          cache: 'pnpm'
-          cache-dependency-path: Website/pnpm-lock.yaml
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('Website/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - run: cd Website && pnpm install --frozen-lockfile
 
       - name: Generate solution

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: master
+      - name: Set up mise
+        uses: jdx/mise-action@v4
       - name: Wait for Latest Release
         run: sleep 10
       - name: Build Package Version Listing
@@ -58,14 +60,9 @@ jobs:
           ref: master
           path: current
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Set up mise
+        uses: jdx/mise-action@v4
       # TODO: use pnpm
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'npm'
-          cache-dependency-path: Website/package-lock.json
       - run: cd Website && npm ci
 
       - name: Generate changelog

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+node = '24'
+pnpm = '10'
+dotnet = '9.0'


### PR DESCRIPTION
Replace actions/setup-node, pnpm/action-setup, and actions/setup-dotnet with jdx/mise-action reading mise.toml across build.yml, copilot-setup-steps.yml, and deploy-pages.yml. The build-docs job in deploy-pages.yml reads its own mise.toml from the latest-docs branch (added separately) since it builds that branch's independent Website dependency set.