### PR TITLE
Bump GitHub Actions to Node.js 24-compatible major versions

### DIFF
--- a/.github/workflows/activation.yml
+++ b/.github/workflows/activation.yml
@@ -12,7 +12,7 @@ jobs:
         uses: game-ci/unity-request-activation-file@v2
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download astcenc
         run: ./scripts/download-astcenc.sh --platform all
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: Library
           key: Library-build-${{ github.ref }}
@@ -28,7 +28,7 @@ jobs:
             Library-build-
 
       - uses: anatawa12/sh-actions/setup-vrc-get@master
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -39,7 +39,7 @@ jobs:
       - name: Copy README
         run: cp README.md Packages/com.github.kurotu.vrc-quest-tools/
 
-      - uses: game-ci/unity-builder@v4
+      - uses: game-ci/unity-builder@v5
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -51,7 +51,7 @@ jobs:
           allowDirtyBuild: true
           versioning: None
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: unitypackage
           path: VRCQuestTools.unitypackage
@@ -105,12 +105,12 @@ jobs:
             dependencies:
               name: aao-minimum
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download astcenc
         run: ./scripts/download-astcenc.sh --platform linux
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: Library
           key: Library-test-${{ matrix.sdk.unityVersion }}-${{ matrix.sdk.vrcsdkVersion }}-${{ github.ref }}
@@ -118,7 +118,7 @@ jobs:
             Library-test-${{ matrix.sdk.unityVersion }}-${{ matrix.sdk.vrcsdkVersion }}
 
       - uses: anatawa12/sh-actions/setup-vrc-get@master
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -163,10 +163,10 @@ jobs:
     runs-on: ubuntu-latest
     container: unityci/editor:ubuntu-2022.3.22f1-windows-mono-3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up mise
         uses: jdx/mise-action@v4
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: Library
           key: Library-build-${{ github.ref }}
@@ -174,7 +174,7 @@ jobs:
             Library-build-
 
       - uses: anatawa12/sh-actions/setup-vrc-get@master
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -212,7 +212,7 @@ jobs:
           DOTNET_CLI_UI_LANGUAGE: en
 
       - name: Upload lint log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: lint
@@ -221,7 +221,7 @@ jobs:
   vpm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download astcenc
         run: ./scripts/download-astcenc.sh --platform all
       - name: Copy README
@@ -230,7 +230,7 @@ jobs:
         run: |
           cd Packages/com.github.kurotu.vrc-quest-tools
           zip -r ../../$(jq -r '.name' package.json)-$(jq -r '.version' package.json).zip $(ls)
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: vpm
           path: "*.zip"
@@ -238,14 +238,14 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up mise
         uses: jdx/mise-action@v4
       - name: Get pnpm store directory
         id: pnpm-cache
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('Website/pnpm-lock.yaml') }}
@@ -259,13 +259,13 @@ jobs:
     needs: [build, test, lint, vpm, docs]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: unitypackage
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: vpm
 
@@ -284,7 +284,7 @@ jobs:
       - name: Generate release note
         run: ./scripts/generate-releasenote.sh ${GITHUB_REF#refs/tags/v} | tee ${{ github.workspace }}-release.txt
 
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v3
         with:
           body_path: ${{ github.workspace }}-release.txt
           draft: true

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v11
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,13 +30,13 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up mise
         uses: jdx/mise-action@v4
 
       - name: Cache Library folder
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Library
           key: Library-build-${{ github.ref }}
@@ -50,7 +50,7 @@ jobs:
         run: vrc-get repo add https://vpm-catalog.vercel.app/index.json
 
       - name: Resolve VPM packages
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 5
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache Unity Editor
         id: cache-unity-editor
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Unity/Hub/Editor
           key: Unity-Editor-2022.3.22f1-${{ github.head_ref || github.ref }}
@@ -92,7 +92,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('Website/pnpm-lock.yaml') }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -182,7 +182,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ${{env.listPublishDirectory}}
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,7 +30,7 @@ jobs:
   build-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: master
       - name: Set up mise
@@ -44,7 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: repo
           path: index.json
@@ -52,10 +52,10 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: latest-docs
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: master
           path: current
@@ -95,7 +95,7 @@ jobs:
           ./scripts/generate-changelog-links.sh | cat current/CHANGELOG_JP.md - > Website/i18n/ja/docusaurus-plugin-content-docs/current/changelog.md
 
       - run: cd Website && pnpm run build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: docs
           path: Website/build
@@ -103,7 +103,7 @@ jobs:
   build-latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: master
       - name: Determine version
@@ -149,7 +149,7 @@ jobs:
             }
           }' > latest-index.json
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: latest
           path: |
@@ -163,23 +163,23 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: repo
           path: ${{env.listPublishDirectory}}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: docs
           path: ${{env.listPublishDirectory}}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: latest
           path: ${{env.listPublishDirectory}}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -188,4 +188,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       TZ: Asia/Tokyo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT }}
       - name: Make release commit and push it
@@ -29,7 +29,7 @@ jobs:
     needs: bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: latest-docs
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
GitHub is deprecating Node.js 20 runners; update actions/checkout, actions/cache, actions/upload-artifact, actions/download-artifact, actions/stale, actions/configure-pages, actions/deploy-pages, nick-fields/retry, game-ci/unity-builder, and softprops/action-gh-release to the earliest major release that runs on node24.

game-ci/unity-test-runner@v4 and game-ci/unity-request-activation-file@v2 are left unchanged: no newer major exists upstream yet (latest releases still declare node20).