### PR TITLE
Add a migration tool for legacy Avatar Dynamics settings

### DIFF
--- a/Assets/VRCQuestTools-Tests/Editor/Inspector/AvatarDynamicsSelectorTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Inspector/AvatarDynamicsSelectorTests.cs
@@ -125,9 +125,14 @@ namespace KRT.VRCQuestTools.Inspector
                 new VRCPhysBoneCollider[] { physBoneCollider },
                 new ContactBase[] { contact });
 
-            Assert.AreEqual(0, converterSettings.physBonesToKeep.Length, "physBonesToKeep should be cleared");
-            Assert.AreEqual(0, converterSettings.physBoneCollidersToKeep.Length, "physBoneCollidersToKeep should be cleared");
-            Assert.AreEqual(0, converterSettings.contactsToKeep.Length, "contactsToKeep should be cleared");
+            // Elements are nulled in place rather than shrinking the arrays (protects any prefab
+            // variant/instance that overrides these same arrays with different, equal-length
+            // content - see AvatarDynamicsSettingsUtility.ClearLegacyArraysInPlace), so "cleared"
+            // means all-null, not necessarily zero-length.
+            Assert.IsTrue(converterSettings.physBonesToKeep.All(p => p == null), "physBonesToKeep should be cleared");
+            Assert.IsTrue(converterSettings.physBoneCollidersToKeep.All(c => c == null), "physBoneCollidersToKeep should be cleared");
+            Assert.IsTrue(converterSettings.contactsToKeep.All(c => c == null), "contactsToKeep should be cleared");
+            Assert.IsFalse(converterSettings.HasLegacyAvatarDynamicsSettings);
         }
 
         /// <summary>

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/AvatarDynamicsMigrationUtilityTests.cs
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/AvatarDynamicsMigrationUtilityTests.cs
@@ -1,0 +1,684 @@
+// <copyright file="AvatarDynamicsMigrationUtilityTests.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+#pragma warning disable CS0618
+
+using System;
+using System.Linq;
+using KRT.VRCQuestTools.Components;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using VRC.SDK3.Avatars.Components;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+
+namespace KRT.VRCQuestTools.Utils
+{
+    /// <summary>
+    /// Tests for AvatarDynamicsMigrationUtility: scanning for and migrating legacy Avatar Dynamics
+    /// settings on both project prefabs (base prefabs and variants) and scene objects.
+    /// </summary>
+    public class AvatarDynamicsMigrationUtilityTests : KRT.VRCQuestTools.TestUtilities.IsolatedEditorSceneTest
+    {
+        private string testFolder;
+
+        /// <summary>
+        /// Creates a scratch folder under Assets/ for prefab assets created by each test.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            var folderName = $"VQT_MigrationTests_{Guid.NewGuid():N}";
+            testFolder = $"Assets/{folderName}";
+            AssetDatabase.CreateFolder("Assets", folderName);
+        }
+
+        /// <summary>
+        /// Deletes the scratch folder and every prefab asset created inside it.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (AssetDatabase.IsValidFolder(testFolder))
+            {
+                AssetDatabase.DeleteAsset(testFolder);
+            }
+            AssetDatabase.Refresh();
+        }
+
+        [Test]
+        public void Migrate_BaseOnlyLegacyPrefab_MigratesAndClearsLegacyFields()
+        {
+            var root = CreateAvatarHierarchy("BaseAvatar");
+            var physBone = root.GetComponentInChildren<VRCPhysBone>();
+            root.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { physBone };
+            var path = SaveAsPrefabAndDestroy(root, "BasePrefab");
+
+            var target = AvatarDynamicsMigrationTarget.ForProjectPrefab(path);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { target });
+
+            Assert.AreEqual(1, result.MigratedCount);
+            Assert.AreEqual(0, result.SkippedCount);
+
+            var migratedAsset = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            var converterSettings = migratedAsset.GetComponent<AvatarConverterSettings>();
+
+            // Elements are nulled in place rather than shrinking the array (protects any prefab
+            // variant/instance that overrides this same array with different, equal-length content
+            // - see AvatarDynamicsSettingsUtility.ClearLegacyArraysInPlace), so "cleared" means
+            // all-null, not necessarily zero-length.
+            Assert.IsTrue(converterSettings.physBonesToKeep.All(p => p == null), "Legacy field should be cleared on the asset");
+            Assert.IsFalse(converterSettings.HasLegacyAvatarDynamicsSettings);
+
+            // The kept PhysBone should have no PlatformComponentRemover (it wasn't marked for removal).
+            var boneObject = migratedAsset.GetComponentInChildren<VRCPhysBone>().gameObject;
+            Assert.IsNull(boneObject.GetComponent<PlatformComponentRemover>());
+        }
+
+        [Test]
+        public void Migrate_ProjectPrefab_PartialSelection_RemovesUnkeptComponentsViaPCR()
+        {
+            var root = CreateAvatarHierarchy("BaseAvatar2");
+            var keptBone = root.GetComponentInChildren<VRCPhysBone>();
+            var removedBone = new GameObject("RemovedBone");
+            removedBone.transform.SetParent(root.transform);
+            var removedPhysBone = removedBone.AddComponent<VRCPhysBone>();
+
+            // Only keptBone is listed as kept, so removedPhysBone should be marked for Android removal.
+            root.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { keptBone };
+            var path = SaveAsPrefabAndDestroy(root, "BasePrefabPartialKeep");
+
+            var target = AvatarDynamicsMigrationTarget.ForProjectPrefab(path);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { target });
+
+            Assert.AreEqual(1, result.MigratedCount);
+
+            var migratedAsset = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            var bones = migratedAsset.GetComponentsInChildren<VRCPhysBone>(true);
+            var keptBoneAfter = bones.First(b => b.gameObject.name == "Bone");
+            var removedBoneAfter = bones.First(b => b.gameObject.name == "RemovedBone");
+
+            Assert.IsNull(keptBoneAfter.gameObject.GetComponent<PlatformComponentRemover>(), "Kept PhysBone's GameObject should not need a PlatformComponentRemover");
+
+            var remover = removedBoneAfter.gameObject.GetComponent<PlatformComponentRemover>();
+            Assert.IsNotNull(remover, "Removed PhysBone's GameObject should have a PlatformComponentRemover");
+            var setting = Array.Find(remover.componentSettings, s => s.component == removedBoneAfter);
+            Assert.IsNotNull(setting);
+            Assert.IsTrue(setting.removeOnAndroid);
+        }
+
+        [Test]
+        public void Migrate_VariantOverridingLegacyFields_MigratesIndependentlyOfBase()
+        {
+            // Base prefab has no legacy settings at all.
+            var baseRoot = CreateAvatarHierarchy("Base");
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "Base");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            // Variant overrides physBonesToKeep by itself.
+            var variantInstance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset);
+            var variantPhysBone = variantInstance.GetComponentInChildren<VRCPhysBone>();
+            variantInstance.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { variantPhysBone };
+            var variantPath = SaveAsPrefabAndDestroy(variantInstance, "Variant");
+
+            Assert.IsTrue(PrefabUtility.IsPartOfVariantPrefab(AssetDatabase.LoadAssetAtPath<GameObject>(variantPath)), "Sanity check: Variant should actually be a Prefab Variant of Base");
+
+            var baseTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(basePath);
+            var variantTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(variantPath);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { baseTarget, variantTarget });
+
+            Assert.AreEqual(1, result.MigratedCount, "Only the variant has legacy settings to migrate");
+            Assert.AreEqual(1, result.SkippedCount, "The base prefab never had legacy settings");
+
+            var migratedVariant = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+            var variantSettings = migratedVariant.GetComponent<AvatarConverterSettings>();
+            Assert.IsTrue(variantSettings.physBonesToKeep.All(p => p == null));
+            Assert.IsFalse(variantSettings.HasLegacyAvatarDynamicsSettings);
+
+            // The LoadPrefabContents/SaveAsPrefabAsset round trip used for the no-Undo migration
+            // path must not flatten the variant into a standalone prefab.
+            Assert.IsTrue(PrefabUtility.IsPartOfVariantPrefab(migratedVariant), "Should still be a Prefab Variant after migration");
+            Assert.IsNotNull(PrefabUtility.GetCorrespondingObjectFromSource(migratedVariant), "Variant should still be linked to its base prefab after migration");
+
+            var baseAssetAfter = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+            Assert.IsFalse(baseAssetAfter.GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings, "Base was never legacy and should remain untouched");
+        }
+
+        [Test]
+        public void Migrate_BaseAndVariantBothHaveOwnLegacySettings_EachMigratesIndependently()
+        {
+            // Base has two PhysBones and keeps "Bone" (BoneA), so "BoneB" is marked for removal.
+            var baseRoot = CreateAvatarHierarchy("MixedBase");
+            var boneA = baseRoot.GetComponentInChildren<VRCPhysBone>();
+            var boneBObject = new GameObject("BoneB");
+            boneBObject.transform.SetParent(baseRoot.transform);
+            var boneB = boneBObject.AddComponent<VRCPhysBone>();
+            baseRoot.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { boneA };
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "MixedBase");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            // Variant overrides with the opposite selection: keeps BoneB, removes BoneA - a
+            // genuinely different legacy configuration from the base's, not merely inherited.
+            var variantInstance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset);
+            var variantBoneB = variantInstance.transform.Find("BoneB").GetComponent<VRCPhysBone>();
+            variantInstance.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { variantBoneB };
+            var variantPath = SaveAsPrefabAndDestroy(variantInstance, "MixedVariant");
+
+            var baseTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(basePath);
+            var variantTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(variantPath);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { baseTarget, variantTarget });
+
+            Assert.AreEqual(2, result.MigratedCount, "Both base and variant have their own distinct legacy settings to migrate");
+            Assert.AreEqual(0, result.SkippedCount);
+
+            // Base: BoneA kept (no PCR), BoneB removed (PCR removeOnAndroid=true).
+            var migratedBase = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+            var baseBones = migratedBase.GetComponentsInChildren<VRCPhysBone>(true);
+            var baseBoneA = baseBones.First(b => b.gameObject.name == "Bone");
+            var baseBoneB = baseBones.First(b => b.gameObject.name == "BoneB");
+            Assert.IsNull(baseBoneA.gameObject.GetComponent<PlatformComponentRemover>(), "Base: kept BoneA should have no PCR");
+            var baseRemoverB = baseBoneB.gameObject.GetComponent<PlatformComponentRemover>();
+            Assert.IsNotNull(baseRemoverB, "Base: removed BoneB should have a PCR");
+            Assert.IsTrue(Array.Find(baseRemoverB.componentSettings, s => s.component == baseBoneB).removeOnAndroid);
+            Assert.IsFalse(migratedBase.GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings);
+
+            // Variant: independently, BoneB kept (no PCR) and BoneA removed (PCR removeOnAndroid=true)
+            // - the exact opposite of base, proving the variant's migration used its OWN override
+            // data rather than inheriting/copying base's result.
+            var migratedVariant = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+            var variantBones = migratedVariant.GetComponentsInChildren<VRCPhysBone>(true);
+            var vBoneA = variantBones.First(b => b.gameObject.name == "Bone");
+            var vBoneB = variantBones.First(b => b.gameObject.name == "BoneB");
+            Assert.IsNull(vBoneB.gameObject.GetComponent<PlatformComponentRemover>(), "Variant: kept BoneB should have no PCR");
+            var variantRemoverA = vBoneA.gameObject.GetComponent<PlatformComponentRemover>();
+            Assert.IsNotNull(variantRemoverA, "Variant: removed BoneA should have a PCR");
+            Assert.IsTrue(Array.Find(variantRemoverA.componentSettings, s => s.component == vBoneA).removeOnAndroid);
+            Assert.IsFalse(migratedVariant.GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings);
+            Assert.IsTrue(PrefabUtility.IsPartOfVariantPrefab(migratedVariant), "Should still be a Prefab Variant after migration");
+        }
+
+        // Regression test for the exact bug the previous test's failure surfaced: migrating ONLY
+        // the base (leaving the variant unselected/out of the batch, e.g. the user unchecked it in
+        // the review window) must not corrupt the variant's own, still-unmigrated legacy override.
+        // Before ClearLegacyArraysInPlace, shrinking the base's physBonesToKeep from length 1 to 0
+        // silently dropped the variant's equal-length per-index override on the same array, making
+        // the variant's independent (and still-pending) legacy settings vanish even though the
+        // variant itself was never touched.
+        [Test]
+        public void Migrate_OnlyBaseSelected_VariantsIndependentLegacySettingsSurviveUntouched()
+        {
+            var baseRoot = CreateAvatarHierarchy("SurviveBase");
+            var boneA = baseRoot.GetComponentInChildren<VRCPhysBone>();
+            var boneBObject = new GameObject("BoneB");
+            boneBObject.transform.SetParent(baseRoot.transform);
+            var boneB = boneBObject.AddComponent<VRCPhysBone>();
+            baseRoot.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { boneA };
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "SurviveBase");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            var variantInstance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset);
+            var variantBoneB = variantInstance.transform.Find("BoneB").GetComponent<VRCPhysBone>();
+            variantInstance.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { variantBoneB };
+            var variantPath = SaveAsPrefabAndDestroy(variantInstance, "SurviveVariant");
+
+            // Migrate ONLY the base - the variant is deliberately left out of this batch.
+            var baseTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(basePath);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { baseTarget });
+
+            Assert.AreEqual(1, result.MigratedCount);
+            Assert.IsFalse(AssetDatabase.LoadAssetAtPath<GameObject>(basePath).GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings, "Base should be migrated");
+
+            var untouchedVariant = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+            var untouchedVariantSettings = untouchedVariant.GetComponent<AvatarConverterSettings>();
+            Assert.IsTrue(untouchedVariantSettings.HasLegacyAvatarDynamicsSettings, "Variant's own legacy settings must survive even though it was never included in the batch");
+            var keptBones = untouchedVariantSettings.physBonesToKeep.Where(p => p != null).ToArray();
+            Assert.AreEqual(1, keptBones.Length);
+            Assert.AreEqual("BoneB", keptBones[0].gameObject.name, "Variant should still intend to keep its own BoneB, not have inherited base's cleared/empty state");
+        }
+
+        [Test]
+        public void Migrate_BaseFirstOrdering_VariantInheritingLegacyBecomesNoOp()
+        {
+            // Base prefab has legacy settings; the variant does not override them at all,
+            // so it only ever sees the inherited (eventually migrated) value.
+            var baseRoot = CreateAvatarHierarchy("InheritBase");
+            var basePhysBone = baseRoot.GetComponentInChildren<VRCPhysBone>();
+            baseRoot.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { basePhysBone };
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "InheritBase");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            // Variant with no override of Avatar Dynamics settings at all.
+            var variantInstance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset);
+            var variantPath = SaveAsPrefabAndDestroy(variantInstance, "InheritVariant");
+
+            var baseTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(basePath);
+            var variantTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(variantPath);
+
+            // Pass the variant first to confirm Migrate (not the caller) enforces base-before-variant ordering.
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { variantTarget, baseTarget });
+
+            Assert.AreEqual(1, result.MigratedCount, "Only the base needed an actual change");
+            Assert.AreEqual(1, result.SkippedCount, "The variant should resolve to 'already migrated' once the base is done, not get its own redundant override");
+
+            var migratedBase = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+            Assert.IsFalse(migratedBase.GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings);
+        }
+
+        [Test]
+        public void FindMigrationTargets_OrdersProjectPrefabsByAssetPath()
+        {
+            // "AAA_Variant" sorts before its own base "ZZZ_Base" by path, making the two orderings
+            // observably different: the scan lists by asset path for stable display, while
+            // Migrate() re-derives the dependency-safe processing order itself (covered by
+            // Migrate_BaseFirstOrdering_VariantInheritingLegacyBecomesNoOp).
+            var baseRoot = CreateAvatarHierarchy("ZZZ_Base");
+            var basePhysBone = baseRoot.GetComponentInChildren<VRCPhysBone>();
+            baseRoot.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { basePhysBone };
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "ZZZ_Base");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            var variantInstance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset);
+            var variantPhysBone = variantInstance.GetComponentInChildren<VRCPhysBone>();
+            variantInstance.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { variantPhysBone };
+            var variantPath = SaveAsPrefabAndDestroy(variantInstance, "AAA_Variant");
+
+            var targets = AvatarDynamicsMigrationUtility.FindMigrationTargets();
+            var prefabPaths = targets.Where(t => t.IsProjectPrefab).Select(t => t.ProjectPrefabAssetPath).ToArray();
+
+            var sorted = prefabPaths.OrderBy(p => p, StringComparer.Ordinal).ToArray();
+            CollectionAssert.AreEqual(sorted, prefabPaths, "Project prefabs should be listed in ordinal asset-path order");
+
+            var baseIndex = Array.IndexOf(prefabPaths, basePath);
+            var variantIndex = Array.IndexOf(prefabPaths, variantPath);
+            Assert.GreaterOrEqual(baseIndex, 0, "Base prefab should be discovered");
+            Assert.GreaterOrEqual(variantIndex, 0, "Variant prefab should be discovered");
+            Assert.Less(variantIndex, baseIndex, "Path order should determine the listing even when it disagrees with dependency order");
+        }
+
+        // Prefab dependency ordering must also cover plain nested prefab instances, not just Prefab
+        // Variant inheritance: "Container" is NOT a variant of "Nested", it just embeds an instance
+        // of Nested as a child with no override of its own. If Container were migrated before Nested,
+        // it would read Nested's still-unmigrated legacy settings through inheritance and write an
+        // unnecessary (though not corrupting) instance-level override to "freeze" that soon-to-change
+        // value, instead of correctly resolving to a clean no-op once Nested is actually migrated.
+        [Test]
+        public void Migrate_NestedNonVariantPrefabDependency_MigratesDependencyFirstAndAvoidsRedundantOverride()
+        {
+            var nestedRoot = CreateAvatarHierarchy("Nested");
+            var nestedBone = nestedRoot.GetComponentInChildren<VRCPhysBone>();
+            nestedRoot.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { nestedBone };
+            var nestedPath = SaveAsPrefabAndDestroy(nestedRoot, "Nested");
+            var nestedAsset = AssetDatabase.LoadAssetAtPath<GameObject>(nestedPath);
+
+            var containerRoot = new GameObject("Container");
+            containerRoot.transform.SetParent(TestRoot.transform);
+            PrefabUtility.InstantiatePrefab(nestedAsset, containerRoot.transform);
+            var containerPath = SaveAsPrefabAndDestroy(containerRoot, "Container");
+
+            Assert.IsFalse(PrefabUtility.IsPartOfVariantPrefab(AssetDatabase.LoadAssetAtPath<GameObject>(containerPath)), "Sanity check: Container is not a Prefab Variant of Nested, just a container for a nested instance of it");
+
+            var nestedTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(nestedPath);
+            var containerTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(containerPath);
+
+            // Pass Container first to confirm Migrate (not the caller) resolves the dependency order.
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { containerTarget, nestedTarget });
+
+            Assert.AreEqual(1, result.MigratedCount, "Only Nested needed an actual change");
+            Assert.AreEqual(1, result.SkippedCount, "Container should resolve to a clean no-op via inheritance, not get a redundant override");
+
+            var migratedNested = AssetDatabase.LoadAssetAtPath<GameObject>(nestedPath);
+            Assert.IsFalse(migratedNested.GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings);
+
+            var migratedContainer = AssetDatabase.LoadAssetAtPath<GameObject>(containerPath);
+            Assert.IsFalse(migratedContainer.GetComponentInChildren<AvatarConverterSettings>(true).HasLegacyAvatarDynamicsSettings);
+        }
+
+        // Same class of bug as Migrate_BaseAndVariantBothHaveOwnLegacySettings_EachMigratesIndependently,
+        // but between a Prefab Variant asset and a scene instance of it, rather than between two
+        // prefab assets. Base has no legacy settings; the variant has its own (keeps "Bone"); a
+        // scene-file instance of the VARIANT overrides with a different, equal-length selection
+        // (keeps "BoneB" instead). Both the variant and the scene instance are migrated in the same
+        // batch and must end up with their own, independent, correct PCR state.
+        [Test]
+        public void Migrate_PrefabVariantAndSceneInstanceBothHaveOwnLegacySettings_EachMigratesIndependently()
+        {
+            var baseRoot = CreateAvatarHierarchy("PVSI_Base");
+            var boneBObject = new GameObject("BoneB");
+            boneBObject.transform.SetParent(baseRoot.transform);
+            boneBObject.AddComponent<VRCPhysBone>();
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "PVSI_Base");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            // Variant keeps "Bone" (BoneA), so "BoneB" is marked for removal.
+            var variantInstance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset);
+            var variantBoneA = variantInstance.transform.Find("Bone").GetComponent<VRCPhysBone>();
+            variantInstance.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { variantBoneA };
+            var variantPath = SaveAsPrefabAndDestroy(variantInstance, "PVSI_Variant");
+            Assert.IsTrue(PrefabUtility.IsPartOfVariantPrefab(AssetDatabase.LoadAssetAtPath<GameObject>(variantPath)), "Sanity check: should be a Prefab Variant");
+            var variantAsset = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+
+            // A scene-file instance of the variant overrides with the opposite selection: keeps
+            // BoneB, removes BoneA.
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            var sceneInstance = (GameObject)PrefabUtility.InstantiatePrefab(variantAsset, scene);
+            var instanceBoneB = sceneInstance.transform.Find("BoneB").GetComponent<VRCPhysBone>();
+            var instanceConverterSettings = sceneInstance.GetComponent<AvatarConverterSettings>();
+            instanceConverterSettings.physBonesToKeep = new[] { instanceBoneB };
+            PrefabUtility.RecordPrefabInstancePropertyModifications(instanceConverterSettings);
+            var scenePath = SaveActiveSceneAndUnload(scene, "PVSI_Scene");
+
+            var variantTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(variantPath);
+            var sceneTarget = AvatarDynamicsMigrationTarget.ForSceneFile(scenePath);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { variantTarget, sceneTarget });
+
+            Assert.AreEqual(2, result.MigratedCount, "Both the variant and the scene instance have their own distinct legacy settings to migrate");
+            Assert.AreEqual(0, result.SkippedCount);
+
+            // Variant: BoneA kept (no PCR), BoneB removed (PCR removeOnAndroid=true).
+            var migratedVariant = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+            var variantBones = migratedVariant.GetComponentsInChildren<VRCPhysBone>(true);
+            var vBoneA = variantBones.First(b => b.gameObject.name == "Bone");
+            var vBoneB = variantBones.First(b => b.gameObject.name == "BoneB");
+            Assert.IsNull(vBoneA.gameObject.GetComponent<PlatformComponentRemover>(), "Variant: kept BoneA should have no PCR");
+            var variantRemoverB = vBoneB.gameObject.GetComponent<PlatformComponentRemover>();
+            Assert.IsNotNull(variantRemoverB, "Variant: removed BoneB should have a PCR");
+            Assert.IsTrue(Array.Find(variantRemoverB.componentSettings, s => s.component == vBoneB).removeOnAndroid);
+            Assert.IsFalse(migratedVariant.GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings);
+
+            // Scene instance: independently, BoneB kept and BoneA removed - the exact opposite of
+            // the variant it's an instance of, proving the instance's migration used its OWN
+            // override data, and that the instance correctly overrides the PCR it inherited from
+            // the variant (BoneB's inherited remover must be neutralized/removed at the instance
+            // level, and BoneA needs a new instance-level remover the variant never had).
+            var reopened = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+            try
+            {
+                var reopenedConverterSettings = reopened.GetRootGameObjects()
+                    .SelectMany(r => r.GetComponentsInChildren<AvatarConverterSettings>(true))
+                    .First();
+                Assert.IsFalse(reopenedConverterSettings.HasLegacyAvatarDynamicsSettings);
+
+                var sceneBones = reopened.GetRootGameObjects().SelectMany(r => r.GetComponentsInChildren<VRCPhysBone>(true)).ToArray();
+                var sBoneA = sceneBones.First(b => b.gameObject.name == "Bone");
+                var sBoneB = sceneBones.First(b => b.gameObject.name == "BoneB");
+
+                var removerA = sBoneA.gameObject.GetComponent<PlatformComponentRemover>();
+                Assert.IsNotNull(removerA, "Scene instance: removed BoneA should have a PCR (added at the instance level)");
+                Assert.IsTrue(Array.Find(removerA.componentSettings, s => s.component == sBoneA).removeOnAndroid);
+
+                var removerB = sBoneB.gameObject.GetComponent<PlatformComponentRemover>();
+                var settingB = removerB != null ? Array.Find(removerB.componentSettings, s => s.component == sBoneB) : null;
+                Assert.IsTrue(removerB == null || settingB == null || !settingB.removeOnAndroid, "Scene instance: kept BoneB should not be marked for Android removal");
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(reopened, true);
+            }
+        }
+
+        // Regression test mirroring Migrate_OnlyBaseSelected_VariantsIndependentLegacySettingsSurviveUntouched,
+        // for the Prefab/Prefab Variant -> scene-file-instance relationship instead of the
+        // base-prefab -> variant-prefab one.
+        [Test]
+        public void Migrate_OnlyPrefabVariantSelected_SceneInstanceIndependentLegacySettingsSurviveUntouched()
+        {
+            var baseRoot = CreateAvatarHierarchy("SurvivePVSI_Base");
+            var boneBObject = new GameObject("BoneB");
+            boneBObject.transform.SetParent(baseRoot.transform);
+            boneBObject.AddComponent<VRCPhysBone>();
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "SurvivePVSI_Base");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            var variantInstance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset);
+            var variantBoneA = variantInstance.transform.Find("Bone").GetComponent<VRCPhysBone>();
+            variantInstance.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { variantBoneA };
+            var variantPath = SaveAsPrefabAndDestroy(variantInstance, "SurvivePVSI_Variant");
+            var variantAsset = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            var sceneInstance = (GameObject)PrefabUtility.InstantiatePrefab(variantAsset, scene);
+            var instanceBoneB = sceneInstance.transform.Find("BoneB").GetComponent<VRCPhysBone>();
+            var instanceConverterSettings = sceneInstance.GetComponent<AvatarConverterSettings>();
+            instanceConverterSettings.physBonesToKeep = new[] { instanceBoneB };
+            PrefabUtility.RecordPrefabInstancePropertyModifications(instanceConverterSettings);
+            var scenePath = SaveActiveSceneAndUnload(scene, "SurvivePVSI_Scene");
+
+            // Migrate ONLY the variant - the scene file is deliberately left out of this batch.
+            var variantTarget = AvatarDynamicsMigrationTarget.ForProjectPrefab(variantPath);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { variantTarget });
+
+            Assert.AreEqual(1, result.MigratedCount);
+            Assert.IsFalse(AssetDatabase.LoadAssetAtPath<GameObject>(variantPath).GetComponent<AvatarConverterSettings>().HasLegacyAvatarDynamicsSettings, "Variant should be migrated");
+
+            var reopened = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+            try
+            {
+                var untouchedConverterSettings = reopened.GetRootGameObjects()
+                    .SelectMany(r => r.GetComponentsInChildren<AvatarConverterSettings>(true))
+                    .First();
+                Assert.IsTrue(untouchedConverterSettings.HasLegacyAvatarDynamicsSettings, "Scene instance's own legacy settings must survive even though the scene was never included in the batch");
+                var keptBones = untouchedConverterSettings.physBonesToKeep.Where(p => p != null).ToArray();
+                Assert.AreEqual(1, keptBones.Length);
+                Assert.AreEqual("BoneB", keptBones[0].gameObject.name, "Scene instance should still intend to keep its own BoneB, not have inherited the variant's migrated state");
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(reopened, true);
+            }
+        }
+
+        [Test]
+        public void Migrate_SceneInstanceOverride_MigratesInstanceWithoutTouchingSourcePrefab()
+        {
+            // Source prefab never had legacy settings.
+            var baseRoot = CreateAvatarHierarchy("InstanceOverrideBase");
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "InstanceOverrideBase");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            // A scene instance overrides physBonesToKeep by itself.
+            var instance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset, TestRoot.transform);
+            var instancePhysBone = instance.GetComponentInChildren<VRCPhysBone>();
+            var instanceConverterSettings = instance.GetComponent<AvatarConverterSettings>();
+            instanceConverterSettings.physBonesToKeep = new[] { instancePhysBone };
+            PrefabUtility.RecordPrefabInstancePropertyModifications(instanceConverterSettings);
+
+            var targets = AvatarDynamicsMigrationUtility.FindMigrationTargets();
+            var sceneTarget = targets.FirstOrDefault(t => !t.IsProjectPrefab && t.SceneConverterSettings == instanceConverterSettings);
+            Assert.IsNotNull(sceneTarget, "The scene instance override should be discovered as a scene target");
+
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { sceneTarget });
+            Assert.AreEqual(1, result.MigratedCount);
+
+            Assert.IsFalse(instanceConverterSettings.HasLegacyAvatarDynamicsSettings, "Instance override should be cleared");
+
+            var sourceSettings = AssetDatabase.LoadAssetAtPath<GameObject>(basePath).GetComponent<AvatarConverterSettings>();
+            Assert.IsFalse(sourceSettings.HasLegacyAvatarDynamicsSettings, "Source prefab never had legacy settings and must stay untouched");
+        }
+
+        [Test]
+        public void Migrate_UnloadedSceneFile_MigratesAndSaves()
+        {
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            var root = BuildAvatarHierarchy("SceneFileAvatar");
+            var physBone = root.GetComponentInChildren<VRCPhysBone>();
+            root.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { physBone };
+            var scenePath = SaveActiveSceneAndUnload(scene, "TargetScene");
+
+            var target = AvatarDynamicsMigrationTarget.ForSceneFile(scenePath);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { target });
+
+            Assert.AreEqual(1, result.MigratedCount);
+
+            var reopened = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+            try
+            {
+                var converterSettings = reopened.GetRootGameObjects()
+                    .SelectMany(r => r.GetComponentsInChildren<AvatarConverterSettings>(true))
+                    .First();
+                Assert.IsTrue(converterSettings.physBonesToKeep.All(p => p == null), "Legacy field should be cleared and saved to the scene file");
+                Assert.IsFalse(converterSettings.HasLegacyAvatarDynamicsSettings);
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(reopened, true);
+            }
+        }
+
+        [Test]
+        public void Migrate_SceneFileWithMultipleAvatars_MigratesOnlySelectedAvatar()
+        {
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            var avatarA = BuildAvatarHierarchy("AvatarA");
+            avatarA.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { avatarA.GetComponentInChildren<VRCPhysBone>() };
+            var avatarB = BuildAvatarHierarchy("AvatarB");
+            avatarB.GetComponent<AvatarConverterSettings>().physBonesToKeep = new[] { avatarB.GetComponentInChildren<VRCPhysBone>() };
+            var scenePath = SaveActiveSceneAndUnload(scene, "MultiAvatarScene");
+
+            var targets = AvatarDynamicsMigrationUtility.FindMigrationTargets();
+            var fileTargets = targets.Where(t => t.IsSceneFile && t.SceneFileAssetPath == scenePath).ToArray();
+            Assert.AreEqual(2, fileTargets.Length, "Each AvatarConverterSettings in the scene file should be listed as its own target");
+
+            var targetA = fileTargets.First(t => t.SceneFileHierarchyPath == "AvatarA");
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { targetA });
+
+            Assert.AreEqual(1, result.MigratedCount);
+            Assert.AreEqual(0, result.SkippedCount);
+
+            var reopened = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+            try
+            {
+                var all = reopened.GetRootGameObjects().SelectMany(r => r.GetComponentsInChildren<AvatarConverterSettings>(true)).ToArray();
+                var a = all.First(c => c.gameObject.name == "AvatarA");
+                var b = all.First(c => c.gameObject.name == "AvatarB");
+                Assert.IsFalse(a.HasLegacyAvatarDynamicsSettings, "Selected AvatarA should be migrated");
+                Assert.IsTrue(b.HasLegacyAvatarDynamicsSettings, "Unselected AvatarB must keep its legacy settings");
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(reopened, true);
+            }
+        }
+
+        // Regression test: ApplyWithoutUndo must call RecordPrefabInstancePropertyModifications, or an
+        // instance-level legacy override inside a scene file silently reverts to the (non-legacy)
+        // prefab source's values once the migrated scene is saved and reloaded.
+        [Test]
+        public void Migrate_UnloadedSceneFile_PrefabInstanceOverride_PersistsAfterSave()
+        {
+            var baseRoot = CreateAvatarHierarchy("SceneInstanceBase");
+            var basePath = SaveAsPrefabAndDestroy(baseRoot, "SceneInstanceBase");
+            var baseAsset = AssetDatabase.LoadAssetAtPath<GameObject>(basePath);
+
+            // Replaces the active scene (TestRoot is already empty at this point), which sidesteps
+            // this environment's "Cannot create a new scene additively with an untitled scene
+            // unsaved" restriction on EditorSceneManager.NewScene(..., Additive).
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            var instance = (GameObject)PrefabUtility.InstantiatePrefab(baseAsset, scene);
+            var instancePhysBone = instance.GetComponentInChildren<VRCPhysBone>();
+            var instanceConverterSettings = instance.GetComponent<AvatarConverterSettings>();
+            instanceConverterSettings.physBonesToKeep = new[] { instancePhysBone };
+            PrefabUtility.RecordPrefabInstancePropertyModifications(instanceConverterSettings);
+            var scenePath = SaveActiveSceneAndUnload(scene, "InstanceOverrideScene");
+
+            var target = AvatarDynamicsMigrationTarget.ForSceneFile(scenePath);
+            var result = AvatarDynamicsMigrationUtility.Migrate(new[] { target });
+
+            Assert.AreEqual(1, result.MigratedCount);
+
+            var reopened = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+            try
+            {
+                var converterSettings = reopened.GetRootGameObjects()
+                    .SelectMany(r => r.GetComponentsInChildren<AvatarConverterSettings>(true))
+                    .First();
+                Assert.IsTrue(converterSettings.physBonesToKeep.All(p => p == null), "Instance override should be cleared AND persisted to disk");
+                Assert.IsFalse(converterSettings.HasLegacyAvatarDynamicsSettings);
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(reopened, true);
+            }
+
+            var sourceSettings = AssetDatabase.LoadAssetAtPath<GameObject>(basePath).GetComponent<AvatarConverterSettings>();
+            Assert.IsFalse(sourceSettings.HasLegacyAvatarDynamicsSettings, "Source prefab never had legacy settings and must stay untouched");
+        }
+
+        [Test]
+        public void FindMigrationTargets_ExcludesAlreadyLoadedScenePath()
+        {
+            // Replaces the active scene so the resulting scene keeps whatever path we save it to
+            // (SaveScene without saveAsCopy) while staying loaded/active - exactly the "already
+            // loaded at this exact path" condition this test needs to exercise.
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            var root = BuildAvatarHierarchy("LoadedSceneAvatar");
+            var physBone = root.GetComponentInChildren<VRCPhysBone>();
+            var converterSettings = root.GetComponent<AvatarConverterSettings>();
+            converterSettings.physBonesToKeep = new[] { physBone };
+            var scenePath = $"{testFolder}/LoadedScene.unity";
+            EditorSceneManager.SaveScene(scene, scenePath);
+
+            try
+            {
+                var targets = AvatarDynamicsMigrationUtility.FindMigrationTargets();
+
+                var fileTarget = targets.FirstOrDefault(t => t.IsSceneFile && t.SceneFileAssetPath == scenePath);
+                Assert.IsNull(fileTarget, "An already-loaded scene should not also be scanned as a separate scene-file target");
+
+                var liveTarget = targets.FirstOrDefault(t => !t.IsProjectPrefab && !t.IsSceneFile && t.SceneConverterSettings == converterSettings);
+                Assert.IsNotNull(liveTarget, "The already-loaded scene's avatar should still be found via the live-scene scan");
+            }
+            finally
+            {
+                // Move off the doomed path before TearDown deletes testFolder, so no console error
+                // fires for a loaded scene whose backing file just disappeared out from under it.
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            }
+        }
+
+        private GameObject BuildAvatarHierarchy(string name)
+        {
+            var root = new GameObject(name);
+            root.AddComponent<VRCAvatarDescriptor>();
+            root.AddComponent<AvatarConverterSettings>();
+
+            var bone = new GameObject("Bone");
+            bone.transform.SetParent(root.transform);
+            bone.AddComponent<VRCPhysBone>();
+
+            return root;
+        }
+
+        private GameObject CreateAvatarHierarchy(string name)
+        {
+            var root = BuildAvatarHierarchy(name);
+            root.transform.SetParent(TestRoot.transform);
+            return root;
+        }
+
+        private string SaveAsPrefabAndDestroy(GameObject instance, string assetName)
+        {
+            var path = $"{testFolder}/{assetName}.prefab";
+            PrefabUtility.SaveAsPrefabAsset(instance, path);
+            UnityEngine.Object.DestroyImmediate(instance);
+            return path;
+        }
+
+        // Saves the given (currently active, Single-mode) scene to a path under testFolder, then
+        // replaces the active scene so the saved file is left unloaded - i.e. an ordinary project
+        // scene file on disk, matching what AvatarDynamicsMigrationUtility scans for. CloseScene
+        // isn't used here because this environment's EditorSceneManager.NewScene(..., Additive)
+        // (needed to have more than one loaded scene to close down to) refuses to run while the
+        // active scene is untitled/unsaved, which is the state every test starts from.
+        private string SaveActiveSceneAndUnload(Scene scene, string sceneName)
+        {
+            var path = $"{testFolder}/{sceneName}.unity";
+            EditorSceneManager.SaveScene(scene, path);
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            return path;
+        }
+    }
+}

--- a/Assets/VRCQuestTools-Tests/Editor/Utils/AvatarDynamicsMigrationUtilityTests.cs.meta
+++ b/Assets/VRCQuestTools-Tests/Editor/Utils/AvatarDynamicsMigrationUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ac15e83d2976954baff89f64a113256
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Avatar Converter Settings` now warns when a MA Sync Parameter Sequence or AAO Trace and Optimize component is missing on the avatar, with a button to add it.
 - [NDMF] Preview for `Platform GameObject Remover`. Renderers under GameObjects to be removed are hidden for the target platform.
 - Added `Enable Debug Log` menu under `Tools/VRCQuestTools/Settings` to enable verbose debug logging in real projects.
+- Added `Migrate Legacy Avatar Dynamics Settings` menu under `Tools/VRCQuestTools` to migrate obsolete Avatar Dynamics settings of `Avatar Converter Settings` to `Platform Component Remover` components.
 
 ### Changed
 - NDMF material conversion previews now appear immediately and finish compressing in the background, so the editor no longer freezes while a preview regenerates.
@@ -65,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lilToon to Toon Standard conversion computing gloss/metallic strength from the un-linearized (gamma-space) Reflection Color, which also caused Metallic to be inadvertently gamma-decoded a second time.
 - [NDMF] Fixed converted materials turning pink when VRCFury is present and the NDMF phase resolves to Optimizing, by suppressing VRCFury's own non-mobile material removal for avatars VRCQuestTools is about to convert in that phase. `Auto` now resolves to the Optimizing phase even when VRCFury components exist, as long as VRCFury's material removal can be suppressed; otherwise it falls back to the Transforming phase as before.
 - Fixed material replacement doing nothing when the target material already used a shader allowed for Mobile avatars. Both `VQT Material Swap` and `Material Replacement` in additional material conversion settings now accept such a material as the replacement target.
+- Fixed applying Avatar Dynamics settings to a Prefab silently discarding the keep selection of a Prefab Variant or prefab instance which overrode the legacy keep lists with the same array length.
 
 ### Removed
 - Removed support for Unity 2019.

--- a/CHANGELOG_JP.md
+++ b/CHANGELOG_JP.md
@@ -25,6 +25,7 @@
 - `Avatar Converter Settings` で、アバターに MA Sync Parameter Sequence または AAO Trace and Optimize コンポーネントがない場合に警告と追加ボタンを表示するように追加。
 - [NDMF] `Platform GameObject Remover` のプレビューを追加。対象プラットフォームで削除される GameObject 配下の Renderer が非表示になります。
 - `Tools/VRCQuestTools/Settings` に `Enable Debug Log` メニューを追加し、実プロジェクトでもデバッグログを有効化できるようにしました。
+- `Tools/VRCQuestTools` に `Migrate Legacy Avatar Dynamics Settings` メニューを追加。`Avatar Converter Settings` の旧形式の Avatar Dynamics 設定を `Platform Component Remover` コンポーネントへ移行できます。
 
 ### 変更
 - NDMF のマテリアル変換プレビューを即座に表示し、圧縮はバックグラウンドで完了するように変更。プレビューの再生成中にエディターが固まらなくなります。
@@ -64,6 +65,7 @@
 - lilToon から Toon Standard への変換で、Gloss/Metallic の強度を Reflection Color から算出する際に色空間の線形変換をしていなかった問題を修正。Metallic 側は意図せず二重にガンマデコードされていました。
 - [NDMF] VRCFuryが存在し、かつNDMFフェーズがOptimizingに解決される場合に変換後のマテリアルがピンク色になる問題を修正。VRCQuestToolsがそのフェーズで変換しようとしているアバターについては、VRCFury自身の非モバイルマテリアル削除処理を抑制するようにしました。`Auto`は、VRCFuryのマテリアル削除処理を抑制できる場合に限りOptimizingフェーズに解決されるようになりました（抑制できない場合は従来どおりTransformingフェーズにフォールバックします）。
 - 置換元のマテリアルが Mobile アバターで許可されたシェーダーを使用している場合にマテリアル置換が行われない問題を修正。`VQT Material Swap` と追加のマテリアル変換設定の「マテリアル置換」の両方で、そのようなマテリアルを置換の対象に指定できます。
+- Prefab へ Avatar Dynamics 設定を適用したときに、旧形式の維持リストを同じ配列長でオーバーライドしている Prefab Variant やインスタンス側の選択が失われる問題を修正。
 
 ### 削除
 - Unity 2019 のサポートを終了。

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/I18nBase.cs
@@ -274,6 +274,17 @@ namespace KRT.VRCQuestTools.I18n
         internal string PlatformComponentRemoverEditorCheckboxMobileTooltip => GetText("PlatformComponentRemoverEditorCheckboxMobileTooltip");
         internal string ComponentLabel => GetText("ComponentLabel");
 
+        // Avatar Dynamics Migration
+        internal string MigrateAvatarDynamicsSettingsWindowTitle => GetText("MigrateAvatarDynamicsSettingsWindowTitle");
+        internal string MigrateAvatarDynamicsSettingsDescription => GetText("MigrateAvatarDynamicsSettingsDescription");
+        internal string MigrateAvatarDynamicsSettingsAssetWarning => GetText("MigrateAvatarDynamicsSettingsAssetWarning");
+        internal string MigrateAvatarDynamicsSettingsConfirmation(int directWriteCount) => GetText("MigrateAvatarDynamicsSettingsConfirmation", directWriteCount);
+        internal string MigrateAvatarDynamicsSettingsProjectPrefabsLabel => GetText("MigrateAvatarDynamicsSettingsProjectPrefabsLabel");
+        internal string MigrateAvatarDynamicsSettingsSceneObjectsLabel => GetText("MigrateAvatarDynamicsSettingsSceneObjectsLabel");
+        internal string MigrateAvatarDynamicsSettingsNoTargetsMessage => GetText("MigrateAvatarDynamicsSettingsNoTargetsMessage");
+        internal string MigrateAvatarDynamicsSettingsButtonLabel(int count) => GetText("MigrateAvatarDynamicsSettingsButtonLabel", count);
+        internal string MigrateAvatarDynamicsSettingsResultMessage(int migratedCount, int skippedCount) => GetText("MigrateAvatarDynamicsSettingsResultMessage", migratedCount, skippedCount);
+
         // Platform GameObject Remover
         internal string PlatformGameObjectRemoverEditorDescription => GetText("PlatformGameObjectRemoverEditorDescription");
         internal string PlatformGameObjectRemoverEditorKeepOnPCLabel => GetText("PlatformGameObjectRemoverEditorKeepOnPCLabel");

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/en-US.po
@@ -557,6 +557,33 @@ msgstr "Keep the selected components in the Mobile build."
 msgid "ComponentLabel"
 msgstr "Component"
 
+msgid "MigrateAvatarDynamicsSettingsWindowTitle"
+msgstr "Avatar Dynamics Migration"
+
+msgid "MigrateAvatarDynamicsSettingsDescription"
+msgstr "Avatar Dynamics keep/remove settings are now managed with the Platform Component Remover component. The Avatar Converter Settings listed here still have settings saved in the old format. Migrating replaces them with Platform Component Remover components while preserving which PhysBones, PhysBone Colliders, and Contacts are kept. Select the Prefabs and scene objects to migrate."
+
+msgid "MigrateAvatarDynamicsSettingsAssetWarning"
+msgstr "Migrating a Prefab or an unloaded scene file writes the changes directly to the asset file. Undo cannot revert them. Before continuing, back up your project or make sure it is under version control."
+
+msgid "MigrateAvatarDynamicsSettingsConfirmation"
+msgstr "This will directly modify {0} project Prefab asset(s) and unloaded scene file(s) in total. Undo cannot revert this change. Continue?"
+
+msgid "MigrateAvatarDynamicsSettingsProjectPrefabsLabel"
+msgstr "Project Prefabs"
+
+msgid "MigrateAvatarDynamicsSettingsSceneObjectsLabel"
+msgstr "Scene Objects"
+
+msgid "MigrateAvatarDynamicsSettingsNoTargetsMessage"
+msgstr "No Avatar Dynamics settings need migration."
+
+msgid "MigrateAvatarDynamicsSettingsButtonLabel"
+msgstr "Migrate Selected ({0})"
+
+msgid "MigrateAvatarDynamicsSettingsResultMessage"
+msgstr "Migrated {0} target(s). {1} target(s) needed no change, for example because they inherit settings from an already migrated base Prefab."
+
 msgid "PlatformGameObjectRemoverEditorDescription"
 msgstr "This GameObject will be removed at build time for unselected build targets."
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/I18n/ja-JP.po
@@ -557,6 +557,33 @@ msgstr "チェックを入れたコンポーネントをMobileビルドで維持
 msgid "ComponentLabel"
 msgstr "コンポーネント"
 
+msgid "MigrateAvatarDynamicsSettingsWindowTitle"
+msgstr "Avatar Dynamics の移行"
+
+msgid "MigrateAvatarDynamicsSettingsDescription"
+msgstr "Avatar Dynamics の維持・削除に関する設定は、Platform Component Remover コンポーネントで管理するようになりました。一覧にある Avatar Converter Settings には、旧形式で保存された設定が残っています。移行すると、維持する PhysBone・PhysBone Collider・Contact の選択を保ったまま、設定が Platform Component Remover コンポーネントに置き換わります。移行する Prefab とシーン内のオブジェクトを選んでください。"
+
+msgid "MigrateAvatarDynamicsSettingsAssetWarning"
+msgstr "Prefab や開いていないシーンファイルを移行すると、変更はアセットファイルへ直接書き込まれます。Undo では元に戻せません。続行する前に、プロジェクトをバックアップするか、バージョン管理下にあることを確認してください。"
+
+msgid "MigrateAvatarDynamicsSettingsConfirmation"
+msgstr "プロジェクトの Prefab アセットと開いていないシーンファイルを、合わせて {0} 件直接変更します。この変更は Undo では元に戻せません。続行しますか？"
+
+msgid "MigrateAvatarDynamicsSettingsProjectPrefabsLabel"
+msgstr "プロジェクトの Prefab"
+
+msgid "MigrateAvatarDynamicsSettingsSceneObjectsLabel"
+msgstr "シーン内のオブジェクト"
+
+msgid "MigrateAvatarDynamicsSettingsNoTargetsMessage"
+msgstr "移行が必要な Avatar Dynamics の設定はありません。"
+
+msgid "MigrateAvatarDynamicsSettingsButtonLabel"
+msgstr "選択項目を移行 ({0})"
+
+msgid "MigrateAvatarDynamicsSettingsResultMessage"
+msgstr "{0} 件を移行しました。{1} 件は、移行済みの元 Prefab から設定を継承しているなどの理由で、変更の必要がありませんでした。"
+
 msgid "PlatformGameObjectRemoverEditorDescription"
 msgstr "チェックを入れていないビルドターゲットでは、このGameObjectをビルド時に削除します。"
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/AvatarDynamicsMigrationMenu.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/AvatarDynamicsMigrationMenu.cs
@@ -1,0 +1,22 @@
+// <copyright file="AvatarDynamicsMigrationMenu.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using KRT.VRCQuestTools.Views;
+using UnityEditor;
+
+namespace KRT.VRCQuestTools.Menus
+{
+    /// <summary>
+    /// Defines the menu to migrate legacy Avatar Dynamics settings on demand.
+    /// </summary>
+    internal static class AvatarDynamicsMigrationMenu
+    {
+        [MenuItem(VRCQuestToolsMenus.MenuPaths.MigrateAvatarDynamicsSettings, false, (int)VRCQuestToolsMenus.MenuPriorities.MigrateAvatarDynamicsSettings)]
+        private static void InitFromMenu()
+        {
+            AvatarDynamicsMigrationWindow.ShowWindow();
+        }
+    }
+}

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/AvatarDynamicsMigrationMenu.cs.meta
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/AvatarDynamicsMigrationMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6746cbe37a0b6641b8b64b8a8169871
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/VRCQuestToolsMenus.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Menus/VRCQuestToolsMenus.cs
@@ -23,6 +23,7 @@ namespace KRT.VRCQuestTools.Menus
             internal const string RemoveMissingComponents = RootMenu + "Remove Missing Components";
             internal const string RemoveAllVertexColors = RootMenu + "Remove All Vertex Colors";
             internal const string RemovePhysBones = RootMenu + "Remove PhysBones";
+            internal const string MigrateAvatarDynamicsSettings = RootMenu + "Migrate Legacy Avatar Dynamics Settings";
             internal const string BlendShapesCopy = RootMenu + "BlendShapes Copy";
             internal const string MSMapGenerator = RootMenu + "Metallic Smoothness Map";
             internal const string UnitySettings = RootMenu + "Unity Settings for Mobile";
@@ -49,6 +50,7 @@ namespace KRT.VRCQuestTools.Menus
             RemoveMissingComponents,
             RemoveUnsupportedComponents,
             RemoveAllVertexColors,
+            MigrateAvatarDynamicsSettings,
             BlendShapesCopy = 800,
             MSMapGenerator,
             UnitySettings = 900,

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/AvatarDynamicsMigrationUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/AvatarDynamicsMigrationUtility.cs
@@ -1,0 +1,523 @@
+// <copyright file="AvatarDynamicsMigrationUtility.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+#pragma warning disable CS0618
+
+using System.Collections.Generic;
+using System.Linq;
+using KRT.VRCQuestTools.Components;
+using KRT.VRCQuestTools.Models.VRChat;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+
+namespace KRT.VRCQuestTools.Utils
+{
+    /// <summary>
+    /// A single migration target: a project prefab asset, an unloaded project scene file, or a live
+    /// AvatarConverterSettings instance (in a loaded scene, or in the currently open Prefab Stage).
+    /// </summary>
+    internal class AvatarDynamicsMigrationTarget
+    {
+        /// <summary>
+        /// Gets a display label for the target.
+        /// </summary>
+        internal string Label { get; }
+
+        /// <summary>
+        /// Gets the asset path when this target is a project prefab; otherwise null.
+        /// </summary>
+        internal string ProjectPrefabAssetPath { get; }
+
+        /// <summary>
+        /// Gets the scene asset path when this target is an unloaded project scene file; otherwise null.
+        /// </summary>
+        internal string SceneFileAssetPath { get; }
+
+        /// <summary>
+        /// Gets the hierarchy path of the target AvatarConverterSettings inside the scene file, or
+        /// null when the target stands for the whole scene file.
+        /// </summary>
+        internal string SceneFileHierarchyPath { get; }
+
+        /// <summary>
+        /// Gets the scene this target belongs to (asset path, or scene name for an unsaved scene),
+        /// for grouping scene targets per scene in the UI. Null for project prefab targets.
+        /// </summary>
+        internal string SceneGroupLabel { get; }
+
+        /// <summary>
+        /// Gets the label of the target object within its scene (hierarchy path). Null for project
+        /// prefab targets.
+        /// </summary>
+        internal string ObjectLabel { get; }
+
+        /// <summary>
+        /// Gets the live AvatarConverterSettings when this target is a scene (or Prefab Stage) object; otherwise null.
+        /// </summary>
+        internal AvatarConverterSettings SceneConverterSettings { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this target is a project prefab asset.
+        /// </summary>
+        internal bool IsProjectPrefab => ProjectPrefabAssetPath != null;
+
+        /// <summary>
+        /// Gets a value indicating whether this target is an unloaded project scene file.
+        /// </summary>
+        internal bool IsSceneFile => SceneFileAssetPath != null;
+
+        private AvatarDynamicsMigrationTarget(string label, string projectPrefabAssetPath, string sceneFileAssetPath, string sceneFileHierarchyPath, string sceneGroupLabel, string objectLabel, AvatarConverterSettings sceneConverterSettings)
+        {
+            Label = label;
+            ProjectPrefabAssetPath = projectPrefabAssetPath;
+            SceneFileAssetPath = sceneFileAssetPath;
+            SceneFileHierarchyPath = sceneFileHierarchyPath;
+            SceneGroupLabel = sceneGroupLabel;
+            ObjectLabel = objectLabel;
+            SceneConverterSettings = sceneConverterSettings;
+        }
+
+        internal static AvatarDynamicsMigrationTarget ForProjectPrefab(string assetPath)
+        {
+            return new AvatarDynamicsMigrationTarget(assetPath, assetPath, null, null, null, null, null);
+        }
+
+        internal static AvatarDynamicsMigrationTarget ForSceneFile(string assetPath)
+        {
+            return new AvatarDynamicsMigrationTarget(assetPath, null, assetPath, null, assetPath, null, null);
+        }
+
+        internal static AvatarDynamicsMigrationTarget ForSceneFileObject(string assetPath, string hierarchyPath)
+        {
+            return new AvatarDynamicsMigrationTarget($"{assetPath} [{hierarchyPath}]", null, assetPath, hierarchyPath, assetPath, hierarchyPath, null);
+        }
+
+        internal static AvatarDynamicsMigrationTarget ForSceneObject(string sceneGroupLabel, string hierarchyPath, AvatarConverterSettings converterSettings)
+        {
+            return new AvatarDynamicsMigrationTarget($"{sceneGroupLabel} [{hierarchyPath}]", null, null, null, sceneGroupLabel, hierarchyPath, converterSettings);
+        }
+    }
+
+    /// <summary>
+    /// Result of running <see cref="AvatarDynamicsMigrationUtility.Migrate(IEnumerable{AvatarDynamicsMigrationTarget})"/>.
+    /// </summary>
+    internal readonly struct AvatarDynamicsMigrationResult
+    {
+        /// <summary>
+        /// Gets the number of targets that were actually migrated.
+        /// </summary>
+        internal int MigratedCount { get; }
+
+        /// <summary>
+        /// Gets the number of selected targets that turned out to have nothing left to migrate
+        /// (e.g. a prefab variant resolved via an already-migrated base prefab).
+        /// </summary>
+        internal int SkippedCount { get; }
+
+        internal AvatarDynamicsMigrationResult(int migratedCount, int skippedCount)
+        {
+            MigratedCount = migratedCount;
+            SkippedCount = skippedCount;
+        }
+    }
+
+    /// <summary>
+    /// Finds and migrates <see cref="AvatarConverterSettings"/> components which still store their
+    /// Avatar Dynamics settings in the legacy physBonesToKeep/physBoneCollidersToKeep/contactsToKeep
+    /// fields, converting them to <see cref="PlatformComponentRemover"/> components.
+    /// </summary>
+    internal static class AvatarDynamicsMigrationUtility
+    {
+        /// <summary>
+        /// Scans project prefabs and scene files under Assets/, and AvatarConverterSettings in loaded
+        /// scenes (and the currently open Prefab Stage), for legacy Avatar Dynamics settings.
+        /// Scene files are listed per contained AvatarConverterSettings, not per file.
+        /// Prefabs and scene files are ordered by asset path for stable, predictable display;
+        /// <see cref="Migrate"/> re-derives the dependency-safe processing order itself, so the
+        /// scan order carries no execution-order meaning.
+        /// Scanning unloaded scene files requires briefly opening each one, so this is noticeably
+        /// more expensive than the prefab/loaded-scene scan alone.
+        /// </summary>
+        /// <returns>Migration targets ordered by asset path.</returns>
+        internal static AvatarDynamicsMigrationTarget[] FindMigrationTargets()
+        {
+            return FindProjectPrefabTargets().Concat(FindSceneFileTargets()).Concat(FindLoadedSceneTargets()).ToArray();
+        }
+
+        /// <summary>
+        /// Migrates the given targets. Project prefab assets are processed base-before-variant and
+        /// saved directly to disk (not covered by Undo); unloaded scene files are opened additively,
+        /// migrated, saved, and closed as a batch (also not covered by Undo); already-loaded scene
+        /// and Prefab Stage objects are migrated in place using the existing Undo-tracked path and
+        /// left for the user to save. Each target is re-checked for legacy settings immediately
+        /// before migrating, since migrating a base prefab can resolve a variant's (or a scene file's
+        /// prefab instance's) legacy settings without any change being needed there.
+        /// </summary>
+        /// <param name="targets">Targets to migrate.</param>
+        /// <returns>Migration result summary.</returns>
+        internal static AvatarDynamicsMigrationResult Migrate(IEnumerable<AvatarDynamicsMigrationTarget> targets)
+        {
+            var migratedCount = 0;
+            var skippedCount = 0;
+
+            var prefabTargets = targets.Where(t => t.IsProjectPrefab).ToArray();
+            var orderedPrefabPaths = OrderPrefabPathsByDependencyDepth(prefabTargets.Select(t => t.ProjectPrefabAssetPath));
+            var prefabTargetsByPath = prefabTargets.ToLookup(t => t.ProjectPrefabAssetPath);
+            foreach (var path in orderedPrefabPaths)
+            {
+                foreach (var target in prefabTargetsByPath[path])
+                {
+                    if (MigrateProjectPrefab(target.ProjectPrefabAssetPath))
+                    {
+                        migratedCount++;
+                    }
+                    else
+                    {
+                        skippedCount++;
+                    }
+                }
+            }
+
+            // Grouped per scene file so each file is opened at most once even when several of its
+            // AvatarConverterSettings are listed (and selected) as individual targets.
+            foreach (var group in targets.Where(t => t.IsSceneFile).GroupBy(t => t.SceneFileAssetPath))
+            {
+                // A whole-file target (null hierarchy path) subsumes any per-object selection.
+                var hierarchyPaths = group.Any(t => t.SceneFileHierarchyPath == null)
+                    ? null
+                    : new HashSet<string>(group.Select(t => t.SceneFileHierarchyPath));
+                var sceneResult = MigrateSceneFile(group.Key, hierarchyPaths);
+                migratedCount += sceneResult.MigratedCount;
+                skippedCount += sceneResult.SkippedCount;
+            }
+
+            foreach (var target in targets.Where(t => !t.IsProjectPrefab && !t.IsSceneFile))
+            {
+                if (MigrateSceneObject(target.SceneConverterSettings))
+                {
+                    migratedCount++;
+                }
+                else
+                {
+                    skippedCount++;
+                }
+            }
+
+            return new AvatarDynamicsMigrationResult(migratedCount, skippedCount);
+        }
+
+        private static IEnumerable<AvatarDynamicsMigrationTarget> FindProjectPrefabTargets()
+        {
+            var currentStagePath = PrefabStageUtility.GetCurrentPrefabStage()?.assetPath;
+
+            var candidatePaths = AssetDatabase.FindAssets("t:Prefab", new[] { "Assets" })
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Distinct()
+                .Where(path => path != currentStagePath)
+                .Select(path => (path, root: AssetDatabase.LoadAssetAtPath<GameObject>(path)))
+                .Where(x => x.root != null && !PrefabUtility.IsPartOfImmutablePrefab(x.root))
+                .Where(x => x.root.GetComponentsInChildren<AvatarConverterSettings>(true).Any(HasLegacySettings))
+                .Select(x => x.path)
+                .OrderBy(path => path, System.StringComparer.Ordinal)
+                .ToArray();
+
+            return candidatePaths.Select(AvatarDynamicsMigrationTarget.ForProjectPrefab);
+        }
+
+        private static IEnumerable<AvatarDynamicsMigrationTarget> FindSceneFileTargets()
+        {
+            var loadedPaths = new HashSet<string>(
+                Enumerable.Range(0, SceneManager.sceneCount)
+                    .Select(SceneManager.GetSceneAt)
+                    .Select(s => s.path)
+                    .Where(p => !string.IsNullOrEmpty(p)));
+
+            var scenePaths = AssetDatabase.FindAssets("t:Scene", new[] { "Assets" })
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Distinct()
+                .Where(path => !loadedPaths.Contains(path))
+                .OrderBy(path => path, System.StringComparer.Ordinal);
+
+            var targets = new List<AvatarDynamicsMigrationTarget>();
+            foreach (var scenePath in scenePaths)
+            {
+                var scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+                try
+                {
+                    var sceneTargets = scene.GetRootGameObjects()
+                        .SelectMany(root => root.GetComponentsInChildren<AvatarConverterSettings>(true))
+                        .Where(HasLegacySettings)
+                        .Select(c => AvatarDynamicsMigrationTarget.ForSceneFileObject(scenePath, GetHierarchyPath(c.gameObject)));
+                    targets.AddRange(sceneTargets);
+                }
+                finally
+                {
+                    EditorSceneManager.CloseScene(scene, true);
+                }
+            }
+
+            return targets;
+        }
+
+        private static IEnumerable<AvatarDynamicsMigrationTarget> FindLoadedSceneTargets()
+        {
+            var targets = new List<AvatarDynamicsMigrationTarget>();
+
+            var stage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (stage != null)
+            {
+                var stageTargets = stage.prefabContentsRoot.GetComponentsInChildren<AvatarConverterSettings>(true)
+                    .Where(HasLegacySettings)
+                    .Select(c => AvatarDynamicsMigrationTarget.ForSceneObject($"{stage.assetPath} (Prefab Stage)", GetHierarchyPath(c.gameObject), c));
+                targets.AddRange(stageTargets);
+            }
+
+            var scenes = Enumerable.Range(0, SceneManager.sceneCount)
+                .Select(SceneManager.GetSceneAt)
+                .Where(s => s.isLoaded);
+            foreach (var scene in scenes)
+            {
+                var sceneLabel = string.IsNullOrEmpty(scene.path) ? scene.name : scene.path;
+                var sceneTargets = scene.GetRootGameObjects()
+                    .SelectMany(root => root.GetComponentsInChildren<AvatarConverterSettings>(true))
+                    .Where(HasLegacySettings)
+                    .Select(c => AvatarDynamicsMigrationTarget.ForSceneObject(sceneLabel, GetHierarchyPath(c.gameObject), c));
+                targets.AddRange(sceneTargets);
+            }
+
+            return targets;
+        }
+
+        private static bool MigrateProjectPrefab(string assetPath)
+        {
+            // Guard against stale scan data: if the user opened this exact prefab in Prefab Mode
+            // after it was scanned, LoadPrefabContents/SaveAsPrefabAsset here would silently
+            // overwrite their in-stage edits on disk. Migrate the live stage contents instead (Undo-
+            // tracked, like any other already-open scene/stage object) and leave saving to the user.
+            var stage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (stage != null && stage.assetPath == assetPath)
+            {
+                var didMigrateStage = false;
+                foreach (var converterSettings in stage.prefabContentsRoot.GetComponentsInChildren<AvatarConverterSettings>(true))
+                {
+                    if (MigrateSceneObject(converterSettings))
+                    {
+                        didMigrateStage = true;
+                    }
+                }
+
+                return didMigrateStage;
+            }
+
+            var root = PrefabUtility.LoadPrefabContents(assetPath);
+            try
+            {
+                var didMigrate = false;
+                foreach (var converterSettings in root.GetComponentsInChildren<AvatarConverterSettings>(true))
+                {
+                    // Re-check: a base prefab migrated earlier in this run may already have resolved
+                    // this component's (inherited) legacy settings, leaving nothing to change here.
+                    if (!HasLegacySettings(converterSettings))
+                    {
+                        continue;
+                    }
+
+                    MigrateOne(converterSettings, false);
+                    didMigrate = true;
+                }
+
+                if (didMigrate)
+                {
+                    PrefabUtility.SaveAsPrefabAsset(root, assetPath);
+                }
+
+                return didMigrate;
+            }
+            finally
+            {
+                PrefabUtility.UnloadPrefabContents(root);
+            }
+        }
+
+        private static AvatarDynamicsMigrationResult MigrateSceneFile(string scenePath, HashSet<string> hierarchyPaths)
+        {
+            // Guard against stale scan data: if the user opened this exact scene themselves after
+            // it was scanned, OpenScene/SaveScene/CloseScene here would silently commit their
+            // unrelated edits and yank the scene out of the Hierarchy. Migrate it in place instead,
+            // like any other already-loaded scene, and leave saving to the user.
+            var loadedScene = SceneManager.GetSceneByPath(scenePath);
+            if (loadedScene.IsValid() && loadedScene.isLoaded)
+            {
+                var loadedMigrated = 0;
+                var loadedSkipped = 0;
+                foreach (var converterSettings in SelectConverterSettings(loadedScene, hierarchyPaths))
+                {
+                    if (MigrateSceneObject(converterSettings))
+                    {
+                        loadedMigrated++;
+                    }
+                    else
+                    {
+                        loadedSkipped++;
+                    }
+                }
+
+                return new AvatarDynamicsMigrationResult(loadedMigrated, loadedSkipped);
+            }
+
+            var scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+            try
+            {
+                var migrated = 0;
+                var skipped = 0;
+                foreach (var converterSettings in SelectConverterSettings(scene, hierarchyPaths))
+                {
+                    // Re-check: a base prefab migrated earlier in this run may already have resolved
+                    // a prefab instance's (inherited) legacy settings, leaving nothing to change here.
+                    if (!HasLegacySettings(converterSettings))
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    MigrateOne(converterSettings, false);
+                    migrated++;
+                }
+
+                if (migrated > 0)
+                {
+                    EditorSceneManager.SaveScene(scene, scenePath);
+                }
+
+                return new AvatarDynamicsMigrationResult(migrated, skipped);
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(scene, true);
+            }
+        }
+
+        // With a null filter (whole-file target), only components that still have legacy settings
+        // count - the others were never listed as targets, so they are neither migrated nor
+        // "skipped". With an explicit selection, every selected component is returned so a
+        // since-resolved one is reported as skipped rather than silently dropped.
+        private static IEnumerable<AvatarConverterSettings> SelectConverterSettings(Scene scene, HashSet<string> hierarchyPaths)
+        {
+            var all = scene.GetRootGameObjects().SelectMany(root => root.GetComponentsInChildren<AvatarConverterSettings>(true));
+            return hierarchyPaths == null
+                ? all.Where(HasLegacySettings)
+                : all.Where(c => hierarchyPaths.Contains(GetHierarchyPath(c.gameObject)));
+        }
+
+        private static bool MigrateSceneObject(AvatarConverterSettings converterSettings)
+        {
+            if (!HasLegacySettings(converterSettings))
+            {
+                return false;
+            }
+
+            MigrateOne(converterSettings, true);
+
+            var stage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (stage != null && converterSettings.gameObject.scene == stage.scene)
+            {
+                EditorSceneManager.MarkSceneDirty(stage.scene);
+            }
+            else
+            {
+                EditorSceneManager.MarkSceneDirty(converterSettings.gameObject.scene);
+            }
+
+            return true;
+        }
+
+        private static void MigrateOne(AvatarConverterSettings converterSettings, bool recordUndo)
+        {
+            var providers = converterSettings.physBonesToKeep
+                .Where(p => p != null)
+                .Select(p => (VRCPhysBoneProviderBase)new VRCPhysBoneProvider(p))
+                .ToArray();
+            var colliders = converterSettings.physBoneCollidersToKeep.Where(c => c != null).ToArray();
+            var contacts = converterSettings.contactsToKeep.Where(c => c != null).ToArray();
+
+            if (recordUndo)
+            {
+                AvatarDynamicsSettingsUtility.Apply(converterSettings, providers, colliders, contacts);
+            }
+            else
+            {
+                AvatarDynamicsSettingsUtility.ApplyWithoutUndo(converterSettings, providers, colliders, contacts);
+            }
+        }
+
+        private static bool HasLegacySettings(AvatarConverterSettings converterSettings)
+        {
+            return converterSettings != null
+                && converterSettings.AvatarDescriptor != null
+                && converterSettings.HasLegacyAvatarDynamicsSettings;
+        }
+
+        // Orders prefab asset paths so that, within this set, anything another prefab in the set
+        // depends on comes first - covering both Prefab Variant inheritance (a variant references
+        // its base) and plain nested prefab instances (a prefab containing a child instance of
+        // another prefab in the set), not just variant lineage. This matters because migrating a
+        // dependency after its dependent has already been read/migrated can make the dependent
+        // either race a stale (pre-migration) copy of the dependency's legacy settings (picking up
+        // an inherited value that's about to change, and writing an unnecessary/redundant override
+        // of its own to "freeze" that soon-to-be-wrong value) or, for the specific legacy-array
+        // fields this tool clears, silently drop an unrelated equal-length override (see
+        // AvatarDynamicsSettingsUtility.ClearLegacyArraysInPlace for that mechanism - ordering
+        // doesn't strictly need it there since arrays are never shrunk, but ordering still avoids
+        // the redundant-override case).
+        private static string[] OrderPrefabPathsByDependencyDepth(IEnumerable<string> paths)
+        {
+            var pathArray = paths.Distinct().ToArray();
+            var pathSet = new HashSet<string>(pathArray);
+            var depthCache = new Dictionary<string, int>();
+            return pathArray.OrderBy(path => GetDependencyDepth(path, pathSet, depthCache)).ToArray();
+        }
+
+        // Depth relative to the OTHER paths in pathSet only: 0 if this asset doesn't depend (directly
+        // or transitively) on any other path in the set, otherwise one more than the deepest such
+        // dependency. AssetDatabase.GetDependencies naturally covers both a Prefab Variant's
+        // reference to its base and a nested prefab instance's reference to its source prefab, so
+        // this generalizes the earlier variant-only GetCorrespondingObjectFromSource-based depth.
+        private static int GetDependencyDepth(string path, HashSet<string> pathSet, Dictionary<string, int> depthCache)
+        {
+            if (depthCache.TryGetValue(path, out var cached))
+            {
+                return cached;
+            }
+
+            var directDependencies = AssetDatabase.GetDependencies(path, false)
+                .Where(dependency => dependency != path && pathSet.Contains(dependency));
+
+            var depth = 0;
+            foreach (var dependency in directDependencies)
+            {
+                depth = System.Math.Max(depth, GetDependencyDepth(dependency, pathSet, depthCache) + 1);
+            }
+
+            depthCache[path] = depth;
+            return depth;
+        }
+
+        private static string GetHierarchyPath(GameObject gameObject)
+        {
+            var path = gameObject.name;
+            var parent = gameObject.transform.parent;
+            while (parent != null)
+            {
+                path = parent.name + "/" + path;
+                parent = parent.parent;
+            }
+
+            return path;
+        }
+    }
+}

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/AvatarDynamicsMigrationUtility.cs.meta
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/AvatarDynamicsMigrationUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb45f62c5d1b0964dabeea468447b5d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/AvatarDynamicsSettingsUtility.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Utils/AvatarDynamicsSettingsUtility.cs
@@ -39,15 +39,68 @@ namespace KRT.VRCQuestTools.Utils
             Undo.SetCurrentGroupName(ApplyUndoName);
             var undoGroup = Undo.GetCurrentGroup();
 
-            ApplyCore(converterSettings.AvatarDescriptor, providersToKeep, collidersToKeep, contactsToKeep);
+            ApplyCore(converterSettings.AvatarDescriptor, providersToKeep, collidersToKeep, contactsToKeep, true);
 
             Undo.RecordObject(converterSettings, ApplyUndoName);
-            converterSettings.physBonesToKeep = new VRCPhysBone[0];
-            converterSettings.physBoneCollidersToKeep = new VRCPhysBoneCollider[0];
-            converterSettings.contactsToKeep = new ContactBase[0];
+            ClearLegacyArraysInPlace(converterSettings);
             PrefabUtility.RecordPrefabInstancePropertyModifications(converterSettings);
 
             Undo.CollapseUndoOperations(undoGroup);
+        }
+
+        /// <summary>
+        /// Applies avatar dynamics settings to PlatformComponentRemover components and clears legacy fields,
+        /// without recording Undo operations. Use this for GameObjects loaded via
+        /// <see cref="PrefabUtility.LoadPrefabContents(string)"/>, which the Undo system cannot target,
+        /// or for GameObjects in a scene that is about to be saved and closed as a batch operation.
+        /// </summary>
+        /// <param name="converterSettings">AvatarConverterSettings to update.</param>
+        /// <param name="providersToKeep">PhysBone providers to keep.</param>
+        /// <param name="collidersToKeep">PhysBone colliders to keep.</param>
+        /// <param name="contactsToKeep">Contacts to keep.</param>
+        internal static void ApplyWithoutUndo(
+            AvatarConverterSettings converterSettings,
+            VRCPhysBoneProviderBase[] providersToKeep,
+            VRCPhysBoneCollider[] collidersToKeep,
+            ContactBase[] contactsToKeep)
+        {
+            ApplyCore(converterSettings.AvatarDescriptor, providersToKeep, collidersToKeep, contactsToKeep, false);
+
+            ClearLegacyArraysInPlace(converterSettings);
+            EditorUtility.SetDirty(converterSettings);
+
+            // Needed when converterSettings lives on a prefab instance (e.g. inside a scene file being
+            // migrated as a batch): without this, clearing the legacy fields above is lost on save,
+            // since Unity only persists prefab-instance field changes recorded as instance overrides.
+            PrefabUtility.RecordPrefabInstancePropertyModifications(converterSettings);
+        }
+
+        // Nulls out every element instead of assigning a new, shorter array. A prefab variant (or a
+        // prefab instance anywhere - in a scene, in another project) can override one of these arrays
+        // with its own, different, but EQUAL-LENGTH content; Unity only records a per-index override
+        // in that case, not an Array.size override. If this prefab's array is later shrunk, that
+        // now-out-of-range per-index override is silently dropped by Unity's prefab merge, and the
+        // dependent variant/instance's own (unrelated) legacy settings are lost right along with it -
+        // even if that variant/instance is never touched by this migration. Keeping the length stable
+        // avoids that entirely; HasLegacyAvatarDynamicsSettings already treats an all-null array as
+        // "no legacy settings" (KRT.VRCQuestTools.Components.AvatarConverterSettings.HasLegacyAvatarDynamicsSettings),
+        // and every consumer of these arrays already filters out nulls.
+        private static void ClearLegacyArraysInPlace(AvatarConverterSettings converterSettings)
+        {
+            for (var i = 0; i < converterSettings.physBonesToKeep.Length; i++)
+            {
+                converterSettings.physBonesToKeep[i] = null;
+            }
+
+            for (var i = 0; i < converterSettings.physBoneCollidersToKeep.Length; i++)
+            {
+                converterSettings.physBoneCollidersToKeep[i] = null;
+            }
+
+            for (var i = 0; i < converterSettings.contactsToKeep.Length; i++)
+            {
+                converterSettings.contactsToKeep[i] = null;
+            }
         }
 
         /// <summary>
@@ -67,7 +120,7 @@ namespace KRT.VRCQuestTools.Utils
             Undo.SetCurrentGroupName(ApplyUndoName);
             var undoGroup = Undo.GetCurrentGroup();
 
-            ApplyCore(avatarDescriptor, providersToKeep, collidersToKeep, contactsToKeep);
+            ApplyCore(avatarDescriptor, providersToKeep, collidersToKeep, contactsToKeep, true);
 
             Undo.CollapseUndoOperations(undoGroup);
         }
@@ -76,7 +129,8 @@ namespace KRT.VRCQuestTools.Utils
             VRC_AvatarDescriptor avatarDescriptor,
             VRCPhysBoneProviderBase[] providersToKeep,
             VRCPhysBoneCollider[] collidersToKeep,
-            ContactBase[] contactsToKeep)
+            ContactBase[] contactsToKeep,
+            bool recordUndo)
         {
             var avatarRoot = avatarDescriptor.gameObject;
             var physBonesToKeep = providersToKeep.SelectMany(p => p.GetPhysBones()).ToArray();
@@ -91,8 +145,12 @@ namespace KRT.VRCQuestTools.Utils
 
             foreach (var component in physBonesToRemove.Cast<Component>().Concat(collidersToRemove).Concat(contactsToRemove))
             {
-                var remover = GetOrAddPlatformComponentRemover(component.gameObject);
-                Undo.RecordObject(remover, ApplyUndoName);
+                var remover = GetOrAddPlatformComponentRemover(component.gameObject, recordUndo);
+                if (recordUndo)
+                {
+                    Undo.RecordObject(remover, ApplyUndoName);
+                }
+
                 remover.UpdateComponentSettings();
                 var setting = System.Array.Find(remover.componentSettings, s => s.component == component);
                 if (setting != null)
@@ -109,7 +167,11 @@ namespace KRT.VRCQuestTools.Utils
                 var remover = component.gameObject.GetComponent<PlatformComponentRemover>();
                 if (remover != null)
                 {
-                    Undo.RecordObject(remover, ApplyUndoName);
+                    if (recordUndo)
+                    {
+                        Undo.RecordObject(remover, ApplyUndoName);
+                    }
+
                     var setting = System.Array.Find(remover.componentSettings, s => s.component == component);
                     if (setting != null)
                     {
@@ -127,17 +189,24 @@ namespace KRT.VRCQuestTools.Utils
                 bool hasEffect = System.Array.Exists(remover.componentSettings, s => s.removeOnAndroid || s.removeOnPC);
                 if (!hasEffect)
                 {
-                    Undo.DestroyObjectImmediate(remover);
+                    if (recordUndo)
+                    {
+                        Undo.DestroyObjectImmediate(remover);
+                    }
+                    else
+                    {
+                        Object.DestroyImmediate(remover);
+                    }
                 }
             }
         }
 
-        private static PlatformComponentRemover GetOrAddPlatformComponentRemover(GameObject gameObject)
+        private static PlatformComponentRemover GetOrAddPlatformComponentRemover(GameObject gameObject, bool recordUndo)
         {
             var remover = gameObject.GetComponent<PlatformComponentRemover>();
             if (remover == null)
             {
-                remover = Undo.AddComponent<PlatformComponentRemover>(gameObject);
+                remover = recordUndo ? Undo.AddComponent<PlatformComponentRemover>(gameObject) : gameObject.AddComponent<PlatformComponentRemover>();
             }
 
             return remover;

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsMigrationWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsMigrationWindow.cs
@@ -1,0 +1,209 @@
+// <copyright file="AvatarDynamicsMigrationWindow.cs" company="kurotu">
+// Copyright (c) kurotu.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// </copyright>
+
+using System.Linq;
+using KRT.VRCQuestTools.Models;
+using KRT.VRCQuestTools.Utils;
+using UnityEditor;
+using UnityEngine;
+
+namespace KRT.VRCQuestTools.Views
+{
+    /// <summary>
+    /// Review window for migrating legacy Avatar Dynamics settings (AvatarConverterSettings'
+    /// physBonesToKeep/physBoneCollidersToKeep/contactsToKeep) to PlatformComponentRemover.
+    /// Lists every affected project prefab and scene object so the user can exclude targets,
+    /// or migrate nothing at all.
+    /// </summary>
+    internal class AvatarDynamicsMigrationWindow : EditorWindow
+    {
+        private AvatarDynamicsMigrationTarget[] targets = new AvatarDynamicsMigrationTarget[0];
+        private bool[] selected = new bool[0];
+        private Vector2 scrollPosition;
+        private bool foldoutPrefabs = true;
+        private bool foldoutScenes = true;
+
+        /// <summary>
+        /// Shows the window, scanning for migration targets.
+        /// </summary>
+        internal static void ShowWindow()
+        {
+            var window = GetWindow<AvatarDynamicsMigrationWindow>();
+            window.Rescan();
+            window.Show();
+        }
+
+        private void OnEnable()
+        {
+            titleContent = new GUIContent(VRCQuestToolsSettings.I18nResource.MigrateAvatarDynamicsSettingsWindowTitle);
+            Rescan();
+        }
+
+        private void Rescan()
+        {
+            targets = AvatarDynamicsMigrationUtility.FindMigrationTargets();
+            selected = targets.Select(t => true).ToArray();
+        }
+
+        private void OnGUI()
+        {
+            var i18n = VRCQuestToolsSettings.I18nResource;
+
+            EditorGUILayout.LabelField(i18n.MigrateAvatarDynamicsSettingsDescription, EditorStyles.wordWrappedLabel);
+            EditorGUILayout.Space();
+
+            if (targets.Length == 0)
+            {
+                EditorGUILayout.HelpBox(i18n.MigrateAvatarDynamicsSettingsNoTargetsMessage, MessageType.Info);
+                EditorGUILayout.Space();
+                if (GUILayout.Button(i18n.CloseLabel))
+                {
+                    Close();
+                }
+                return;
+            }
+
+            EditorGUILayout.HelpBox(i18n.MigrateAvatarDynamicsSettingsAssetWarning, MessageType.Warning);
+            EditorGUILayout.Space();
+
+            using (var scrollView = new EditorGUILayout.ScrollViewScope(scrollPosition))
+            {
+                scrollPosition = scrollView.scrollPosition;
+
+                var prefabIndices = IndicesWhere(t => t.IsProjectPrefab);
+                if (prefabIndices.Length > 0)
+                {
+                    if (foldoutPrefabs = EditorGUILayout.BeginFoldoutHeaderGroup(foldoutPrefabs, $"{i18n.MigrateAvatarDynamicsSettingsProjectPrefabsLabel} ({prefabIndices.Length})"))
+                    {
+                        DrawTargetGroup(prefabIndices);
+                    }
+                    EditorGUILayout.EndFoldoutHeaderGroup();
+                    EditorGUILayout.Space();
+                }
+
+                var sceneIndices = IndicesWhere(t => !t.IsProjectPrefab);
+                if (sceneIndices.Length > 0)
+                {
+                    if (foldoutScenes = EditorGUILayout.BeginFoldoutHeaderGroup(foldoutScenes, $"{i18n.MigrateAvatarDynamicsSettingsSceneObjectsLabel} ({sceneIndices.Length})"))
+                    {
+                        DrawSceneTargetGroup(sceneIndices);
+                    }
+                    EditorGUILayout.EndFoldoutHeaderGroup();
+                }
+            }
+
+            EditorGUILayout.Space(8);
+
+            var selectedCount = selected.Count(s => s);
+            using (new EditorGUI.DisabledScope(selectedCount == 0))
+            {
+                if (EditorGUIUtility.LargeButton(i18n.MigrateAvatarDynamicsSettingsButtonLabel(selectedCount)))
+                {
+                    OnClickMigrate();
+                }
+            }
+
+            EditorGUILayout.Space(4);
+
+            if (GUILayout.Button(i18n.CloseLabel))
+            {
+                Close();
+            }
+        }
+
+        private int[] IndicesWhere(System.Func<AvatarDynamicsMigrationTarget, bool> predicate)
+        {
+            return Enumerable.Range(0, targets.Length).Where(i => predicate(targets[i])).ToArray();
+        }
+
+        private void DrawTargetGroup(int[] indices)
+        {
+            var i18n = VRCQuestToolsSettings.I18nResource;
+            using (new EditorGUI.IndentLevelScope())
+            {
+                using (var horizontal = new EditorGUILayout.HorizontalScope())
+                {
+                    if (GUILayout.Button(i18n.SelectAllButtonLabel))
+                    {
+                        foreach (var i in indices)
+                        {
+                            selected[i] = true;
+                        }
+                    }
+                    if (GUILayout.Button(i18n.DeselectAllButtonLabel))
+                    {
+                        foreach (var i in indices)
+                        {
+                            selected[i] = false;
+                        }
+                    }
+                }
+                foreach (var i in indices)
+                {
+                    selected[i] = EditorGUILayout.ToggleLeft(targets[i].Label, selected[i]);
+                }
+            }
+        }
+
+        // Scene targets are grouped per scene: the scene appears once as a plain header row, and
+        // each of its avatars gets an indented checkbox beneath it, so a scene containing several
+        // avatars is visually one unit rather than repeated path-prefixed rows.
+        private void DrawSceneTargetGroup(int[] indices)
+        {
+            var i18n = VRCQuestToolsSettings.I18nResource;
+            using (new EditorGUI.IndentLevelScope())
+            {
+                using (var horizontal = new EditorGUILayout.HorizontalScope())
+                {
+                    if (GUILayout.Button(i18n.SelectAllButtonLabel))
+                    {
+                        foreach (var i in indices)
+                        {
+                            selected[i] = true;
+                        }
+                    }
+                    if (GUILayout.Button(i18n.DeselectAllButtonLabel))
+                    {
+                        foreach (var i in indices)
+                        {
+                            selected[i] = false;
+                        }
+                    }
+                }
+                foreach (var group in indices.GroupBy(i => targets[i].SceneGroupLabel))
+                {
+                    EditorGUILayout.LabelField(group.Key, EditorStyles.boldLabel);
+                    using (new EditorGUI.IndentLevelScope())
+                    {
+                        foreach (var i in group)
+                        {
+                            selected[i] = EditorGUILayout.ToggleLeft(targets[i].ObjectLabel ?? targets[i].Label, selected[i]);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void OnClickMigrate()
+        {
+            var i18n = VRCQuestToolsSettings.I18nResource;
+            var selectedTargets = Enumerable.Range(0, targets.Length).Where(i => selected[i]).Select(i => targets[i]).ToArray();
+            var directWriteCount = selectedTargets.Count(t => t.IsProjectPrefab || t.IsSceneFile);
+
+            if (directWriteCount > 0 && !EditorUtility.DisplayDialog(VRCQuestTools.Name, i18n.MigrateAvatarDynamicsSettingsConfirmation(directWriteCount), i18n.YesLabel, i18n.CancelLabel))
+            {
+                return;
+            }
+
+            var result = AvatarDynamicsMigrationUtility.Migrate(selectedTargets);
+            AssetDatabase.SaveAssets();
+
+            EditorUtility.DisplayDialog(VRCQuestTools.Name, i18n.MigrateAvatarDynamicsSettingsResultMessage(result.MigratedCount, result.SkippedCount), i18n.CloseLabel);
+
+            Rescan();
+            Repaint();
+        }
+    }
+}

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsMigrationWindow.cs
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsMigrationWindow.cs
@@ -30,8 +30,17 @@ namespace KRT.VRCQuestTools.Views
         /// </summary>
         internal static void ShowWindow()
         {
+            // Creating the window runs OnEnable, which already scans; an unconditional Rescan here
+            // would repeat the expensive scan (it opens every unloaded scene under Assets/) on
+            // first open. Rescan explicitly only when reusing an already-open window, so invoking
+            // the menu again still refreshes the list.
+            var isOpen = HasOpenInstances<AvatarDynamicsMigrationWindow>();
             var window = GetWindow<AvatarDynamicsMigrationWindow>();
-            window.Rescan();
+            if (isOpen)
+            {
+                window.Rescan();
+            }
+
             window.Show();
         }
 

--- a/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsMigrationWindow.cs.meta
+++ b/Packages/com.github.kurotu.vrc-quest-tools/Editor/Views/AvatarDynamicsMigrationWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 508f82749045f7c46b08e86168bc884a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

`AvatarConverterSettings` still ships the obsolete `physBonesToKeep` / `physBoneCollidersToKeep` / `contactsToKeep` fields, but nothing moved existing avatars to Platform Component Remover. This adds **Tools/VRCQuestTools/Migrate Legacy Avatar Dynamics Settings**, a review window that scans the project and migrates selected targets while preserving which PhysBones, PhysBone Colliders, and Contacts are kept. The workflow is informed by TexTransTool's Migrator window.

## Behavior

- Scans project Prefabs and scene files under `Assets/`, loaded scenes, and the current Prefab Stage. Scene files are listed per contained `AvatarConverterSettings` and grouped per scene in the window; Prefabs are listed in asset-path order.
- Prefabs are migrated in dependency order derived from `AssetDatabase.GetDependencies`, so a base Prefab is processed before its Variants and before Prefabs nesting an instance of it. A target that merely inherits legacy settings from an already-migrated source resolves to a clean no-op instead of gaining a redundant override.
- Prefab assets and unloaded scene files are written directly to disk (not covered by Undo) and require an extra confirmation; already-open scenes and Prefab Stage contents are migrated through the Undo-tracked path and left for the user to save.
- Stale-scan guards: if the user opens a listed Prefab in Prefab Mode or opens a listed scene after scanning, migration switches to the in-place Undo-tracked path instead of overwriting their unsaved edits on disk.
- Migration is manual-only. There is deliberately no startup scan: it would open every unloaded scene under `Assets/` on every launch, which is too slow and too noisy.

## Notes

- Fixes a pre-existing silent data-loss bug that also affected the interactive Avatar Dynamics Selector / PhysBones Remover Apply path: clearing the legacy arrays by assigning new zero-length arrays dropped equal-length per-index overrides held by dependent Prefab Variants and instances (Unity records no `Array.size` override in that case). The arrays are now cleared by nulling elements in place, keeping dependents' own settings intact.
- Adds `AvatarDynamicsSettingsUtility.ApplyWithoutUndo` for contexts the Undo system cannot target (`LoadPrefabContents`, batch-processed scenes), including `RecordPrefabInstancePropertyModifications` so instance-level clears survive scene saves.

## Test plan

- [x] 15 new EditMode tests: partial keep selections, Variant chains (own override / inherited no-op / opposite equal-length overrides), unloaded scene files (plain avatars, Prefab instances with instance-level overrides, per-avatar selection within one scene), un-batched dependents keeping their own settings, dependency-independent path-ordered listing
- [x] Full EditMode suite green locally (0 failures; 19 pre-existing environment-dependent skips)
- [x] Manually exercised the window against fixture Prefabs / a 3-level Variant chain / multi-avatar scenes, and migrated a real avatar Prefab in this project
- [x] CI Build workflow passed on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)