### PR TITLE
Fix Website TypeScript errors and Docusaurus deprecation warning

### DIFF
--- a/Website/docusaurus.config.js
+++ b/Website/docusaurus.config.js
@@ -23,7 +23,11 @@ const config = {
   projectName: 'VRCQuestTools', // Usually your repo name.
 
   // onBrokenLinks: 'warn', // Temporary ignore broken links for missing i18n pages.
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want

--- a/Website/src/components/HomepageFeatures/index.tsx
+++ b/Website/src/components/HomepageFeatures/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 import Translate from '@docusaurus/Translate';
 
 type FeatureItem = {
-  title: JSX.Element;
-  description: JSX.Element;
+  title: ReactNode;
+  description: ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
@@ -47,7 +47,7 @@ function Feature({title, description}: FeatureItem) {
   );
 }
 
-export default function HomepageFeatures(): JSX.Element {
+export default function HomepageFeatures(): ReactNode {
   return (
     <section className={styles.features}>
       <div className="container">

--- a/Website/src/pages/index.tsx
+++ b/Website/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
@@ -30,7 +30,7 @@ function HomepageHeader() {
   );
 }
 
-export default function Home(): JSX.Element {
+export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout


### PR DESCRIPTION
Replace JSX.Element with ReactNode and drop the default React import in homepage components, matching Docusaurus's current TS template and avoiding a known TypeScript/@types/react 19 generic-children checker bug (microsoft/TypeScript#61692) triggered by @docusaurus/Translate. Also migrate the deprecated top-level onBrokenMarkdownLinks option to markdown.hooks.onBrokenMarkdownLinks ahead of Docusaurus v4.